### PR TITLE
Separate migrations to build

### DIFF
--- a/.github/workflows/test.js.yml
+++ b/.github/workflows/test.js.yml
@@ -36,14 +36,21 @@ jobs:
       - run: yarn install --network-timeout 1000000
         env:
             NODE_AUTH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-      - run: yarn run-migrations
+#      - run: yarn run-migrations
+#        env:
+#          PGHOST: localhost
+#          PGPORT: 5442
+#          PGDATABASE: frap-dev
+#          PGUSER: frap
+#          PGPASSWORD: frap
+#     Migrations are run on yarn build
+      - run: yarn build
         env:
           PGHOST: localhost
           PGPORT: 5442
           PGDATABASE: frap-dev
           PGUSER: frap
           PGPASSWORD: frap
-      - run: yarn build
       - run: yarn test
         env:
           PGHOST: localhost

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "migrate-fra:test:persist-node-value": "yarn jest --no-cache --detectOpenHandles --setupFiles dotenv/config --config jest.config.test.js",
     "migrate-fra:data-export:compare": "yarn jest --no-cache --detectOpenHandles --setupFiles dotenv/config --config src/test/dataExportComparison/jest.config.js",
     "migrate-fra:bulk-download:compare": "yarn jest --no-cache --detectOpenHandles --setupFiles dotenv/config --config src/test/bulkDownloadComparison/jest.config.js",
-    "build": "yarn build:client && yarn build:server && yarn build:copy",
+    "build": "yarn build:client && yarn build:server && yarn build:copy && yarn run-migrations",
     "build:server": "yarn tsc --project tsconfig.server.json && yarn tscpaths -v -p tsconfig.server.paths.json -s ./server -o ./dist",
     "build:client": "cross-env NODE_ENV=production webpack --config webpack.config.babel.js",
     "build:copy": "shx cp -Rf src/server/db/migration/* dist/server/db/migration/. && shx cp -Rf web-resources dist/ && shx cp -Rf src/server/static dist/server/",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,37 +1,6 @@
 import 'tsconfig-paths/register'
 import 'dotenv/config'
 
-// import * as os from 'os'
-// import * as cluster from 'cluster'
-import * as migrations from './db/migration/execMigrations'
 import { serverInit } from './serverInit'
 
-// @ts-ignore
-// if (cluster.isMaster) {
-// check db migrations in master process
-migrations()
-
-//   const numWorkers = process.env.WEB_CONCURRENCY || os.cpus().length
-//
-//   console.log(`Master cluster setting up ${numWorkers} workers...`)
-//
-//   for (let i = 0; i < numWorkers; i += 1) {
-//     // @ts-ignore
-//     cluster.fork()
-//   }
-//
-//   // @ts-ignore
-//   cluster.on('online', function (worker: any) {
-//     console.log(`Worker ${worker.process.pid} is online`)
-//   })
-//
-//   // @ts-ignore
-//   cluster.on('exit', function (worker: any, code: any, signal: any) {
-//     console.log(`Worker ${worker.process.pid} died with code: ${code}, and signal: ${signal}`)
-//     console.log('Starting a new worker')
-//     // @ts-ignore
-//     cluster.fork()
-//   })
-// } else {
 serverInit()
-// }

--- a/src/server/serverLocal.ts
+++ b/src/server/serverLocal.ts
@@ -1,8 +1,7 @@
-import * as migrations from './db/migration/execMigrations'
-
 import * as init from './serverInit'
 
+// @ts-ignore
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config()
 
-migrations()
 init.serverInit()


### PR DESCRIPTION
move migrations to `build`

you can still manually run migrations with
`yarn run-migrations`