### PR TITLE
Forest Characteristics: Fix issue with column names

### DIFF
--- a/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristics.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristics.tsx
@@ -26,7 +26,7 @@ const ForestCharacteristics: React.FC<Props> = (props) => {
   const plantationTotal = ODPs.calcTotalSubFieldArea({
     originalDataPoint,
     field: 'forestPercent',
-    subField: 'plantationPercent',
+    subField: 'forestPlantationPercent',
   })
 
   const hasPlantation = plantationTotal && Numbers.greaterThanOrEqualTo(plantationTotal, 0)
@@ -98,7 +98,7 @@ const ForestCharacteristics: React.FC<Props> = (props) => {
                     ODPs.calcTotalSubFieldArea({
                       originalDataPoint,
                       field: 'forestPercent',
-                      subField: 'naturalForestPercent',
+                      subField: 'forestNaturalPercent',
                     })
                   )}
                 </td>
@@ -107,7 +107,7 @@ const ForestCharacteristics: React.FC<Props> = (props) => {
                     ODPs.calcTotalSubFieldArea({
                       originalDataPoint,
                       field: 'forestPercent',
-                      subField: 'plantationPercent',
+                      subField: 'forestPlantationPercent',
                     })
                   )}
                 </td>
@@ -116,7 +116,7 @@ const ForestCharacteristics: React.FC<Props> = (props) => {
                     ODPs.calcTotalSubFieldArea({
                       originalDataPoint,
                       field: 'forestPercent',
-                      subField: 'otherPlantedPercent',
+                      subField: 'otherPlantedForestPercent',
                     })
                   )}
                 </td>

