### PR TITLE
Geo: add forest area property name on forest products metadata

### DIFF
--- a/src/meta/geo/forest.ts
+++ b/src/meta/geo/forest.ts
@@ -38,41 +38,49 @@ export const sourcesMetadata = {
     scale: 24.7376,
     palette: ['#800080'], // purple
     citation: 'https://doi.org/10.1016/j.rse.2014.04.014', // from gee asset
+    forestAreaDataProperty: 'fa_jaxa',
   },
   [ForestSource.TandemX]: {
     scale: 55.6597,
     palette: ['#008000'], // green
     citation: 'https://geoservice.dlr.de/web/dataguide/fnf50/',
+    forestAreaDataProperty: 'fa_tandemx',
   },
   [ForestSource.ESAGlobCover]: {
     scale: 309.2208,
     palette: ['#FF0000'], // red
     citation: 'http://due.esrin.esa.int/page_globcover.php', // from gee asset
+    forestAreaDataProperty: 'fa_esa_2009',
   },
   [ForestSource.GlobeLand]: {
     scale: 30,
     palette: ['#0000FF'], // blue
     citation: 'http://www.globallandcover.com/home_en.html', // official web site
+    forestAreaDataProperty: 'fa_globeland',
   },
   [ForestSource.Copernicus]: {
     scale: 100,
     palette: ['#FFFF00'], // yellow
     citation: ' https://doi.org/10.3390/rs12061044', // from gee asset
+    forestAreaDataProperty: 'fa_copernicus',
   },
   [ForestSource.ESRI]: {
     scale: 10,
     palette: ['#FF7F50'], // coral
     citation: ' https://www.arcgis.com/home/item.html?id=d6642f8a4f6d4685a24ae2dc0c73d4ac',
+    forestAreaDataProperty: 'fa_esri',
   },
   [ForestSource.ESAWorldCover]: {
     scale: 10,
     palette: ['#00ffff'], // cyan
     citation: 'https://esa-worldcover.org/en', // on gee citation 'A publication is under preparation'
+    forestAreaDataProperty: 'fa_esa_2020',
   },
   [ForestSource.Hansen]: {
     scale: 30.92,
     palette: ['#00ff00'], // lime
     citation: 'https://doi.org/10.1126/science.1244693', // from gee asset
+    forestAreaDataProperty: 'fa_hansen',
   },
   [ForestSource.MODIS]: {
     scale: 231.6563,


### PR DESCRIPTION
Added forest area estimation property name for each product to facilitate query to create charts/tables. I am not sure here about how to handle camelCase property names vs underscore table columns but I think I can modify it later if required.