### PR TITLE
Fix DataSource row names

### DIFF
--- a/src/client/pages/AssessmentSection/Descriptions/Description/DataSources/DataSourceRow.tsx
+++ b/src/client/pages/AssessmentSection/Descriptions/Description/DataSources/DataSourceRow.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Objects } from '@utils/objects'
 
-import { DataSource, dataSourceType, RowType } from '@meta/assessment'
+import { Cols, DataSource, dataSourceType, RowType } from '@meta/assessment'
 
 import { useCycle } from '@client/store/assessment'
 import { useTableSections } from '@client/store/pages/assessmentSection'
@@ -52,8 +52,8 @@ const DataSourceRow: React.FC<Props> = (props: Props) => {
   )
 
   const rows = table.rows
-    .filter((row) => row.props.variableName && row.props.type === RowType.data && row.props.label?.key)
-    .map((r, index) => t(r.props.label?.key, { idx: index + 1 }))
+    .filter((row) => row.props.variableName && row.props.type === RowType.data)
+    .map((r) => t(Cols.getLabel({ cycle, col: r.cols[0], t })))
 
   return (
     <>

--- a/src/client/pages/AssessmentSection/Descriptions/Description/DataSources/DataSourceRow.tsx
+++ b/src/client/pages/AssessmentSection/Descriptions/Description/DataSources/DataSourceRow.tsx
@@ -52,7 +52,7 @@ const DataSourceRow: React.FC<Props> = (props: Props) => {
   )
 
   const rows = table.rows
-    .filter((row) => row.props.variableName && row.props.type === RowType.data)
+    .filter((row) => row.props.variableName && row.props.type === RowType.data && row.props.label?.key)
     .map((r, index) => t(r.props.label?.key, { idx: index + 1 }))
 
   return (


### PR DESCRIPTION
Resolves #1694

Todo
- [x] Fix 2025 cycle issues

Issue:
Display incorrect or empty rows
Reason: label.key was taken from row, not first column (header column of row)

Fix:
Get label key from first (header) column

Screenshots

![image](https://user-images.githubusercontent.com/5508251/201315539-55834ac9-caa1-43d9-a8bf-9c875ef5a17c.png)

![image](https://user-images.githubusercontent.com/5508251/201315638-e93bafce-5662-41c9-9716-65aa7d6ef280.png)


2025 specific keys
![image](https://user-images.githubusercontent.com/5508251/201316660-c8e25ad9-6044-42c5-b716-6a3965aae4c6.png)