--- a/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristicsPlantation.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristicsPlantation.tsx
@@ -16,7 +16,7 @@ type Props = {
 const ForestCharacteristicsPlantation: React.FC<Props> = (props) => {
   const { canEditData } = props
   const originalDataPoint = useOriginalDataPoint()
-  const { i18n } = useTranslation()
+  const { t } = useTranslation()
 
   const nationalClasses = originalDataPoint?.nationalClasses.filter((nationalClass) => !nationalClass.placeHolder)
 
@@ -26,11 +26,9 @@ const ForestCharacteristicsPlantation: React.FC<Props> = (props) => {
         <table className="fra-table odp__sub-table">
           <thead>
             <tr>
-              <th className="fra-table__header-cell-left">
-                {i18n.t('fraForestCharacteristicsClass.plantationForest')}
-              </th>
-              <th className="fra-table__header-cell fra-table__divider">{i18n.t('nationalDataPoint.area')}</th>
-              <th className="fra-table__header-cell">{i18n.t('fraForestCharacteristicsClass.ofWhichIntroduced')}</th>
+              <th className="fra-table__header-cell-left">{t('fraForestCharacteristicsClass.plantationForest')}</th>
+              <th className="fra-table__header-cell fra-table__divider">{t('nationalDataPoint.area')}</th>
+              <th className="fra-table__header-cell">{t('fraForestCharacteristicsClass.ofWhichIntroduced')}</th>
             </tr>
           </thead>
 
@@ -42,14 +40,14 @@ const ForestCharacteristicsPlantation: React.FC<Props> = (props) => {
 
           <tfoot>
             <tr>
-              <th className="fra-table__header-cell-left">{i18n.t('nationalDataPoint.total')}</th>
+              <th className="fra-table__header-cell-left">{t('nationalDataPoint.total')}</th>
               <th className="fra-table__calculated-cell fra-table__divider">
                 {originalDataPoint &&
                   Numbers.format(
                     ODPs.calcTotalSubFieldArea({
                       originalDataPoint,
                       field: 'forestPercent',
-                      subField: 'plantationPercent',
+                      subField: 'forestPlantationPercent',
                     })
                   )}
               </th>
@@ -59,8 +57,8 @@ const ForestCharacteristicsPlantation: React.FC<Props> = (props) => {
                     ODPs.calcTotalSubSubFieldArea({
                       originalDataPoint,
                       field: 'forestPercent',
-                      subField: 'plantationPercent',
-                      subSubField: 'plantationIntroducedPercent',
+                      subField: 'forestPlantationPercent',
+                      subSubField: 'forestPlantationIntroducedPercent',
                     })
                   )}
               </td>

--- a/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristicsPlantationRow.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristicsPlantationRow.tsx
@@ -14,10 +14,10 @@ import ReviewIndicator from '@client/components/ReviewIndicator'
 
 import { useNationalClassNameComments, useNationalClassValidation } from '../../hooks'
 
-const columns = [{ name: 'plantationIntroducedPercent', type: 'decimal' }]
+const columns = [{ name: 'forestPlantationIntroducedPercent', type: 'decimal' }]
 
 const allowedClass = (nc: ODPNationalClass) =>
-  nc.plantationPercent !== null && Number(nc.plantationPercent) >= 0 && Number(nc.forestPercent) > 0
+  nc.forestPlantationPercent !== null && Number(nc.forestPlantationPercent) >= 0 && Number(nc.forestPercent) > 0
 
 type Props = {
   canEditData: boolean
@@ -36,20 +36,20 @@ const ForestCharacteristicsPlantationRow: React.FC<Props> = (props) => {
 
   const { nationalClasses, id } = originalDataPoint
   const nationalClass = nationalClasses[index]
-  const { name, area, forestPercent, plantationPercent, plantationIntroducedPercent, uuid } = nationalClass
+  const { name, area, forestPercent, forestPlantationPercent, forestPlantationIntroducedPercent, uuid } = nationalClass
   const target = [id, 'class', `${uuid}`, 'plantation_forest_introduced'] as string[]
   const classNameRowComments = useNationalClassNameComments(target)
   const validationStatus = useNationalClassValidation(index)
   const classNamePercentageValidation = validationStatus.validPlantationIntroducedPercentage === false ? 'error' : ''
   const plantationIntroduced = area
-    ? Numbers.mul(area, Numbers.div(Numbers.mul(plantationPercent, forestPercent), 10000))
+    ? Numbers.mul(area, Numbers.div(Numbers.mul(forestPlantationPercent, forestPercent), 10000))
     : null
 
   if (!allowedClass(nationalClass)) {
     return null
   }
 
-  // const isPlantationPercentNull = plantationPercent === null
+  // const isPlantationPercentNull = forestPlantationPercent === null
 
   const isZeroOrNullPlantationIntroduced = plantationIntroduced === null || Numbers.eq(plantationIntroduced, 0)
 
@@ -60,14 +60,14 @@ const ForestCharacteristicsPlantationRow: React.FC<Props> = (props) => {
       <td className={`fra-table__cell ${classNamePercentageValidation}`}>
         <PercentInput
           disabled={!canEditData || isZeroOrNullPlantationIntroduced}
-          numberValue={isZeroOrNullPlantationIntroduced ? 0 : plantationIntroducedPercent}
+          numberValue={isZeroOrNullPlantationIntroduced ? 0 : forestPlantationIntroducedPercent}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
             dispatch(
               OriginalDataPointActions.updateNationalClass({
                 odp: originalDataPoint,
                 index,
-                field: 'plantationIntroducedPercent',
-                prevValue: plantationIntroducedPercent,
+                field: 'forestPlantationIntroducedPercent',
+                prevValue: forestPlantationIntroducedPercent,
                 value: event.target.value,
                 assessmentName: assessment.props.name,
                 cycleName: cycle.name,

--- a/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristicsRow.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristicsRow.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Numbers } from '@utils/numbers'
+import classNames from 'classnames'
 
 import { ODPNationalClass, OriginalDataPoint } from '@meta/assessment'
 
@@ -15,9 +16,9 @@ import { useNationalClassNameComments, useNationalClassValidation } from '../../
 
 const columns = [
   { name: 'area', type: 'decimal' },
-  { name: 'naturalForestPercent', type: 'decimal' },
-  { name: 'plantationPercent', type: 'decimal' },
-  { name: 'otherPlantedPercent', type: 'decimal' },
+  { name: 'forestNaturalPercent', type: 'decimal' },
+  { name: 'forestPlantationPercent', type: 'decimal' },
+  { name: 'otherPlantedForestPercent', type: 'decimal' },
 ]
 
 const allowedClass = (nc: ODPNationalClass) => Number(nc.forestPercent) > 0
@@ -38,12 +39,11 @@ const ForestCharacteristicsRow: React.FC<Props> = (props) => {
 
   const { nationalClasses, id } = originalDataPoint
   const nationalClass = nationalClasses[index]
-  const { name, area, naturalForestPercent, plantationPercent, otherPlantedPercent, uuid } = nationalClass
+  const { name, area, forestNaturalPercent, forestPlantationPercent, otherPlantedForestPercent, uuid } = nationalClass
   const target = [id, 'class', `${uuid}`, 'forest_charasteristics'] as string[]
   const classNameRowComments = useNationalClassNameComments(target)
   const validationStatus = useNationalClassValidation(index)
-  // TODO: Use classNames when validationStatus is implemented
-  const classNamePercentageValidation = validationStatus.validFocPercentage === false ? 'error' : ''
+  const errorClass = { error: validationStatus.validFocPercentage === false }
 
   if (!allowedClass(nationalClass)) {
     return null
@@ -55,17 +55,17 @@ const ForestCharacteristicsRow: React.FC<Props> = (props) => {
       <th className="fra-table__calculated-sub-cell fra-table__divider">
         {area && Numbers.format((Number(area) * Number(nationalClass.forestPercent)) / 100)}
       </th>
-      <td className={`fra-table__cell ${classNamePercentageValidation}`}>
+      <td className={classNames('fra-table__cell', errorClass)}>
         <PercentInput
           disabled={!canEditData}
-          numberValue={naturalForestPercent}
+          numberValue={forestNaturalPercent}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
             dispatch(
               OriginalDataPointActions.updateNationalClass({
                 odp: originalDataPoint,
                 index,
-                field: 'naturalForestPercent',
-                prevValue: naturalForestPercent,
+                field: 'forestNaturalPercent',
+                prevValue: forestNaturalPercent,
                 value: event.target.value,
                 assessmentName: assessment.props.name,
                 cycleName: cycle.name,
@@ -89,17 +89,17 @@ const ForestCharacteristicsRow: React.FC<Props> = (props) => {
         />
       </td>
 
-      <td className={`fra-table__cell ${classNamePercentageValidation}`}>
+      <td className={classNames('fra-table__cell', errorClass)}>
         <PercentInput
           disabled={!canEditData}
-          numberValue={plantationPercent}
+          numberValue={forestPlantationPercent}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
             dispatch(
               OriginalDataPointActions.updateNationalClass({
                 odp: originalDataPoint,
                 index,
-                field: 'plantationPercent',
-                prevValue: plantationPercent,
+                field: 'forestPlantationPercent',
+                prevValue: forestPlantationPercent,
                 value: event.target.value,
                 assessmentName: assessment.props.name,
                 cycleName: cycle.name,
@@ -123,17 +123,17 @@ const ForestCharacteristicsRow: React.FC<Props> = (props) => {
         />
       </td>
 
-      <td className={`fra-table__cell ${classNamePercentageValidation}`}>
+      <td className={classNames('fra-table__cell', errorClass)}>
         <PercentInput
           disabled={!canEditData}
-          numberValue={otherPlantedPercent}
+          numberValue={otherPlantedForestPercent}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
             dispatch(
               OriginalDataPointActions.updateNationalClass({
                 odp: originalDataPoint,
                 index,
-                field: 'otherPlantedPercent',
-                prevValue: otherPlantedPercent,
+                field: 'otherPlantedForestPercent',
+                prevValue: otherPlantedForestPercent,
                 value: event.target.value,
                 assessmentName: assessment.props.name,
                 cycleName: cycle.name,

--- a/src/client/store/pages/originalDataPoint/actions/handlePaste.test.ts
+++ b/src/client/store/pages/originalDataPoint/actions/handlePaste.test.ts
@@ -77,9 +77,9 @@ describe('OriginalDataPoint paste test:', () => {
       countryIso,
       nationalClasses: [
         { name: 'Closed forest' },
-        { name: 'Open forest', otherPlantedPercent: '10' },
+        { name: 'Open forest', otherPlantedForestPercent: '10' },
         { name: 'Hardwood plantations' },
-        { name: 'Coconut plantations', otherPlantedPercent: '25' },
+        { name: 'Coconut plantations', otherPlantedForestPercent: '25' },
         { name: '', placeHolder: true },
       ],
     } as OriginalDataPoint
@@ -87,21 +87,21 @@ describe('OriginalDataPoint paste test:', () => {
       { name: 'Closed forest' },
       {
         name: 'Open forest',
-        otherPlantedPercent: '10',
+        otherPlantedForestPercent: '10',
         otherLandPalmsPercent: '10',
         otherLandTreeOrchardsPercent: '20',
       },
       { name: 'Hardwood plantations' },
       {
         name: 'Coconut plantations',
-        otherPlantedPercent: '25',
+        otherPlantedForestPercent: '25',
         otherLandPalmsPercent: '30',
         otherLandTreeOrchardsPercent: '40',
       },
     ] as Array<ODPNationalClass>
     const result = handlePaste(
       otherLandCharacteristicsCols,
-      (nc: ODPNationalClass) => Number(nc.otherPlantedPercent) > 0,
+      (nc: ODPNationalClass) => Number(nc.otherPlantedForestPercent) > 0,
       originalOdp,
       false,
       [
@@ -114,7 +114,7 @@ describe('OriginalDataPoint paste test:', () => {
     expect(
       digOnlyCertainFieldsOutOfOdp(4, result.updatedOdp, [
         'name',
-        'otherPlantedPercent',
+        'otherPlantedForestPercent',
         'otherLandPalmsPercent',
         'otherLandTreeOrchardsPercent',
       ])

--- a/src/meta/assessment/originalDataPoint/odpNationalClass.ts
+++ b/src/meta/assessment/originalDataPoint/odpNationalClass.ts
@@ -16,11 +16,11 @@ export interface ODPNationalClass {
   definition?: string
   forestPercent?: string
   name?: string
-  naturalForestPercent?: string
-  otherPlantedPercent?: string
+  forestNaturalPercent?: string
+  otherPlantedForestPercent?: string
   otherWoodedLandPercent?: string
   placeHolder?: boolean
-  plantationIntroducedPercent?: string
-  plantationPercent?: string
+  forestPlantationIntroducedPercent?: string
+  forestPlantationPercent?: string
   uuid?: string
 }

--- a/src/meta/assessment/originalDataPoint/odps/updateNationalClass.ts
+++ b/src/meta/assessment/originalDataPoint/odps/updateNationalClass.ts
@@ -17,11 +17,16 @@ const getValueOrNull = (value: string | null, rowIsMaxed: boolean): string | nul
 }
 
 const calculateValues = (nationalClass: ODPNationalClass) => {
-  const { naturalForestPercent, plantationPercent, otherPlantedPercent, forestPercent, otherWoodedLandPercent } =
-    nationalClass
+  const {
+    forestNaturalPercent,
+    forestPlantationPercent,
+    otherPlantedForestPercent,
+    forestPercent,
+    otherWoodedLandPercent,
+  } = nationalClass
 
   const rowIsMaxedForestCharacteristics = Numbers.eq(
-    Numbers.sum([naturalForestPercent, plantationPercent, otherPlantedPercent]),
+    Numbers.sum([forestNaturalPercent, forestPlantationPercent, otherPlantedForestPercent]),
     100
   )
 
@@ -29,9 +34,9 @@ const calculateValues = (nationalClass: ODPNationalClass) => {
 
   return {
     ...nationalClass,
-    naturalForestPercent: getValueOrNull(naturalForestPercent, rowIsMaxedForestCharacteristics),
-    plantationPercent: getValueOrNull(plantationPercent, rowIsMaxedForestCharacteristics),
-    otherPlantedPercent: getValueOrNull(otherPlantedPercent, rowIsMaxedForestCharacteristics),
+    forestNaturalPercent: getValueOrNull(forestNaturalPercent, rowIsMaxedForestCharacteristics),
+    forestPlantationPercent: getValueOrNull(forestPlantationPercent, rowIsMaxedForestCharacteristics),
+    otherPlantedForestPercent: getValueOrNull(otherPlantedForestPercent, rowIsMaxedForestCharacteristics),
     forestPercent: getValueOrNull(forestPercent, rowIsMaxedExtentOfForest),
     otherWoodedLandPercent: getValueOrNull(otherWoodedLandPercent, rowIsMaxedExtentOfForest),
   }


### PR DESCRIPTION
Resolves #1660

Video

https://user-images.githubusercontent.com/5508251/198568831-cd06fa7f-8f3e-4192-98e3-b4bcae605024.mov

Description
Fixes issue where column names were mismatched; historically columns were prefixed with 'forest' but omitted in later changes. Renamed properties in national class to match previous