### PR TITLE
fix range headers, fix minor issues

### DIFF
--- a/client/pages/Assessment/pages/Section/components/DataTable/Table/Row/RowData/Cell/Cell.tsx
+++ b/client/pages/Assessment/pages/Section/components/DataTable/Table/Row/RowData/Cell/Cell.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { AssessmentName, Col, ColType, Row, Table } from '@meta/assessment'
-import { TableData as TypeTableData, TableDatas } from '@meta/data'
+import { TableData, TableDatas } from '@meta/data'
 import { useCountryIso } from '@client/hooks'
 import Calculated from './Calculated'
 import Number from './Number'
@@ -23,7 +23,7 @@ const ComponentsByName: Record<string, React.FC<PropsCell>> = {
 }
 
 type Props = {
-  data: TypeTableData
+  data: TableData
   assessmentName: AssessmentName
   sectionName: string
   table: Table

--- a/client/pages/Assessment/pages/Section/components/DataTable/Table/Row/RowData/Cell/Cell.tsx
+++ b/client/pages/Assessment/pages/Section/components/DataTable/Table/Row/RowData/Cell/Cell.tsx
@@ -6,7 +6,7 @@ import { useCountryIso } from '@client/hooks'
 import Calculated from './Calculated'
 import Number from './Number'
 import Text from './Text'
-// import Select from './Select'
+import Select from './Select'
 // import Placeholder from './Placeholder'
 import useClassName from './useClassName'
 // import useOnChange from './useOnChange'
@@ -18,7 +18,7 @@ const ComponentsByName: Record<string, React.FC<PropsCell>> = {
   [ColType.textarea]: Text,
   [ColType.decimal]: Number,
   [ColType.integer]: Number,
-  // [ColType.select]: Select, // TODO
+  [ColType.select]: Select,
   // [ColType.placeholder]: Placeholder,
 }
 

--- a/client/pages/Assessment/pages/Section/components/DataTable/Table/Row/RowData/Cell/Cell.tsx
+++ b/client/pages/Assessment/pages/Section/components/DataTable/Table/Row/RowData/Cell/Cell.tsx
@@ -7,7 +7,7 @@ import Calculated from './Calculated'
 import Number from './Number'
 import Text from './Text'
 import Select from './Select'
-// import Placeholder from './Placeholder'
+import Placeholder from './Placeholder'
 import useClassName from './useClassName'
 // import useOnChange from './useOnChange'
 import { PropsCell } from './props'
@@ -19,7 +19,7 @@ const ComponentsByName: Record<string, React.FC<PropsCell>> = {
   [ColType.decimal]: Number,
   [ColType.integer]: Number,
   [ColType.select]: Select,
-  // [ColType.placeholder]: Placeholder,
+  [ColType.placeholder]: Placeholder,
 }
 
 type Props = {

--- a/client/pages/Assessment/pages/Section/components/DataTable/Table/Row/RowData/Cell/Placeholder/Placeholder.tsx
+++ b/client/pages/Assessment/pages/Section/components/DataTable/Table/Row/RowData/Cell/Placeholder/Placeholder.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
 
-import { useI18n } from '@webapp/hooks'
+import { useTranslation } from 'react-i18next'
 import { PropsCell } from '../props'
 
 const Placeholder: React.FC<PropsCell> = (props) => {
-  const { col } = props
-  const i18n = useI18n()
+  const { col, datum } = props
+  const { i18n } = useTranslation()
 
-  const { label, labelKey, labelParams } = col
+  const { /* label */ labelKey /* labelParams */ } = col.props
 
   let labelCell = ''
-  if (label) labelCell = label
-  if (labelKey) labelCell = i18n.t(labelKey, labelParams)
-
-  return <div>{labelCell}</div>
+  // if (label) labelCell = label
+  if (labelKey) labelCell = i18n.t(labelKey /* labelParams */)
+  //
+  return <div>{labelCell || datum || ''}</div>
 }
 
 export default Placeholder

--- a/client/pages/Assessment/pages/Section/components/DataTable/Table/Row/RowData/Cell/Select/Select.tsx
+++ b/client/pages/Assessment/pages/Section/components/DataTable/Table/Row/RowData/Cell/Select/Select.tsx
@@ -1,56 +1,64 @@
 import React from 'react'
-import { ColType } from '@meta/assessment/col'
-import { useTranslation } from 'react-i18next'
-import { PropsCell } from '../props'
 
-const getOptionLabel = (option: ColOptionSpec, i18n: I18n, optionsLabelKeyPrefix: string): string => {
-  const { optionName } = option
-  const label = i18n.t(`${optionsLabelKeyPrefix}.${optionName}`)
-  return option.type === ColType.header ? `--- ${label} ---` : label
+// TODO Implement Select component
+
+const Select = ({ datum }: { datum: string }) => {
+  return <span>{datum}</span>
 }
 
-const optionNotSelected: ColOptionSpec = { optionName: 'notSelected', hidden: true }
-
-const Select: React.FC<PropsCell> = (props) => {
-  const { onChange, onPaste, col, datum, disabled } = props
-  const { options, optionsLabelKeyPrefix } = col.props
-  const optionSelected = options.find((option) => option.optionName === datum)
-
-  const i18n = useTranslation()
-
-  if (disabled) {
-    return (
-      <div className="text-input__container">
-        <div className="text-input__readonly-view">
-          {datum && getOptionLabel(optionSelected, i18n, optionsLabelKeyPrefix)}
-        </div>
-      </div>
-    )
-  }
-
-  return (
-    <div className="fra-table__select-container">
-      <select
-        className="fra-table__select no-print"
-        value={datum || optionNotSelected.optionName}
-        disabled={disabled}
-        onChange={onChange}
-        onPaste={onPaste}
-      >
-        {[optionNotSelected, ...options].map((option) => {
-          const { hidden, optionName } = option
-          return (
-            <option key={optionName} value={optionName} disabled={option.type === TypeSpec.header} hidden={!!hidden}>
-              {getOptionLabel(option, i18n, optionsLabelKeyPrefix)}
-            </option>
-          )
-        })}
-      </select>
-      <div className="text-input__readonly-view only-print" style={{ textAlign: 'left' }}>
-        {datum && getOptionLabel(optionSelected, i18n, optionsLabelKeyPrefix)}
-      </div>
-    </div>
-  )
-}
-
+// import { ColType } from '@meta/assessment/col'
+// import { useTranslation } from 'react-i18next'
+// import { PropsCell } from '../props'
+//
+// const getOptionLabel = (option: ColOptionSpec, i18n: I18n, optionsLabelKeyPrefix: string): string => {
+//   const { optionName } = option
+//   const label = i18n.t(`${optionsLabelKeyPrefix}.${optionName}`)
+//   return option.type === ColType.header ? `--- ${label} ---` : label
+// }
+//
+// const optionNotSelected: ColOptionSpec = { optionName: 'notSelected', hidden: true }
+//
+// const Select: React.FC<PropsCell> = (props) => {
+//
+//   const { onChange, onPaste, col, datum, disabled } = props
+//   const { options, optionsLabelKeyPrefix } = col.props
+//   console.log(col.props)
+//   const optionSelected = options.find((option) => option.optionName === datum)
+//   const { i18n } = useTranslation()
+//
+//   if (disabled) {
+//     return (
+//       <div className="text-input__container">
+//         <div className="text-input__readonly-view">
+//           {datum && getOptionLabel(optionSelected, i18n, optionsLabelKeyPrefix)}
+//         </div>
+//       </div>
+//     )
+//   }
+//
+//   return (
+//     <div className="fra-table__select-container">
+//       <select
+//         className="fra-table__select no-print"
+//         value={datum || optionNotSelected.optionName}
+//         disabled={disabled}
+//         onChange={onChange}
+//         onPaste={onPaste}
+//       >
+//         {[optionNotSelected, ...options].map((option) => {
+//           const { hidden, optionName } = option
+//           return (
+//             <option key={optionName} value={optionName} disabled={option.type === TypeSpec.header} hidden={!!hidden}>
+//               {getOptionLabel(option, i18n, optionsLabelKeyPrefix)}
+//             </option>
+//           )
+//         })}
+//       </select>
+//       <div className="text-input__readonly-view only-print" style={{ textAlign: 'left' }}>
+//         {datum && getOptionLabel(optionSelected, i18n, optionsLabelKeyPrefix)}
+//       </div>
+//     </div>
+//   )
+// }
+//
 export default Select

--- a/client/pages/Assessment/pages/Section/components/DataTable/utils/index.ts
+++ b/client/pages/Assessment/pages/Section/components/DataTable/utils/index.ts
@@ -1,9 +1,15 @@
 import { Table } from '@meta/assessment'
-import { TableData as TypeTableData, TableDatas } from '@meta/data'
+import { TableData, TableDatas } from '@meta/data'
 import { CountryIso } from '@meta/area'
 
-export const getHeaders = (data: TypeTableData, countryIso: CountryIso, table: Table): string[] => {
+const handleHeader = (header: string) => {
+  // Case ex. 1990_2000 => 1990-2000
+  if (/^\d{4}\_\d{4}$/.test(header)) return header.replace('_', '-')
+  return header
+}
+
+export const getHeaders = (data: TableData, countryIso: CountryIso, table: Table): string[] => {
   const dataTable = TableDatas.getTableData({ data, countryIso, table })
   if (!dataTable) return []
-  return Object.keys(Object.values(dataTable)[0])
+  return Object.keys(Object.values(dataTable)[0]).map(handleHeader)
 }

--- a/meta/data/tableDatas.ts
+++ b/meta/data/tableDatas.ts
@@ -1,15 +1,13 @@
-import { TableData as TypeTableData } from '@meta/data/index'
+import { TableData } from './tableData'
 import { CountryIso } from '@meta/area'
-import { Table } from '@meta/assessment/table'
-import { Row } from '@meta/assessment/row'
-import { Col } from '@meta/assessment/col'
+import { Table, Row, Col } from '@meta/assessment'
 
-const getTableData = (props: { data: TypeTableData; countryIso: CountryIso; table: Table }) => {
+const getTableData = (props: { data: TableData; countryIso: CountryIso; table: Table }) => {
   const { countryIso, table, data } = props
   return data[countryIso][table.props.name]
 }
 
-const getDatum = (props: { data: TypeTableData; countryIso: CountryIso; table: Table; row: Row; col: Col }) => {
+const getDatum = (props: { data: TableData; countryIso: CountryIso; table: Table; row: Row; col: Col }) => {
   const { data, countryIso, table, row, col } = props
   const dataTable = getTableData({ data, countryIso, table })
   if (!dataTable) return null

--- a/server/controller/cycleData/getTableData.ts
+++ b/server/controller/cycleData/getTableData.ts
@@ -20,16 +20,13 @@ export const getTableData = async (
     tables[tableName] = {}
   })
 
-  return client.tx(async (t) => {
-    return CycleDataRepository.getTableData(
-      {
-        assessment,
-        cycle,
+  return CycleDataRepository.getTableData(
+    {
+      assessment,
+      cycle,
 
-        tables,
-        countryISOs: [countryIso],
-      },
-      t
-    )
-  })
+      tables,
+      countryISOs: [countryIso],
+    }, client)
 }
+


### PR DESCRIPTION
Check all table headers and fix those
- Year range:
  - Database data received as 1990_2000
    - Resolution: match pattern and replace
- Year with Gender:
  - Not fixed, for some reason some tables show ex. 1990_male (metadata issue?)
- Select cell:
  - Show data as string (helps debugging)
  - Find cells in db:
  | `select * from assessment_fra.col
where props ->> 'colType' = 'select'`
- Placeholder cell:
  - Show data as string (helps debugging)

Fixed with regex match