### PR TITLE
ODP 1b allow plantations subcategories when plantation is 0

### DIFF
--- a/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristics.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristics.tsx
@@ -28,7 +28,8 @@ const ForestCharacteristics: React.FC<Props> = (props) => {
     field: 'forestPercent',
     subField: 'plantationPercent',
   })
-  const hasPlantation = plantationTotal && Numbers.greaterThan(plantationTotal, 0)
+
+  const hasPlantation = plantationTotal && Numbers.greaterThanOrEqualTo(plantationTotal, 0)
 
   return (
     <div className="odp__section">

--- a/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristicsPlantationRow.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristicsPlantationRow.tsx
@@ -16,7 +16,8 @@ import { useNationalClassNameComments, useNationalClassValidation } from '../../
 
 const columns = [{ name: 'plantationIntroducedPercent', type: 'decimal' }]
 
-const allowedClass = (nc: ODPNationalClass) => Number(nc.plantationPercent) > 0 && Number(nc.forestPercent) > 0
+const allowedClass = (nc: ODPNationalClass) =>
+  nc.plantationPercent !== null && Number(nc.plantationPercent) >= 0 && Number(nc.forestPercent) > 0
 
 type Props = {
   canEditData: boolean
@@ -48,14 +49,18 @@ const ForestCharacteristicsPlantationRow: React.FC<Props> = (props) => {
     return null
   }
 
+  // const isPlantationPercentNull = plantationPercent === null
+
+  const isZeroOrNullPlantationIntroduced = plantationIntroduced === null || Numbers.eq(plantationIntroduced, 0)
+
   return (
     <tr className={classNameRowComments}>
       <th className="fra-table__category-cell">{name}</th>
       <th className="fra-table__calculated-sub-cell fra-table__divider">{Numbers.format(plantationIntroduced)}</th>
       <td className={`fra-table__cell ${classNamePercentageValidation}`}>
         <PercentInput
-          disabled={!canEditData}
-          numberValue={plantationIntroducedPercent}
+          disabled={!canEditData || isZeroOrNullPlantationIntroduced}
+          numberValue={isZeroOrNullPlantationIntroduced ? 0 : plantationIntroducedPercent}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
             dispatch(
               OriginalDataPointActions.updateNationalClass({


### PR DESCRIPTION
Resolves #1558 

https://user-images.githubusercontent.com/5508251/193819036-4d6f528b-7283-4a3f-9ff9-3637b39aa521.mov



Field is read only if value is 0