### PR TITLE
Add support for Select all for regions in country modal desktop

### DIFF
--- a/src/client/components/CountrySelectModal/CountrySelectModal.tsx
+++ b/src/client/components/CountrySelectModal/CountrySelectModal.tsx
@@ -75,6 +75,18 @@ const CountrySelectModal: React.FC<Props> = (props) => {
     onChange('', selectionUpdate)
   }
 
+  const _onChangeMany = (countryISOs: Array<string>, selectAll: boolean): void => {
+    if (selectAll) {
+      const selectionUpdate = [...countryISOs, ...selection].filter((v) => !unselectableCountries.includes(v))
+      setSelection(selectionUpdate)
+      onChange('', selectionUpdate)
+    } else {
+      const selectionUpdate: Array<string> = selection.filter((v) => !countryISOs.includes(v))
+      setSelection(selectionUpdate)
+      onChange('', selectionUpdate)
+    }
+  }
+
   const _onClose = () => {
     onClose(selection)
     setSelection([])
@@ -109,6 +121,7 @@ const CountrySelectModal: React.FC<Props> = (props) => {
         countries={countriesFiltered}
         onChange={_onChange}
         onChangeAll={_onChangeAll}
+        onChangeMany={_onChangeMany}
         selection={selection}
         unselectableCountries={unselectableCountries}
         excludedRegions={excludedRegions}

--- a/src/client/components/CountrySelectModal/CountrySelectModalBody/CountrySelectModalBody.tsx
+++ b/src/client/components/CountrySelectModal/CountrySelectModalBody/CountrySelectModalBody.tsx
@@ -63,32 +63,37 @@ const CountrySelectModalBody: React.FC<Props> = (props) => {
             <div key={regionCode}>
               <div>
                 <strong>{i18n.t(`area.${regionCode}.listName`)}</strong>
-                {!allRegionCountriesDisabled(countryISOs) && (
+
+                <div
+                  className={classNames('form-field-country-selector', {
+                    disabled: allRegionCountriesDisabled(countryISOs),
+                  })}
+                  onClick={() => {
+                    const newSelection = allSelectedInRegion(countryISOs, selection)
+                      ? selection.filter((countryIso) => !countryISOs.includes(countryIso))
+                      : countryISOs.concat(selection)
+                    onChangeAll(newSelection)
+                  }}
+                  onKeyUp={() => onChangeAll(countryISOs)}
+                  role="button"
+                  tabIndex={0}
+                >
                   <div
-                    className="form-field-country-selector"
-                    onClick={() => {
-                      const newSelection = allSelectedInRegion(countryISOs, selection)
-                        ? selection.filter((countryIso) => !countryISOs.includes(countryIso))
-                        : countryISOs.concat(selection)
-                      onChangeAll(newSelection)
-                    }}
-                    onKeyUp={() => onChangeAll(countryISOs)}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <div
-                      className={classNames('fra-checkbox', {
-                        checked: allSelectedInRegion(countryISOs, selection),
-                        disabled: countryISOs.every((countryIso) => unselectableCountries.includes(countryIso)),
-                      })}
-                    />
-                    <div className="form-field-country-label">
-                      {i18n.t(
-                        `${allSelectedInRegion(countryISOs, selection) ? 'common.unselectAll' : 'common.selectAll'}`
-                      )}
-                    </div>
+                    className={classNames('fra-checkbox', {
+                      checked: allSelectedInRegion(countryISOs, selection) && !allRegionCountriesDisabled(countryISOs),
+                      disabled: countryISOs.every((countryIso) => unselectableCountries.includes(countryIso)),
+                    })}
+                  />
+                  <div className="form-field-country-label">
+                    {i18n.t(
+                      `${
+                        allSelectedInRegion(countryISOs, selection) && !allRegionCountriesDisabled(countryISOs)
+                          ? 'common.unselectAll'
+                          : 'common.selectAll'
+                      }`
+                    )}
                   </div>
-                )}
+                </div>
               </div>
               <select
                 multiple
@@ -116,11 +121,13 @@ const CountrySelectModalBody: React.FC<Props> = (props) => {
         <MediaQuery minWidth={Breakpoints.laptop}>
           {Object.entries(regionCountries).map(([regionCode, countryISOs]) => (
             <div key={regionCode} className="form-field-region-container">
-              <div className="form-field-region-label">{i18n.t(`area.${regionCode}.listName`)}</div>
+              <div className="form-field-region-wrapper">
+                <div className="form-field-region-label">{i18n.t(`area.${regionCode}.listName`)}</div>
 
-              {!allRegionCountriesDisabled(countryISOs) && (
                 <div
-                  className="form-field-country-selector"
+                  className={classNames('form-field-country-selector', {
+                    disabled: allRegionCountriesDisabled(countryISOs),
+                  })}
                   onClick={() => onChangeMany(countryISOs, !allSelectedInRegion(countryISOs, selection))}
                   onKeyUp={() => onChangeMany(countryISOs, !allSelectedInRegion(countryISOs, selection))}
                   role="button"
@@ -128,16 +135,21 @@ const CountrySelectModalBody: React.FC<Props> = (props) => {
                 >
                   <div
                     className={classNames('fra-checkbox', {
-                      checked: allSelectedInRegion(countryISOs, selection),
+                      checked: allSelectedInRegion(countryISOs, selection) && !allRegionCountriesDisabled(countryISOs),
                     })}
                   />
                   <div className="form-field-country-label">
                     {i18n.t(
-                      `${allSelectedInRegion(countryISOs, selection) ? 'common.unselectAll' : 'common.selectAll'}`
+                      `${
+                        allSelectedInRegion(countryISOs, selection) && !allRegionCountriesDisabled(countryISOs)
+                          ? 'common.unselectAll'
+                          : 'common.selectAll'
+                      }`
                     )}
                   </div>
                 </div>
-              )}
+              </div>
+
               <hr />
 
               {countryISOs.map((countryIso: string) => {

--- a/src/client/components/CountrySelectModal/CountrySelectModalBody/CountrySelectModalBody.tsx
+++ b/src/client/components/CountrySelectModal/CountrySelectModalBody/CountrySelectModalBody.tsx
@@ -1,5 +1,5 @@
 import './countrySelectModalBody.scss'
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import MediaQuery from 'react-responsive'
 
@@ -17,10 +17,16 @@ type Props = {
   excludedRegions: Array<string>
   onChange: (countryIso: string) => void
   onChangeAll: (countryISOs: Array<string>) => void
+  onChangeMany: (countryISOs: Array<string>, selectAll: boolean) => void
 }
 
 const CountrySelectModalBody: React.FC<Props> = (props) => {
-  const { countries, onChange, onChangeAll, selection, unselectableCountries, excludedRegions } = props
+  const { countries, onChange, onChangeAll, onChangeMany, selection, unselectableCountries, excludedRegions } = props
+  const allSelectedInRegion = useMemo(
+    () => (region: string[], selection: string[]) =>
+      region.every((v) => selection.includes(v) || unselectableCountries.includes(v)),
+    [unselectableCountries]
+  )
 
   const i18n = useTranslation()
 
@@ -100,6 +106,20 @@ const CountrySelectModalBody: React.FC<Props> = (props) => {
           {Object.entries(regionCountries).map(([regionCode, countryISOs]) => (
             <div key={regionCode} className="form-field-region-container">
               <div className="form-field-region-label">{i18n.t(`area.${regionCode}.listName`)}</div>
+
+              <div
+                className="form-field-country-selector"
+                onClick={() => onChangeMany(countryISOs, !allSelectedInRegion(countryISOs, selection))}
+                onKeyUp={() => onChangeMany(countryISOs, !allSelectedInRegion(countryISOs, selection))}
+                role="button"
+                tabIndex={0}
+              >
+                <div className={classNames('fra-checkbox', { checked: allSelectedInRegion(countryISOs, selection) })} />
+                <div className="form-field-country-label">
+                  {i18n.t(`${allSelectedInRegion(countryISOs, selection) ? 'common.unselectAll' : 'common.selectAll'}`)}
+                </div>
+              </div>
+              <hr />
 
               {countryISOs.map((countryIso: string) => {
                 const unselectable = unselectableCountries.includes(countryIso)

--- a/src/client/components/CountrySelectModal/CountrySelectModalBody/CountrySelectModalBody.tsx
+++ b/src/client/components/CountrySelectModal/CountrySelectModalBody/CountrySelectModalBody.tsx
@@ -61,39 +61,32 @@ const CountrySelectModalBody: React.FC<Props> = (props) => {
         <MediaQuery maxWidth={Breakpoints.laptop - 1}>
           {Object.entries(regionCountries).map(([regionCode, countryISOs]) => (
             <div key={regionCode}>
-              <div>
-                <strong>{i18n.t(`area.${regionCode}.listName`)}</strong>
-
+              <div
+                className={classNames('form-field-country-selector', {
+                  disabled: allRegionCountriesDisabled(countryISOs),
+                })}
+                onClick={() => {
+                  const newSelection = allSelectedInRegion(countryISOs, selection)
+                    ? selection.filter((countryIso) => !countryISOs.includes(countryIso))
+                    : countryISOs.concat(selection)
+                  onChangeAll(newSelection.filter((c) => !unselectableCountries.includes(c)))
+                }}
+                onKeyUp={() => {
+                  const newSelection = allSelectedInRegion(countryISOs, selection)
+                    ? selection.filter((countryIso) => !countryISOs.includes(countryIso))
+                    : countryISOs.concat(selection)
+                  onChangeAll(newSelection.filter((c) => !unselectableCountries.includes(c)))
+                }}
+                role="button"
+                tabIndex={0}
+              >
                 <div
-                  className={classNames('form-field-country-selector', {
-                    disabled: allRegionCountriesDisabled(countryISOs),
+                  className={classNames('fra-checkbox', {
+                    checked: allSelectedInRegion(countryISOs, selection) && !allRegionCountriesDisabled(countryISOs),
+                    disabled: countryISOs.every((countryIso) => unselectableCountries.includes(countryIso)),
                   })}
-                  onClick={() => {
-                    const newSelection = allSelectedInRegion(countryISOs, selection)
-                      ? selection.filter((countryIso) => !countryISOs.includes(countryIso))
-                      : countryISOs.concat(selection)
-                    onChangeAll(newSelection)
-                  }}
-                  onKeyUp={() => onChangeAll(countryISOs)}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <div
-                    className={classNames('fra-checkbox', {
-                      checked: allSelectedInRegion(countryISOs, selection) && !allRegionCountriesDisabled(countryISOs),
-                      disabled: countryISOs.every((countryIso) => unselectableCountries.includes(countryIso)),
-                    })}
-                  />
-                  <div className="form-field-country-label">
-                    {i18n.t(
-                      `${
-                        allSelectedInRegion(countryISOs, selection) && !allRegionCountriesDisabled(countryISOs)
-                          ? 'common.unselectAll'
-                          : 'common.selectAll'
-                      }`
-                    )}
-                  </div>
-                </div>
+                />
+                <strong>{i18n.t(`area.${regionCode}.listName`)}</strong>
               </div>
               <select
                 multiple
@@ -121,33 +114,21 @@ const CountrySelectModalBody: React.FC<Props> = (props) => {
         <MediaQuery minWidth={Breakpoints.laptop}>
           {Object.entries(regionCountries).map(([regionCode, countryISOs]) => (
             <div key={regionCode} className="form-field-region-container">
-              <div className="form-field-region-wrapper">
-                <div className="form-field-region-label">{i18n.t(`area.${regionCode}.listName`)}</div>
-
+              <div
+                className={classNames('form-field-country-selector', {
+                  disabled: allRegionCountriesDisabled(countryISOs),
+                })}
+                onClick={() => onChangeMany(countryISOs, !allSelectedInRegion(countryISOs, selection))}
+                onKeyUp={() => onChangeMany(countryISOs, !allSelectedInRegion(countryISOs, selection))}
+                role="button"
+                tabIndex={0}
+              >
                 <div
-                  className={classNames('form-field-country-selector', {
-                    disabled: allRegionCountriesDisabled(countryISOs),
+                  className={classNames('fra-checkbox', {
+                    checked: allSelectedInRegion(countryISOs, selection) && !allRegionCountriesDisabled(countryISOs),
                   })}
-                  onClick={() => onChangeMany(countryISOs, !allSelectedInRegion(countryISOs, selection))}
-                  onKeyUp={() => onChangeMany(countryISOs, !allSelectedInRegion(countryISOs, selection))}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <div
-                    className={classNames('fra-checkbox', {
-                      checked: allSelectedInRegion(countryISOs, selection) && !allRegionCountriesDisabled(countryISOs),
-                    })}
-                  />
-                  <div className="form-field-country-label">
-                    {i18n.t(
-                      `${
-                        allSelectedInRegion(countryISOs, selection) && !allRegionCountriesDisabled(countryISOs)
-                          ? 'common.unselectAll'
-                          : 'common.selectAll'
-                      }`
-                    )}
-                  </div>
-                </div>
+                />
+                <div className="form-field-region-label">{i18n.t(`area.${regionCode}.listName`)}</div>
               </div>
 
               <hr />

--- a/src/client/components/CountrySelectModal/CountrySelectModalBody/countrySelectModalBody.scss
+++ b/src/client/components/CountrySelectModal/CountrySelectModalBody/countrySelectModalBody.scss
@@ -14,45 +14,51 @@
   }
 
   hr {
-    margin: $spacing-xxxs;
+    margin: $spacing-xxxs 0;
   }
 
-.form-field-country-label {
-  flex: 0 1 100%;
-}
-
-.form-field-region-container {
-  display: flex;
-  flex: 0 1 15%;
-  flex-flow: column;
-}
-
-.form-field-region-label {
-  font-weight: bold;
-  margin-bottom: 10px;
-  padding-left: 15px;
-}
-
-.form-field-country-selector {
-  cursor: pointer;
-  display: flex;
-  padding: 5px;
-  align-items: center;
-
-  .fra-checkbox {
-    margin-right: 4px;
+  .form-field-country-label {
+    flex: 0 1 100%;
   }
 
-  &.disabled {
-    cursor: not-allowed !important;
-    color: $text-disabled;
-    pointer-events: none;
+  .form-field-region-container {
+    display: flex;
+    flex: 0 1 15%;
+    flex-flow: column;
+  }
 
+  .form-field-region-label {
+    font-weight: bold;
+    margin-right: $spacing-xxxs;
+  }
+
+  .form-field-region-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    min-height: 40px;
+  }
+
+  .form-field-country-selector {
+    cursor: pointer;
+    display: flex;
+    padding: 5px;
+    align-items: center;
+    min-width: 83px;
     .fra-checkbox {
-      border: 1px solid $ui-border-light;
+      margin-right: 4px;
+    }
+
+    &.disabled {
+      cursor: not-allowed !important;
+      color: $text-disabled;
+      pointer-events: none;
+
+      .fra-checkbox {
+        border: 1px solid $ui-border-light;
+      }
     }
   }
-}
 
 
 }

--- a/src/client/components/CountrySelectModal/CountrySelectModalBody/countrySelectModalBody.scss
+++ b/src/client/components/CountrySelectModal/CountrySelectModalBody/countrySelectModalBody.scss
@@ -29,14 +29,6 @@
 
   .form-field-region-label {
     font-weight: bold;
-    margin-right: $spacing-xxxs;
-  }
-
-  .form-field-region-wrapper {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    min-height: 40px;
   }
 
   .form-field-country-selector {

--- a/src/client/components/CountrySelectModal/CountrySelectModalBody/countrySelectModalBody.scss
+++ b/src/client/components/CountrySelectModal/CountrySelectModalBody/countrySelectModalBody.scss
@@ -13,6 +13,10 @@
     width: 100%;
   }
 
+  hr {
+    margin: $spacing-xxxs;
+  }
+
 .form-field-country-label {
   flex: 0 1 100%;
 }

--- a/src/client/components/Modal/Modal.tsx
+++ b/src/client/components/Modal/Modal.tsx
@@ -3,27 +3,32 @@ import React from 'react'
 
 import Icon from '@client/components/Icon'
 
+type PropsChildren = {
+  children: React.ReactNode | React.ReactNode[]
+}
+
 export const ModalClose: React.FC<{ onClose(): void }> = ({ onClose }) => (
   <div className="modal-close" onClick={onClose} onKeyDown={onClose} role="button" tabIndex={0}>
     <Icon name="remove" />
   </div>
 )
 
-export const ModalHeader: React.FC = ({ children }) => (
+export const ModalHeader: React.FC<PropsChildren> = ({ children }) => (
   <div className="modal-header">{React.Children.toArray(children)}</div>
 )
 
-export const ModalBody: React.FC = ({ children }) => (
+export const ModalBody: React.FC<PropsChildren> = ({ children }) => (
   <div className="modal-body">{React.Children.toArray(children)}</div>
 )
 
-export const ModalFooter: React.FC = ({ children }) => (
+export const ModalFooter: React.FC<PropsChildren> = ({ children }) => (
   <div className="modal-footer">{React.Children.toArray(children)}</div>
 )
 
 type Props = {
   className?: string
   isOpen?: boolean
+  children: React.ReactNode | React.ReactNode[]
 }
 
 export const Modal: React.FC<Props> = ({ children, isOpen, className = '' }: any) => {

--- a/src/client/styles/checkbox.scss
+++ b/src/client/styles/checkbox.scss
@@ -1,7 +1,7 @@
 @import 'src/client/styles/config';
 
 .fra-checkbox {
-  width: 14px;
+  min-width: 14px;
   height: 14px;
   border-radius: 2px;
   border: 1px solid $ui-border-dark;

--- a/src/client/styles/checkbox.scss
+++ b/src/client/styles/checkbox.scss
@@ -1,7 +1,7 @@
 @import 'src/client/styles/config';
 
 .fra-checkbox {
-  min-width: 14px;
+  width: 14px;
   height: 14px;
   border-radius: 2px;
   border: 1px solid $ui-border-dark;


### PR DESCRIPTION
Resolves #1517 
- [x] Desktop
- [x] Mobile

Note:
Feature hides Select All/Unselect All when all countries of region are selected under another role

<img width="1639" alt="image" src="https://user-images.githubusercontent.com/5508251/191227814-926ba0cf-f47e-4f91-a150-3cfab14db30a.png">


<img width="785" alt="image" src="https://user-images.githubusercontent.com/5508251/191228412-e7d09ab1-de30-47c8-b435-5d5c8d1b8b02.png">

