### PR TITLE
Fix ODP Edit Data sources -> Methods used

### DIFF
--- a/src/client/pages/OriginalDataPoint/components/DataSources/DataSources.tsx
+++ b/src/client/pages/OriginalDataPoint/components/DataSources/DataSources.tsx
@@ -44,7 +44,6 @@ const DataSources: React.FC<Props> = (props) => {
   }
 
   const isDisabled = print || !canEditData || !originalDataPoint.year
-
   return (
     <div className="odp__section">
       {!print && <h3 className="subhead">{i18n.t('nationalDataPoint.dataSources')}</h3>}
@@ -92,7 +91,7 @@ const DataSources: React.FC<Props> = (props) => {
                     disabled={isDisabled}
                     i18n={i18n}
                     localizationPrefix="nationalDataPoint.dataSourceMethodsOptions"
-                    values={originalDataPoint.dataSourceMethods}
+                    values={originalDataPoint.dataSourceMethods ?? []}
                     options={Object.values(ODPDataSourceMethod)}
                     onChange={(values: Array<ODPDataSourceMethod>) => {
                       const originalDataPointUpdate = { ...originalDataPoint, dataSourceMethods: values }


### PR DESCRIPTION
Resolves #1873

Fixes a bug where multiselect not rendered if value is null (eg. not given previously) Multiselect fails on null values, fixed by defaulting to empty array on null

_**Note** Video shows first the bug and then fixed_

https://user-images.githubusercontent.com/5508251/207545695-3eaaa56f-a2ee-4ff5-b269-bf017e6623a5.mov

