### PR TITLE
Meta/2025 meta 5

### DIFF
--- a/src/i18n/resources/en/fra.js
+++ b/src/i18n/resources/en/fra.js
@@ -8,13 +8,13 @@ module.exports = {
 
   // tables
   areaAffectedByFire: {
-    areaUnitLabel2025: 'Area affected (1000 ha)',
+    areaAffected: 'Area affected (1000 ha)',
   },
 
   disturbances: {
-    disturbances2025: 'Forest damage',
-    categoryHeader: 'Predominant cause',
-    areaUnitLabel2025: 'Forest area affected (1000 ha)',
+    forestDamage: 'Forest damage',
+    predominantCause: 'Predominant cause',
+    forestAreaAffected: 'Forest area affected (1000 ha)',
   },
 
   extentOfForest: {

--- a/src/i18n/resources/en/fra.js
+++ b/src/i18n/resources/en/fra.js
@@ -7,6 +7,12 @@ module.exports = {
   forestArea100HaYear: 'Forest area (1000 ha)',
 
   // tables
+  disturbances: {
+    disturbances2025: 'Forest damage',
+    categoryHeader: 'Predominant cause',
+    areaUnitLabel2025: 'Forest area affected (1000 ha)',
+  },
+
   extentOfForest: {
     remainingLandArea: 'Remaining land area',
   },
@@ -15,6 +21,7 @@ module.exports = {
     primaryForest: '…of which primary forest',
     plantationForestIntroducedArea2025: '…of which introduced species',
   },
+
   forestOwnership: {
     ofWhichCommunities2025: '…of which owned by Indigenous Peoples and local communities',
     other2025: 'Other (specify in comments)',

--- a/src/i18n/resources/en/fra.js
+++ b/src/i18n/resources/en/fra.js
@@ -7,6 +7,10 @@ module.exports = {
   forestArea100HaYear: 'Forest area (1000 ha)',
 
   // tables
+  areaAffectedByFire: {
+    areaUnitLabel2025: 'Area affected (1000 ha)',
+  },
+
   disturbances: {
     disturbances2025: 'Forest damage',
     categoryHeader: 'Predominant cause',

--- a/src/test/sectionSpec/fraSpecs.ts
+++ b/src/test/sectionSpec/fraSpecs.ts
@@ -6867,6 +6867,12 @@ export const FraSpecs: Record<string, SectionSpec> = {
                     labelKey: 'disturbances.categoryHeader',
                     className: 'fra-table__header-cell-left',
                     type: 'header',
+                    migration: {
+                      label: {
+                        '2020': { key: 'disturbances.categoryHeader' },
+                        '2025': { key: 'fra.disturbances.disturbances2025' },
+                      },
+                    },
                   },
                   {
                     idx: 1,
@@ -6875,6 +6881,12 @@ export const FraSpecs: Record<string, SectionSpec> = {
                     labelKey: 'disturbances.areaUnitLabel',
                     className: 'fra-table__header-cell',
                     type: 'header',
+                    migration: {
+                      label: {
+                        '2020': { key: 'disturbances.areaUnitLabel' },
+                        '2025': { key: 'fra.disturbances.areaUnitLabel2025' },
+                      },
+                    },
                   },
                 ],
                 type: 'header',
@@ -7476,6 +7488,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
                 mainCategory: true,
                 variableName: 'total',
                 migration: {
+                  cycles: ['2020'],
                   colNames: [
                     '2000',
                     '2001',
@@ -7594,6 +7607,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
                 linkToSection: 'extentOfForest',
                 variableName: 'totalForestArea',
                 migration: {
+                  cycles: ['2020'],
                   colNames: [
                     '2000',
                     '2001',
@@ -7667,6 +7681,12 @@ export const FraSpecs: Record<string, SectionSpec> = {
     },
     dataExport: {
       included: true,
+    },
+    migration: {
+      label: {
+        '2020': { key: 'disturbances.disturbances' },
+        '2025': { key: 'fra.disturbances.disturbances2025' },
+      },
     },
   },
   areaAffectedByFire: {

--- a/src/test/sectionSpec/fraSpecs.ts
+++ b/src/test/sectionSpec/fraSpecs.ts
@@ -7708,6 +7708,12 @@ export const FraSpecs: Record<string, SectionSpec> = {
                     labelKey: 'areaAffectedByFire.categoryHeader',
                     className: 'fra-table__header-cell-left',
                     type: 'header',
+                    migration: {
+                      label: {
+                        '2020': { key: 'fra.categoryHeader2020' },
+                        '2025': { key: 'fra.categoryHeader2025' },
+                      },
+                    },
                   },
                   {
                     idx: 1,
@@ -7716,6 +7722,12 @@ export const FraSpecs: Record<string, SectionSpec> = {
                     labelKey: 'areaAffectedByFire.areaUnitLabel',
                     className: 'fra-table__header-cell',
                     type: 'header',
+                    migration: {
+                      label: {
+                        '2020': { key: 'areaAffectedByFire.areaUnitLabel' },
+                        '2025': { key: 'fra.areaAffectedByFire.areaUnitLabel2025' },
+                      },
+                    },
                   },
                 ],
                 type: 'header',

--- a/src/test/sectionSpec/fraSpecs.ts
+++ b/src/test/sectionSpec/fraSpecs.ts
@@ -6870,7 +6870,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
                     migration: {
                       label: {
                         '2020': { key: 'disturbances.categoryHeader' },
-                        '2025': { key: 'fra.disturbances.disturbances2025' },
+                        '2025': { key: 'fra.disturbances.predominantCause' },
                       },
                     },
                   },
@@ -6884,7 +6884,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
                     migration: {
                       label: {
                         '2020': { key: 'disturbances.areaUnitLabel' },
-                        '2025': { key: 'fra.disturbances.areaUnitLabel2025' },
+                        '2025': { key: 'fra.disturbances.forestAreaAffected' },
                       },
                     },
                   },
@@ -7685,7 +7685,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
     migration: {
       label: {
         '2020': { key: 'disturbances.disturbances' },
-        '2025': { key: 'fra.disturbances.disturbances2025' },
+        '2025': { key: 'fra.disturbances.forestDamage' },
       },
     },
   },
@@ -7725,7 +7725,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
                     migration: {
                       label: {
                         '2020': { key: 'areaAffectedByFire.areaUnitLabel' },
-                        '2025': { key: 'fra.areaAffectedByFire.areaUnitLabel2025' },
+                        '2025': { key: 'fra.areaAffectedByFire.areaAffected' },
                       },
                     },
                   },
@@ -8094,6 +8094,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
               2017,
             ],
             unit: 'haThousand',
+            migration: {},
           },
         ],
       },


### PR DESCRIPTION
Part of #1502

Section 5
- [x]  5a (@sorja )
- [x]  5b (@sorja )
- [x]  5c(@sorja ) no changes

spec:
<img width="977" alt="Screenshot 2022-10-25 at 11 27 18" src="https://user-images.githubusercontent.com/5508251/197737257-931faba4-cab2-486b-8c82-f9577af4477d.png">

2020 5a:

<img width="1708" alt="Screenshot 2022-10-25 at 11 28 16" src="https://user-images.githubusercontent.com/5508251/197737482-0ebd7e11-1a94-42d1-8803-fd7b0ca67de6.png">

2025 5a:

<img width="1710" alt="Screenshot 2022-10-25 at 11 28 35" src="https://user-images.githubusercontent.com/5508251/197737544-141850b5-8fa7-4bb1-a699-a281520ebdda.png">

2020 5b:

<img width="1721" alt="Screenshot 2022-10-25 at 11 28 54" src="https://user-images.githubusercontent.com/5508251/197737622-b8a2d24a-e1bc-4587-8989-bf8651077b4b.png">

2025 5b:

<img width="1723" alt="Screenshot 2022-10-25 at 11 29 14" src="https://user-images.githubusercontent.com/5508251/197737680-c7ae3652-2d52-4f67-9384-87d7fb206967.png">

2020 5c: no change
2025 5c: no change