### PR TITLE
Original data point: Copy previous national classes

### DIFF
--- a/src/client/pages/OriginalDataPoint/OriginalDataPoint.tsx
+++ b/src/client/pages/OriginalDataPoint/OriginalDataPoint.tsx
@@ -35,6 +35,16 @@ const OriginalDataPoint: React.FC = () => {
   const canEditData = useCanEditTableData(TableNames.extentOfForest)
 
   useEffect(() => {
+    dispatch(
+      OriginalDataPointActions.getOriginalDataPointReservedYears({
+        countryIso,
+        assessmentName,
+        cycleName,
+      })
+    )
+  }, [assessmentName, countryIso, cycleName, dispatch, originalDataPoint?.year])
+
+  useEffect(() => {
     if (year !== '-1') {
       dispatch(
         OriginalDataPointActions.getOriginalDataPoint({
@@ -48,7 +58,7 @@ const OriginalDataPoint: React.FC = () => {
     return () => {
       dispatch(OriginalDataPointActions.reset())
     }
-  }, [])
+  }, [assessmentName, countryIso, cycleName, dispatch, year])
 
   useEffect(() => {
     if (user) {

--- a/src/client/pages/OriginalDataPoint/components/NationalClasses/NationalClasses.tsx
+++ b/src/client/pages/OriginalDataPoint/components/NationalClasses/NationalClasses.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from 'react'
-// import { useAppDispatch } from '@client/store'
 import { useTranslation } from 'react-i18next'
 
 import { ODPs, OriginalDataPoint } from '@meta/assessment'
@@ -35,7 +34,7 @@ const NationalClasses: React.FC<Props> = (props) => {
   const reservedYears = useOriginalDataPointReservedYears() ?? []
   const hasPreviousYear = Boolean(ODPs.getPreviousODPYear(year, reservedYears))
   const canCopy = ODPs.canCopyPreviousValues(originalDataPoint)
-  // Copying is disabled if: nationalClass(1+) exist, odp doesnt have a year or there is no previous year
+  // Copying is disabled if: nationalClass(1+) exist, odp doesn't have a year or there is no previous year
   const copyDisabled = !canCopy || !year || year === -1 || originalDataPointUpdating || !hasPreviousYear
 
   const onCopyClick = useCallback(() => {

--- a/src/client/pages/OriginalDataPoint/components/NationalClasses/NationalClasses.tsx
+++ b/src/client/pages/OriginalDataPoint/components/NationalClasses/NationalClasses.tsx
@@ -1,9 +1,17 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 // import { useAppDispatch } from '@client/store'
 import { useTranslation } from 'react-i18next'
 
-import { OriginalDataPoint } from '@meta/assessment'
+import { ODPs, OriginalDataPoint } from '@meta/assessment'
 
+import { useAppDispatch } from '@client/store'
+import { useAssessment, useCycle } from '@client/store/assessment'
+import {
+  OriginalDataPointActions,
+  useIsOriginalDataPointUpdating,
+  useOriginalDataPointReservedYears,
+} from '@client/store/pages/originalDataPoint'
+import { useCountryIso } from '@client/hooks'
 import { useIsPrint } from '@client/hooks/useIsPath'
 
 import NationalClass from './NationalClass'
@@ -14,15 +22,32 @@ type Props = {
 }
 
 const NationalClasses: React.FC<Props> = (props) => {
+  const countryIso = useCountryIso()
+  const assessment = useAssessment()
+  const cycle = useCycle()
   const { canEditData, originalDataPoint } = props
-  const { nationalClasses } = originalDataPoint
-  // const { nationalClasses, id, year } = originalDataPoint
+  const { nationalClasses, year } = originalDataPoint
 
-  // const dispatch = useAppDispatch()
+  const dispatch = useAppDispatch()
   const { i18n } = useTranslation()
   const { print } = useIsPrint()
-  // const saving = false // TODO: useIsAutoSaveSaving()
-  const copyDisabled = true // TODO: !id || !year || !ODPs.canCopyPreviousValues(originalDataPoint) || saving
+  const originalDataPointUpdating = useIsOriginalDataPointUpdating()
+  const reservedYears = useOriginalDataPointReservedYears() ?? []
+  const hasPreviousYear = Boolean(ODPs.getPreviousODPYear(year, reservedYears))
+  const canCopy = ODPs.canCopyPreviousValues(originalDataPoint)
+  // Copying is disabled if: nationalClass(1+) exist, odp doesnt have a year or there is no previous year
+  const copyDisabled = !canCopy || !year || year === -1 || originalDataPointUpdating || !hasPreviousYear
+
+  const onCopyClick = useCallback(() => {
+    dispatch(
+      OriginalDataPointActions.copyPreviousNationalClasses({
+        originalDataPoint,
+        assessmentName: assessment.props.name,
+        cycleName: cycle.name,
+        countryIso,
+      })
+    )
+  }, [assessment.props.name, countryIso, cycle.name, dispatch, originalDataPoint])
 
   return (
     <div className="odp__section">
@@ -34,10 +59,7 @@ const NationalClasses: React.FC<Props> = (props) => {
               type="button"
               className="btn-s btn-primary btn-copy-prev-values"
               disabled={copyDisabled}
-              // onClick={() =>
-              // TODO:
-              // dispatch(OriginalDataPointActions.copyPreviousNationalClasses({ id: originalDataPoint.id }))
-              // }
+              onClick={onCopyClick}
             >
               {i18n.t<string>('nationalDataPoint.copyPreviousValues')}
             </button>

--- a/src/client/pages/OriginalDataPoint/components/YearSelection/YearSelection.tsx
+++ b/src/client/pages/OriginalDataPoint/components/YearSelection/YearSelection.tsx
@@ -1,17 +1,20 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
 
 import { Objects } from '@utils/objects'
 
-import { ApiEndPoint } from '@meta/api/endpoint'
 import { ClientRoutes } from '@meta/app'
 import { ODPYears, OriginalDataPoint } from '@meta/assessment'
 
 import { useAppDispatch } from '@client/store'
 import { useAssessment, useCycle } from '@client/store/assessment'
-import { OriginalDataPointActions, useOriginalDataPoint } from '@client/store/pages/originalDataPoint'
-import { useCountryIso, useGetRequest } from '@client/hooks'
+import {
+  OriginalDataPointActions,
+  useOriginalDataPoint,
+  useOriginalDataPointReservedYears,
+} from '@client/store/pages/originalDataPoint'
+import { useCountryIso } from '@client/hooks'
 
 // TODO: Handle error
 const years = ['', ...ODPYears]
@@ -31,25 +34,9 @@ const YearSelection: React.FC<Props> = (props) => {
   const countryIso = useCountryIso()
   const assessment = useAssessment()
   const cycle = useCycle()
+  const reservedYears = useOriginalDataPointReservedYears() ?? []
 
   const classNameYearSelection = '' // TODO: originalDataPoint.validationStatus && !originalDataPoint.validationStatus.year.valid ? 'error' : ''
-
-  const { data, dispatch: fetchReservedYears } = useGetRequest(
-    ApiEndPoint.CycleData.OriginalDataPoint.reservedYears(),
-    {
-      params: {
-        countryIso,
-        assessmentName: assessment.props.name,
-        cycleName: cycle.name,
-      },
-    }
-  )
-  useEffect(() => {
-    fetchReservedYears()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [originalDataPoint.year])
-
-  const reservedYears: Array<number> = data?.years ?? []
 
   return (
     <div className="odp__section">

--- a/src/client/store/pages/originalDataPoint/actions/copyPreviousNationalClasses.ts
+++ b/src/client/store/pages/originalDataPoint/actions/copyPreviousNationalClasses.ts
@@ -1,0 +1,44 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axios from 'axios'
+
+import { ApiEndPoint } from '@meta/api/endpoint'
+import { CycleParams } from '@meta/api/request'
+import { ODPs, OriginalDataPoint } from '@meta/assessment'
+
+import { RootState } from '@client/store'
+
+import { updateOriginalDataPoint } from './updateOriginalDataPoint'
+
+export const copyPreviousNationalClasses = createAsyncThunk<
+  void,
+  CycleParams & { originalDataPoint: OriginalDataPoint }
+>(
+  'originalDataPoint/copy/previousNationalClasses',
+  async ({ countryIso, assessmentName, cycleName, originalDataPoint }, { dispatch, getState }) => {
+    const state = getState()
+    const { reservedYears } = (state as RootState).pages.originalDataPoint
+    const { year } = originalDataPoint
+
+    const previousODPYear = ODPs.getPreviousODPYear(year, reservedYears)
+
+    const { data } = await axios.get(ApiEndPoint.CycleData.OriginalDataPoint.one(), {
+      params: {
+        countryIso,
+        assessmentName,
+        cycleName,
+        year: previousODPYear,
+      },
+    })
+
+    const updatedOriginalDataPoint = { ...originalDataPoint, nationalClasses: data.nationalClasses }
+
+    dispatch(
+      updateOriginalDataPoint({
+        countryIso,
+        assessmentName,
+        cycleName,
+        originalDataPoint: ODPs.addNationalClassPlaceHolder(updatedOriginalDataPoint),
+      })
+    )
+  }
+)

--- a/src/client/store/pages/originalDataPoint/actions/getOriginalDataPointReservedYears.ts
+++ b/src/client/store/pages/originalDataPoint/actions/getOriginalDataPointReservedYears.ts
@@ -1,0 +1,21 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axios from 'axios'
+
+import { ApiEndPoint } from '@meta/api/endpoint'
+import { CycleParams } from '@meta/api/request'
+
+export const getOriginalDataPointReservedYears = createAsyncThunk<Array<number>, CycleParams>(
+  'originalDataPoint/get/reservedYears',
+  async ({ countryIso, assessmentName, cycleName }) => {
+    const {
+      data: { years },
+    }: { data: { years: number[] } } = await axios.get(ApiEndPoint.CycleData.OriginalDataPoint.reservedYears(), {
+      params: {
+        countryIso,
+        assessmentName,
+        cycleName,
+      },
+    })
+    return years
+  }
+)

--- a/src/client/store/pages/originalDataPoint/hooks/index.ts
+++ b/src/client/store/pages/originalDataPoint/hooks/index.ts
@@ -3,3 +3,6 @@ import { useAppSelector } from '@client/store'
 export const useOriginalDataPoint = () => useAppSelector((state) => state.pages.originalDataPoint?.data)
 
 export const useIsOriginalDataPointUpdating = () => useAppSelector((state) => state.pages.originalDataPoint?.updating)
+
+export const useOriginalDataPointReservedYears = () =>
+  useAppSelector((state) => state.pages.originalDataPoint.reservedYears)

--- a/src/client/store/pages/originalDataPoint/index.ts
+++ b/src/client/store/pages/originalDataPoint/index.ts
@@ -1,3 +1,3 @@
-export type { OriginalDataPointState } from './stateType'
+export { useIsOriginalDataPointUpdating, useOriginalDataPoint, useOriginalDataPointReservedYears } from './hooks'
 export { OriginalDataPointActions } from './slice'
-export { useOriginalDataPoint, useIsOriginalDataPointUpdating } from './hooks'
+export type { OriginalDataPointState } from './stateType'

--- a/src/client/store/pages/originalDataPoint/slice.ts
+++ b/src/client/store/pages/originalDataPoint/slice.ts
@@ -1,15 +1,18 @@
-import { createSlice, Reducer } from '@reduxjs/toolkit'
+import { createSlice, PayloadAction, Reducer } from '@reduxjs/toolkit'
 
-import { OriginalDataPointState } from './stateType'
-import { getOriginalDataPoint } from './actions/getOriginalDataPoint'
-import { pasteNationalClass } from './actions/pasteNationalClass'
-import { updateNationalClass } from './actions/updateNationalClass'
+import { getOriginalDataPointReservedYears } from '@client/store/pages/originalDataPoint/actions/getOriginalDataPointReservedYears'
+
+import { copyPreviousNationalClasses } from './actions/copyPreviousNationalClasses'
 import { createOriginalDataPoint } from './actions/createOriginalDataPoint'
 import { deleteOriginalDataPoint } from './actions/deleteOriginalDataPoint'
-import { updateOriginalDataPoint } from './actions/updateOriginalDataPoint'
+import { getOriginalDataPoint } from './actions/getOriginalDataPoint'
+import { pasteNationalClass } from './actions/pasteNationalClass'
 import { setOriginalDataPointUpdating } from './actions/setOriginalDataPointUpdating'
+import { updateNationalClass } from './actions/updateNationalClass'
+import { updateOriginalDataPoint } from './actions/updateOriginalDataPoint'
+import { OriginalDataPointState } from './stateType'
 
-const initialState: OriginalDataPointState = { data: null }
+const initialState: OriginalDataPointState = { data: null, reservedYears: null }
 
 export const originalDataPointSlice = createSlice({
   name: 'originalDataPoint',
@@ -33,6 +36,10 @@ export const originalDataPointSlice = createSlice({
     builder.addCase(createOriginalDataPoint.fulfilled, (state, { payload }) => {
       state.data = payload
     })
+
+    builder.addCase(getOriginalDataPointReservedYears.fulfilled, (state, { payload }: PayloadAction<Array<number>>) => {
+      state.reservedYears = payload
+    })
   },
 })
 
@@ -44,6 +51,8 @@ export const OriginalDataPointActions = {
   createOriginalDataPoint,
   deleteOriginalDataPoint,
   updateOriginalDataPoint,
+  copyPreviousNationalClasses,
+  getOriginalDataPointReservedYears,
 }
 
 export default originalDataPointSlice.reducer as Reducer<OriginalDataPointState>

--- a/src/client/store/pages/originalDataPoint/stateType.ts
+++ b/src/client/store/pages/originalDataPoint/stateType.ts
@@ -3,4 +3,5 @@ import { OriginalDataPoint } from '@meta/assessment'
 export type OriginalDataPointState = {
   data?: OriginalDataPoint
   updating?: boolean
+  reservedYears: Array<number>
 }

--- a/src/meta/assessment/originalDataPoint/odps/getPreviousODPYear.ts
+++ b/src/meta/assessment/originalDataPoint/odps/getPreviousODPYear.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns previous year or undefined is it's first year
+ * @param year Current ODP year
+ * @param years List of reserved ODP years
+ */
+export const getPreviousODPYear = (year: number, years: Array<number>): number | undefined => {
+  const arr = [...years]
+  // Add and sort current year
+  arr.push(year)
+  arr.sort()
+  // Find position of current year
+  const idx = arr.findIndex((y) => y === year)
+  return arr[idx - 1]
+}

--- a/src/meta/assessment/originalDataPoint/odps/index.ts
+++ b/src/meta/assessment/originalDataPoint/odps/index.ts
@@ -8,6 +8,7 @@ import {
 } from './calc'
 import { canCopyPreviousValues } from './canCopyPreviousValues'
 import { deleteNationalClass } from './deleteNationalClass'
+import { getPreviousODPYear } from './getPreviousODPYear'
 import { removeNationalClassPlaceHolder } from './removeNationalClassPlaceHolder'
 import { updateNationalClass } from './updateNationalClass'
 
@@ -22,4 +23,5 @@ export const ODPs = {
   deleteNationalClass,
   removeNationalClassPlaceHolder,
   updateNationalClass,
+  getPreviousODPYear,
 }

--- a/tools/dataMigration/migrateData/migrateOdps.ts
+++ b/tools/dataMigration/migrateData/migrateOdps.ts
@@ -1,5 +1,5 @@
-import { ITask } from 'pg-promise'
 import * as pgPromise from 'pg-promise'
+import { ITask } from 'pg-promise'
 
 import { Assessment } from '../../../src/meta/assessment/assessment'
 import { getCreateSchemaCycleOriginalDataPointViewDDL } from '../../../src/server/repository/assessment/assessment/getCreateSchemaDDL'
@@ -31,7 +31,8 @@ export const migrateOdps = async (props: { assessment: Assessment }, client: ITa
              description,
              national_classes,
              id_legacy
-      from _legacy.original_data_point;
+      from _legacy.original_data_point
+      where year is not null;
       select setval('${schemaCycle}.original_data_point_id_seq', (select max(id) from _legacy.original_data_point), true);
 
       ${getCreateSchemaCycleOriginalDataPointViewDDL(schemaCycle)}


### PR DESCRIPTION
Resolves #1858 

- Fix ODP copy and add rule to enable button:
  * There is previous year
  * No national classes
  * ODP must have a year
- Moves odp reservedYears to state
- Remove `year = null` ODPs from migration


https://user-images.githubusercontent.com/5508251/207075052-4c4d5973-721b-4e21-b4f3-0621795add4e.mov

