### PR TITLE
Geo: Change forest agreement palette

### DIFF
--- a/src/meta/geo/forest.ts
+++ b/src/meta/geo/forest.ts
@@ -110,7 +110,7 @@ export const sourcesMetadata = {
 }
 
 export const agreementPalette = [
-  '#baecba', // light shade of green
+  '#FFC0CB', // pink
   '#FF0000', // red
   '#FF8000', // shade of brown
   '#FFFF00', // yellow


### PR DESCRIPTION
First level of agreement color wasn't visible because it was very similar to base map green, changed to pink