### PR TITLE
initial commit for previous odp api

### DIFF
--- a/common/api/endpoint/ApiEndPoint.ts
+++ b/common/api/endpoint/ApiEndPoint.ts
@@ -92,6 +92,7 @@ export const ApiEndPoint = {
     many: () => apiPath('originalDataPoints'),
     one: (id = ':id') => apiPath('originalDataPoints', id),
     reservedYears: (countryIso = ':countryIso') => apiPath('originalDataPoints', countryIso, 'years'),
+    previous: (id = ':id') => apiPath('originalDataPoints', id, 'previous'),
   },
   // Old routes, deprecated
   Odp: {

--- a/server/api/originalDataPoint/getPrevious.ts
+++ b/server/api/originalDataPoint/getPrevious.ts
@@ -1,0 +1,18 @@
+import { Express, Response, Request } from 'express'
+import { Requests } from '@server/utils'
+import { ApiEndPoint } from '@common/api/endpoint'
+import { OriginalDataPointService } from '@server/service/originalDataPoint'
+
+export const OdpGetPrevious = {
+  init: (express: Express): void => {
+    express.get(ApiEndPoint.OriginalDataPoint.previous(), async (req: Request, res: Response) => {
+      try {
+        const { id } = req.params
+        const previousOdp = await OriginalDataPointService.getPrevious({ id })
+        res.json({ odp: previousOdp })
+      } catch (err) {
+        Requests.sendErr(res, err)
+      }
+    })
+  },
+}

--- a/server/api/originalDataPoint/index.ts
+++ b/server/api/originalDataPoint/index.ts
@@ -4,12 +4,14 @@ import { OdpRemove } from '@server/api/originalDataPoint/remove'
 import { OdpGet } from '@server/api/originalDataPoint/get'
 import { OdpUpdate } from '@server/api/originalDataPoint/update'
 import { OdpGetReservedYears } from '@server/api/originalDataPoint/getReservedYears'
+import { OdpGetPrevious } from '@server/api/originalDataPoint/getPrevious'
 
 export const OriginalDataPointApi = {
   init: (express: Express): void => {
     OdpCreate.init(express)
     OdpGet.init(express)
     OdpGetReservedYears.init(express)
+    OdpGetPrevious.init(express)
     OdpRemove.init(express)
     OdpUpdate.init(express)
   },

--- a/server/service/originalDataPoint/getPrevious.ts
+++ b/server/service/originalDataPoint/getPrevious.ts
@@ -1,0 +1,10 @@
+import { OriginalDataPointRepository } from '@server/repository/originalDataPoint'
+import { ODP } from '@core/odp'
+
+export const getPrevious = async (props: { id: string }): Promise<ODP> => {
+  const { id } = props
+  const odp = await OriginalDataPointRepository.get({ id })
+  const { countryIso, year } = odp
+  const odps = await OriginalDataPointRepository.getMany({ countryIso })
+  return odps.filter((o) => o.year < year).pop()
+}

--- a/server/service/originalDataPoint/index.ts
+++ b/server/service/originalDataPoint/index.ts
@@ -1,5 +1,6 @@
 import { create } from '@server/service/originalDataPoint/create'
 import { get } from '@server/service/originalDataPoint/get'
+import { getPrevious } from '@server/service/originalDataPoint/getPrevious'
 import { getMany, getManyNormalized } from '@server/service/originalDataPoint/getMany'
 import { remove } from '@server/service/originalDataPoint/remove'
 import { update } from '@server/service/originalDataPoint/update'
@@ -8,6 +9,7 @@ import { getReservedYears } from '@server/service/originalDataPoint/getReservedY
 export const OriginalDataPointService = {
   create,
   get,
+  getPrevious,
   getReservedYears,
   getMany,
   getManyNormalized,


### PR DESCRIPTION
server side implementation for previous odp

`curl localhost:9001/api/originalDataPoints/233/previous`

```
{
  "odp": {
    "id": "232",
    "year": 2000,
    "countryIso": "FIN",
    "dataSourceMethods": [
      "nationalForestInventory"
    ],
    "dataSourceAdditionalComments": "NFI9",
    "dataSourceReferences": null,
    "description": null,
    "nationalClasses": [
      ...
    ]
  }
}
```