### PR TITLE
Meta/2025 meta 7

### DIFF
--- a/src/client/pages/Assessment/SectionWrapper/SectionWrapper.tsx
+++ b/src/client/pages/Assessment/SectionWrapper/SectionWrapper.tsx
@@ -5,6 +5,7 @@ import { AssessmentName } from '@meta/assessment'
 import { Sockets } from '@meta/socket'
 
 import { useAppDispatch } from '@client/store'
+import { useTableSections } from '@client/store/pages/assessmentSection'
 import { useGetTableSections } from '@client/store/pages/assessmentSection/hooks/useGetTableSections'
 import { ReviewActions } from '@client/store/ui/review'
 import { useUser } from '@client/store/user'
@@ -17,18 +18,20 @@ type Props = {
   children: JSX.Element
 }
 
+type SectionParams = {
+  assessmentName: AssessmentName
+  cycleName: string
+  sectionName: string
+}
+
 const SectionWrapper: React.FC<Props> = (props) => {
   const { children } = props
 
+  const { assessmentName, cycleName, sectionName } = useParams<SectionParams>()
   const dispatch = useAppDispatch()
   const countryIso = useCountryIso()
   const user = useUser()
-  const { assessmentName, cycleName, sectionName } = useParams<{
-    assessmentName: AssessmentName
-    cycleName: string
-    sectionName: string
-  }>()
-
+  const tableSections = useTableSections({ sectionName })
   useGetTableSections()
 
   useEffect(() => {
@@ -36,7 +39,7 @@ const SectionWrapper: React.FC<Props> = (props) => {
     DOMs.scrollTo()
   }, [sectionName])
 
-  // fetch section review status
+  // subscribe to section review status update
   useEffect(() => {
     const requestReviewStatusEvent = Sockets.getRequestReviewStatusEvent({
       countryIso,
@@ -60,6 +63,8 @@ const SectionWrapper: React.FC<Props> = (props) => {
       }
     }
   }, [countryIso, assessmentName, cycleName, sectionName, user, dispatch])
+
+  if (!tableSections) return null
 
   return (
     <>

--- a/src/client/store/pages/assessmentSection/slice.ts
+++ b/src/client/store/pages/assessmentSection/slice.ts
@@ -54,7 +54,7 @@ export const assessmentSectionSlice = createSlice({
     builder.addCase(getTableData.fulfilled, (state, { payload }) => {
       const countryIso = Object.keys(payload || {})[0] as CountryIso
       if (countryIso) {
-        const countryData = state?.data?.[countryIso] ?? {}
+        const countryData = state.data?.[countryIso] ?? {}
         state.data = { ...state.data, [countryIso]: { ...countryData, ...payload[countryIso] } }
       }
     })

--- a/src/client/store/pages/assessmentSection/slice.ts
+++ b/src/client/store/pages/assessmentSection/slice.ts
@@ -54,8 +54,8 @@ export const assessmentSectionSlice = createSlice({
     builder.addCase(getTableData.fulfilled, (state, { payload }) => {
       const countryIso = Object.keys(payload || {})[0] as CountryIso
       if (countryIso) {
-        const countryData = (state.data && state.data[countryIso]) || {}
-        state.data = { ...state.data, [countryIso]: { ...payload[countryIso], ...countryData } }
+        const countryData = state?.data?.[countryIso] ?? {}
+        state.data = { ...state.data, [countryIso]: { ...countryData, ...payload[countryIso] } }
       }
     })
 

--- a/src/meta/assessment/assessmentMetaCache.ts
+++ b/src/meta/assessment/assessmentMetaCache.ts
@@ -1,8 +1,8 @@
 export type VariablesByTableCache = Record<string, Record<string, VariableCache>>
 
 export interface VariableCache {
-  variableName: string
   tableName: string
+  variableName: string
 }
 
 export type DependencyCache = {
@@ -17,8 +17,8 @@ export type DependencyCache = {
    *    }
    * }
    */
-  dependants: Record<string, Record<string, Array<VariableCache>>>
   dependencies: Record<string, Record<string, Array<VariableCache>>>
+  dependants: Record<string, Record<string, Array<VariableCache>>>
 }
 
 export interface AssessmentMetaCache {

--- a/src/meta/assessment/row.ts
+++ b/src/meta/assessment/row.ts
@@ -1,4 +1,4 @@
-import { Col, CycledPropsObject } from './index'
+import { Col, CycledPropsObject, VariableCache } from './index'
 
 export enum RowType {
   header = 'header',
@@ -15,45 +15,38 @@ export enum RowType {
 }
 
 export interface RowLabel {
-  key?: string
   prefix?: string
   params?: Record<string, string>
+  key?: string
 }
 
 export interface RowProps {
-  index: number | string
-  linkToSection?: string
-  type: RowType
-  variableName?: string
   calculateFn?: string
-  validateFns?: Array<string>
   chart?: {
-    labelKey: string
     color: string
+    labelKey: string
   }
-  label?: RowLabel
+  /**
+   * This property includes the variable dependants which the row should be excluded from.
+   *
+   * e.g. growingStockAvg.naturallyRegeneratingForest has as dependantsExclude [{ tableName: 'forestCharacteristics', variableName: 'naturalForestArea' }].
+   * This means when forestCharacteristics.naturalForestArea is updated, growingStockAvg.naturallyRegeneratingForest will not be updated
+   * even if forestCharacteristics.naturalForestArea is included in its calculation formula.
+   */
+  dependantsExclude?: Array<VariableCache>
   format?: {
     integer?: boolean
   }
+  index: number | string
+  label?: RowLabel // TODO: remove? (check if used - probably not)
+  linkToSection?: string
   readonly?: boolean
+  type: RowType
+  variableName?: string
+  validateFns?: Array<string>
 }
 
 export interface Row extends CycledPropsObject<RowProps> {
   cols?: Array<Col>
   tableId: number
-  // validator?: Validator
-  // calculateFn?: CalculateValue
-  // chartProps?: RowChartSpec
-  // idx?: string | number
-  // label?: string
-  // validation messages
-  // getValidationMessages?: GetValidationMessages
-  // row header
-  // mainCategory?: boolean
-  // subcategory?: boolean
-  // variableNo?: string
-  // row notice message
-  // rowSpan?: number
-  // colSpan?: number
-  // variableExport?: string
 }

--- a/src/test/sectionSpec/fraSpecs.ts
+++ b/src/test/sectionSpec/fraSpecs.ts
@@ -2095,6 +2095,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
                   calcFormula:
                     '(growingStockTotal.naturallyRegeneratingForest * 1000) / forestCharacteristics.naturalForestArea',
                   readonly: false,
+                  dependantsExclude: [{ tableName: 'forestCharacteristics', variableName: 'naturalForestArea' }],
                 },
               },
               {

--- a/src/test/sectionSpec/fraSpecs.ts
+++ b/src/test/sectionSpec/fraSpecs.ts
@@ -2123,6 +2123,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
                 migration: {
                   calcFormula: '(growingStockTotal.plantedForest * 1000) / forestCharacteristics.plantedForest',
                   readonly: false,
+                  dependantsExclude: [{ tableName: 'forestCharacteristics', variableName: 'plantedForest' }],
                 },
               },
               {
@@ -2151,6 +2152,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
                   calcFormula:
                     '(growingStockTotal.plantationForest * 1000) / forestCharacteristics.plantationForestArea',
                   readonly: false,
+                  dependantsExclude: [{ tableName: 'forestCharacteristics', variableName: 'plantationForestArea' }],
                 },
               },
               {
@@ -2179,6 +2181,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
                   calcFormula:
                     '(growingStockTotal.otherPlantedForest * 1000) / forestCharacteristics.otherPlantedForestArea',
                   readonly: false,
+                  dependantsExclude: [{ tableName: 'forestCharacteristics', variableName: 'otherPlantedForestArea' }],
                 },
               },
               {
@@ -2206,6 +2209,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
                 migration: {
                   calcFormula: '(growingStockTotal.forest * 1000) / extentOfForest.forestArea',
                   readonly: false,
+                  dependantsExclude: [{ tableName: 'extentOfForest', variableName: 'forestArea' }],
                 },
               },
               {
@@ -2233,6 +2237,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
                 migration: {
                   calcFormula: '(growingStockTotal.otherWoodedLand * 1000) / extentOfForest.otherWoodedLand',
                   readonly: false,
+                  dependantsExclude: [{ tableName: 'extentOfForest', variableName: 'otherWoodedLand' }],
                 },
               },
             ],

--- a/src/test/sectionSpec/fraSpecs.ts
+++ b/src/test/sectionSpec/fraSpecs.ts
@@ -484,6 +484,39 @@ export const FraSpecs: Record<string, SectionSpec> = {
                     idx: 'header_0',
                     type: 'header',
                     colSpan: 1,
+                    labelKey: 'forestCharacteristics.plantedForest',
+                    variableNo: 'b',
+                    className: 'fra-table__header-cell-left',
+                    migration: {
+                      variableNo: { '2020': 'b', '2025': 'b=b1+b2' },
+                    },
+                  },
+                  ...fraYears.map((year, idx) => ({
+                    idx,
+                    colSpan: 1,
+                    rowSpan: 1,
+                    type: 'calculated',
+                    colName: `${year}`,
+                  })),
+                ],
+                labelKey: 'forestCharacteristics.plantedForest',
+                variableNo: 'b',
+                variableName: 'plantedForest',
+                variableExport: 'planted_forest',
+                migration: {
+                  calcFormula: `(forestCharacteristics.plantationForestArea || forestCharacteristics.otherPlantedForestArea) 
+      ? (forestCharacteristics.plantationForestArea || 0) + (forestCharacteristics.otherPlantedForestArea || 0) 
+      : null`,
+                },
+              },
+              {
+                idx: 3,
+                type: 'data',
+                cols: [
+                  {
+                    idx: 'header_0',
+                    type: 'header',
+                    colSpan: 1,
                     labelKey: 'forestCharacteristics.plantationForestArea',
                     className: 'fra-table__category-cell',
                     migration: {
@@ -507,7 +540,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
                 },
               },
               {
-                idx: 3,
+                idx: 4,
                 type: 'data',
                 cols: [
                   {
@@ -536,7 +569,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
                 },
               },
               {
-                idx: 4,
+                idx: 5,
                 type: 'data',
                 cols: [
                   {
@@ -563,39 +596,6 @@ export const FraSpecs: Record<string, SectionSpec> = {
                 chartProps: {
                   labelKey: 'forestCharacteristics.otherPlantedForestArea',
                   color: '#f58833',
-                },
-              },
-              {
-                idx: 5,
-                type: 'data',
-                cols: [
-                  {
-                    idx: 'header_0',
-                    type: 'header',
-                    colSpan: 1,
-                    labelKey: 'forestCharacteristics.plantedForest',
-                    variableNo: 'b',
-                    className: 'fra-table__header-cell-left',
-                    migration: {
-                      variableNo: { '2020': 'b', '2025': 'b=b1+b2' },
-                    },
-                  },
-                  ...fraYears.map((year, idx) => ({
-                    idx,
-                    colSpan: 1,
-                    rowSpan: 1,
-                    type: 'calculated',
-                    colName: `${year}`,
-                  })),
-                ],
-                labelKey: 'forestCharacteristics.plantedForest',
-                variableNo: 'b',
-                variableName: 'plantedForest',
-                variableExport: 'planted_forest',
-                migration: {
-                  calcFormula: `(forestCharacteristics.plantationForestArea || forestCharacteristics.otherPlantedForestArea) 
-      ? (forestCharacteristics.plantationForestArea || 0) + (forestCharacteristics.otherPlantedForestArea || 0) 
-      : null`,
                 },
               },
               {
@@ -630,33 +630,33 @@ export const FraSpecs: Record<string, SectionSpec> = {
                   ],
                 },
               },
-              {
-                idx: 7,
-                type: 'data',
-                cols: [
-                  {
-                    idx: 'header_0',
-                    type: 'header',
-                    colSpan: 1,
-                    labelKey: 'forestCharacteristics.totalForestArea',
-                    linkToSection: 'extentOfForest',
-                    className: 'fra-table__header-cell-left',
-                  },
-                  ...fraYears.map((year, idx) => ({
-                    idx,
-                    colSpan: 1,
-                    rowSpan: 1,
-                    type: 'calculated',
-                    colName: `${year}`,
-                  })),
-                ],
-                labelKey: 'forestCharacteristics.totalForestArea',
-                linkToSection: 'extentOfForest',
-                variableName: 'forestArea', // before it was totalForestArea
-                migration: {
-                  calcFormula: 'extentOfForest.forestArea',
-                },
-              },
+              // {
+              //   idx: 7,
+              //   type: 'data',
+              //   cols: [
+              //     {
+              //       idx: 'header_0',
+              //       type: 'header',
+              //       colSpan: 1,
+              //       labelKey: 'forestCharacteristics.totalForestArea',
+              //       linkToSection: 'extentOfForest',
+              //       className: 'fra-table__header-cell-left',
+              //     },
+              //     ...fraYears.map((year, idx) => ({
+              //       idx,
+              //       colSpan: 1,
+              //       rowSpan: 1,
+              //       type: 'calculated',
+              //       colName: `${year}`,
+              //     })),
+              //   ],
+              //   labelKey: 'forestCharacteristics.totalForestArea',
+              //   linkToSection: 'extentOfForest',
+              //   variableName: 'forestArea', // before it was totalForestArea
+              //   migration: {
+              //     calcFormula: 'extentOfForest.forestArea',
+              //   },
+              // },
               {
                 idx: 8,
                 type: 'noticeMessage',

--- a/src/test/sectionSpec/rowSpec.ts
+++ b/src/test/sectionSpec/rowSpec.ts
@@ -1,3 +1,5 @@
+import { VariableCache } from '@meta/assessment'
+
 import { ColSpec } from './colSpec'
 import { TypeSpec } from './typeSpec'
 import { GetValidationMessages, Validator } from './validation'
@@ -38,5 +40,6 @@ export interface RowSpec {
     readonly?: boolean
     validateFns?: Array<string>
     cycles?: Array<string>
+    dependantsExclude?: Array<VariableCache>
   }
 }

--- a/tools/dataMigration/generateMetaCache/dependencyEvaluator/evalDependencies/member.ts
+++ b/tools/dataMigration/generateMetaCache/dependencyEvaluator/evalDependencies/member.ts
@@ -3,8 +3,11 @@ import { ExpressionNodeEvaluator, MemberExpression } from '@openforis/arena-core
 import { VariableCache } from '../../../../../src/meta/assessment/assessmentMetaCache'
 import { Context } from './context'
 
+const includesVariableCache = (variables: Array<VariableCache>, variable: VariableCache): boolean =>
+  Boolean(variables.find((v) => v.variableName === variable.variableName && v.tableName === variable.tableName))
+
 export class MemberEvaluator extends ExpressionNodeEvaluator<Context, MemberExpression> {
-  evaluate(expressionNode: MemberExpression): any {
+  evaluate(expressionNode: MemberExpression): string {
     const { object, property } = expressionNode
 
     const { assessmentMetaCache, row, tableName, type } = this.context
@@ -18,7 +21,7 @@ export class MemberEvaluator extends ExpressionNodeEvaluator<Context, MemberExpr
       const dependantTable = assessmentMetaCache[type].dependants?.[objectName] ?? {}
       const dependants = dependantTable[propertyName] ?? []
       const dependant: VariableCache = { variableName: row.props.variableName, tableName }
-      if (!dependants.find((d) => d.variableName === dependant.variableName)) {
+      if (!includesVariableCache(dependants, dependant)) {
         assessmentMetaCache[type].dependants = {
           ...assessmentMetaCache[type].dependants,
           // @ts-ignore
@@ -34,7 +37,7 @@ export class MemberEvaluator extends ExpressionNodeEvaluator<Context, MemberExpr
       const dependencies = dependencyTable[row.props.variableName] ?? []
       // @ts-ignore
       const dependency: VariableCache = { variableName: propertyName, tableName: objectName }
-      if (!dependencies.find((d) => d.variableName === dependency.variableName)) {
+      if (!includesVariableCache(dependencies, dependency)) {
         assessmentMetaCache[type].dependencies = {
           ...assessmentMetaCache[type].dependencies,
           [tableName]: {

--- a/tools/dataMigration/generateMetaCache/dependencyEvaluator/evalDependencies/member.ts
+++ b/tools/dataMigration/generateMetaCache/dependencyEvaluator/evalDependencies/member.ts
@@ -1,10 +1,14 @@
 import { ExpressionNodeEvaluator, MemberExpression } from '@openforis/arena-core'
 
 import { VariableCache } from '../../../../../src/meta/assessment/assessmentMetaCache'
+import { Row } from '../../../../../src/meta/assessment/row'
 import { Context } from './context'
 
 const includesVariableCache = (variables: Array<VariableCache>, variable: VariableCache): boolean =>
   Boolean(variables.find((v) => v.variableName === variable.variableName && v.tableName === variable.tableName))
+
+const excludeDependant = (row: Row, tableName: string, variableName: string): boolean =>
+  Boolean(row.props?.dependantsExclude?.find((v) => v.tableName === tableName && v.variableName === variableName))
 
 export class MemberEvaluator extends ExpressionNodeEvaluator<Context, MemberExpression> {
   evaluate(expressionNode: MemberExpression): string {
@@ -21,7 +25,7 @@ export class MemberEvaluator extends ExpressionNodeEvaluator<Context, MemberExpr
       const dependantTable = assessmentMetaCache[type].dependants?.[objectName] ?? {}
       const dependants = dependantTable[propertyName] ?? []
       const dependant: VariableCache = { variableName: row.props.variableName, tableName }
-      if (!includesVariableCache(dependants, dependant)) {
+      if (!excludeDependant(row, objectName, propertyName) && !includesVariableCache(dependants, dependant)) {
         assessmentMetaCache[type].dependants = {
           ...assessmentMetaCache[type].dependants,
           // @ts-ignore

--- a/tools/dataMigration/migrateMetadata/getRow.ts
+++ b/tools/dataMigration/migrateMetadata/getRow.ts
@@ -16,6 +16,7 @@ export const getRow = (props: { assessment: Assessment; rowSpec: RowSpec; table:
       calculateFn: rowSpec.migration?.calcFormula,
       readonly: rowSpec.migration?.readonly,
       validateFns: rowSpec.migration?.validateFns,
+      dependantsExclude: rowSpec.migration?.dependantsExclude,
     },
     cols: [],
     tableId: table.id,


### PR DESCRIPTION
- introduce dependantsExclude row property 
```typescript
  /**
   * This property includes the variable dependants which the row should be excluded from.
   *
   * e.g. growingStockAvg.naturallyRegeneratingForest has as dependantsExclude [{ tableName: 'forestCharacteristics', variableName: 'naturalForestArea' }].
   * This means when forestCharacteristics.naturalForestArea is updated, growingStockAvg.naturallyRegeneratingForest will not be updated
   * even if forestCharacteristics.naturalForestArea is included in its calculation formula.
   */
``` 

- [fix dependencies evaluator](https://github.com/openforis/fra-platform/commit/ce64a98a8fc4fa6b2e33fcf9b4f07c2084648bc5)

- [fix getTableData.fulfilled data merge](https://github.com/openforis/fra-platform/commit/8a9089f47a1290fb3b9ff53d203788c256d16101)

- [add dependantsExclude to growingStockAvg table](https://github.com/openforis/fra-platform/commit/82e7b8b6b137fc8d247501371ba46a3aceedfafe)

Example video:

https://user-images.githubusercontent.com/1138156/195673776-5a2cc1f7-25c5-4c83-bf26-0a003f5e473d.mov

