### PR TITLE
Fix Original Data Point creation: Display ODPs without National Classes in section 1a and 1b

### DIFF
--- a/src/client/store/pages/originalDataPoint/actions/createOriginalDataPoint.ts
+++ b/src/client/store/pages/originalDataPoint/actions/createOriginalDataPoint.ts
@@ -1,9 +1,7 @@
 import { NavigateFunction } from 'react-router-dom'
 
 import { createAsyncThunk } from '@reduxjs/toolkit'
-import axios from 'axios'
 
-import { ApiEndPoint } from '@meta/api/endpoint'
 import { CycleParams } from '@meta/api/request'
 import { ClientRoutes } from '@meta/app'
 import { ODPs, OriginalDataPoint } from '@meta/assessment'
@@ -14,32 +12,24 @@ export const createOriginalDataPoint = createAsyncThunk<
     navigate: NavigateFunction
   }
 >('originalDataPoint/create', async ({ assessmentName, cycleName, countryIso, navigate }) => {
-  const originalDataPoint = { countryIso } as OriginalDataPoint
-  const { data } = await axios.post(
-    ApiEndPoint.CycleData.OriginalDataPoint.one(),
-    {
-      originalDataPoint,
-    },
-    {
-      params: {
-        countryIso,
-        assessmentName,
-        cycleName,
-        sectionName: 'extentOfForest',
-      },
-    }
+  navigate(
+    ClientRoutes.Assessment.OriginalDataPoint.Section.getLink({
+      countryIso,
+      assessmentName,
+      cycleName,
+      year: '-1',
+      sectionName: 'extentOfForest',
+    })
   )
-  if (data?.id) {
-    navigate(
-      // After creating a new OriginalDataPoint, year is null, use -1 (handled in view)
-      ClientRoutes.Assessment.OriginalDataPoint.Section.getLink({
-        countryIso,
-        assessmentName,
-        cycleName,
-        year: '-1',
-        sectionName: 'extentOfForest',
-      })
-    )
-  }
-  return ODPs.addNationalClassPlaceHolder(data)
+
+  // Populate store with placeholder
+  return ODPs.addNationalClassPlaceHolder({
+    countryIso,
+    year: null,
+    dataSourceAdditionalComments: '',
+    dataSourceMethods: [],
+    dataSourceReferences: '',
+    description: '',
+    nationalClasses: [],
+  } as OriginalDataPoint)
 })

--- a/src/client/store/pages/originalDataPoint/actions/setOriginalDataPointUpdating.ts
+++ b/src/client/store/pages/originalDataPoint/actions/setOriginalDataPointUpdating.ts
@@ -1,3 +1,0 @@
-import { createAction } from '@reduxjs/toolkit'
-
-export const setOriginalDataPointUpdating = createAction<boolean>('originalDataPoint/updating/set')

--- a/src/client/store/pages/originalDataPoint/actions/updateOriginalDataPoint.ts
+++ b/src/client/store/pages/originalDataPoint/actions/updateOriginalDataPoint.ts
@@ -1,19 +1,16 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import { Functions } from '@utils/functions'
 import axios from 'axios'
-import { Dispatch } from 'redux'
 
 import { ApiEndPoint } from '@meta/api/endpoint'
 import { CycleParams } from '@meta/api/request'
 import { ODPs, OriginalDataPoint } from '@meta/assessment'
 
-import { setOriginalDataPointUpdating } from '@client/store/pages/originalDataPoint/actions/setOriginalDataPointUpdating'
-
 type Props = CycleParams & {
   originalDataPoint: OriginalDataPoint
 }
 
-const createOriginalDataPoint = async (props: Props, dispatch: Dispatch): Promise<OriginalDataPoint> => {
+const createOriginalDataPoint = async (props: Props): Promise<OriginalDataPoint> => {
   const { countryIso, assessmentName, cycleName, originalDataPoint } = props
 
   const { data } = await axios.post(
@@ -30,12 +27,11 @@ const createOriginalDataPoint = async (props: Props, dispatch: Dispatch): Promis
       },
     }
   )
-  dispatch(setOriginalDataPointUpdating(false))
   return ODPs.addNationalClassPlaceHolder(data)
 }
 
 const putOriginalDataPoint = Functions.debounce(
-  async (props: Props, dispatch: Dispatch) => {
+  async (props: Props) => {
     const { countryIso, assessmentName, cycleName, originalDataPoint } = props
 
     await axios.put(
@@ -52,7 +48,6 @@ const putOriginalDataPoint = Functions.debounce(
         },
       }
     )
-    dispatch(setOriginalDataPointUpdating(false))
   },
   1000,
   'updateOriginalDataPoint'
@@ -60,9 +55,9 @@ const putOriginalDataPoint = Functions.debounce(
 
 export const updateOriginalDataPoint = createAsyncThunk<OriginalDataPoint, Props>(
   'originalDataPoint/update',
-  async (props, { dispatch }) => {
-    if (!props.originalDataPoint.id) return createOriginalDataPoint(props, dispatch)
-    putOriginalDataPoint(props, dispatch)
+  async (props) => {
+    if (!props.originalDataPoint.id) return createOriginalDataPoint(props)
+    putOriginalDataPoint(props)
     return props.originalDataPoint
   }
 )

--- a/src/client/store/pages/originalDataPoint/actions/updateOriginalDataPoint.ts
+++ b/src/client/store/pages/originalDataPoint/actions/updateOriginalDataPoint.ts
@@ -13,6 +13,27 @@ type Props = CycleParams & {
   originalDataPoint: OriginalDataPoint
 }
 
+const createOriginalDataPoint = async (props: Props, dispatch: Dispatch): Promise<OriginalDataPoint> => {
+  const { countryIso, assessmentName, cycleName, originalDataPoint } = props
+
+  const { data } = await axios.post(
+    ApiEndPoint.CycleData.OriginalDataPoint.one(),
+    {
+      originalDataPoint: ODPs.removeNationalClassPlaceHolder(originalDataPoint),
+    },
+    {
+      params: {
+        countryIso,
+        assessmentName,
+        cycleName,
+        sectionName: 'extentOfForest',
+      },
+    }
+  )
+  dispatch(setOriginalDataPointUpdating(false))
+  return ODPs.addNationalClassPlaceHolder(data)
+}
+
 const putOriginalDataPoint = Functions.debounce(
   async (props: Props, dispatch: Dispatch) => {
     const { countryIso, assessmentName, cycleName, originalDataPoint } = props
@@ -40,6 +61,7 @@ const putOriginalDataPoint = Functions.debounce(
 export const updateOriginalDataPoint = createAsyncThunk<OriginalDataPoint, Props>(
   'originalDataPoint/update',
   async (props, { dispatch }) => {
+    if (!props.originalDataPoint.id) return createOriginalDataPoint(props, dispatch)
     putOriginalDataPoint(props, dispatch)
     return props.originalDataPoint
   }

--- a/src/client/store/pages/originalDataPoint/slice.ts
+++ b/src/client/store/pages/originalDataPoint/slice.ts
@@ -7,7 +7,6 @@ import { createOriginalDataPoint } from './actions/createOriginalDataPoint'
 import { deleteOriginalDataPoint } from './actions/deleteOriginalDataPoint'
 import { getOriginalDataPoint } from './actions/getOriginalDataPoint'
 import { pasteNationalClass } from './actions/pasteNationalClass'
-import { setOriginalDataPointUpdating } from './actions/setOriginalDataPointUpdating'
 import { updateNationalClass } from './actions/updateNationalClass'
 import { updateOriginalDataPoint } from './actions/updateOriginalDataPoint'
 import { OriginalDataPointState } from './stateType'
@@ -26,15 +25,14 @@ export const originalDataPointSlice = createSlice({
     })
     builder.addCase(updateOriginalDataPoint.fulfilled, (state, { payload }) => {
       state.data = payload
+      state.updating = false
     })
     builder.addCase(updateOriginalDataPoint.pending, (state) => {
       state.updating = true
     })
-    builder.addCase(setOriginalDataPointUpdating, (state, { payload }) => {
-      state.updating = payload
-    })
     builder.addCase(createOriginalDataPoint.fulfilled, (state, { payload }) => {
       state.data = payload
+      state.updating = false
     })
 
     builder.addCase(getOriginalDataPointReservedYears.fulfilled, (state, { payload }: PayloadAction<Array<number>>) => {

--- a/src/server/repository/assessment/assessment/getCreateSchemaDDL.ts
+++ b/src/server/repository/assessment/assessment/getCreateSchemaDDL.ts
@@ -236,8 +236,9 @@ export const getCreateSchemaCycleOriginalDataPointViewDDL = (assessmentCycleSche
       with classes as (
           select o.country_iso,
                  o.year,
-                 jsonb_array_elements(o.national_classes) as class
-          from ${assessmentCycleSchemaName}.original_data_point o
+                 jsonb_array_elements(
+                   case when jsonb_array_length( o.national_classes ) = 0 then '[{}]' else o.national_classes end
+                 ) as class          from ${assessmentCycleSchemaName}.original_data_point o
       ),
             country_years as (
                select c.country_iso,


### PR DESCRIPTION
Resolves #1878 
Resolves https://github.com/openforis/fra-platform/issues/1879

Fixes 2 odp issues:

1. Fix original data point creation
- Initialise the redux store with empty odp but don't persist to db
- Persist to db on first change (= year)

2. getCreateSchemaCycleOriginalDataPointViewDDL: Fix issue with empty original_data_point.national_classes
- Fix issue where jsonb_array_elements would ignore empty arrays (eg. new ODPs without data)


https://user-images.githubusercontent.com/5508251/207889235-a770ffd5-7ed9-4aa1-a526-246a6c30040c.mov


