### PR TITLE
Fix ODP table (1a, 1b) rendering

### DIFF
--- a/src/client/pages/AssessmentSection/DataTable/Table/TableBody/TableBody.tsx
+++ b/src/client/pages/AssessmentSection/DataTable/Table/TableBody/TableBody.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import { Row as TypeRow, RowType, Table } from '@meta/assessment'
+import { TableData } from '@meta/data'
+
+import Row from '@client/pages/AssessmentSection/DataTable/Table/Row'
+
+type Props = {
+  disabled: boolean
+  table: Table
+  sectionName: string
+  assessmentName: string
+  data: TableData
+}
+
+const TableBody: React.FC<Props> = (props) => {
+  const { disabled, table, assessmentName, sectionName, data } = props
+  const rowsData = table.rows.filter((row) => row.props.type !== RowType.header)
+
+  return (
+    <tbody>
+      {rowsData.map((row: TypeRow) => {
+        return (
+          <Row
+            key={row.uuid}
+            assessmentName={assessmentName}
+            sectionName={sectionName}
+            table={table}
+            data={data}
+            row={row}
+            disabled={disabled}
+          />
+        )
+      })}
+    </tbody>
+  )
+}
+
+export default TableBody

--- a/src/client/pages/AssessmentSection/DataTable/Table/TableBody/index.ts
+++ b/src/client/pages/AssessmentSection/DataTable/Table/TableBody/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TableBody'

--- a/src/client/pages/AssessmentSection/DataTable/Table/TableHead/TableHead.tsx
+++ b/src/client/pages/AssessmentSection/DataTable/Table/TableHead/TableHead.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+
+import { ClientRoutes } from '@meta/app'
+import { Col as TypeCol, Cols, Row as TypeRow, RowType, Table } from '@meta/assessment'
+import { TableData } from '@meta/data'
+
+import { useAssessmentCountry, useCycle } from '@client/store/assessment'
+import { useOriginalDataPointYears, useShowOriginalDatapoints } from '@client/store/pages/assessmentSection'
+import { useCountryIso } from '@client/hooks'
+import { useIsPrint } from '@client/hooks/useIsPath'
+import Tooltip from '@client/components/Tooltip'
+import { getODPColSpan } from '@client/pages/AssessmentSection/DataTable/Table/utils/getODPColSpan'
+
+type Props = {
+  headers: string[]
+  table: Table
+  assessmentName: string
+  data: TableData
+}
+
+const TableHead: React.FC<Props> = (props) => {
+  const { headers, table, assessmentName, data } = props
+
+  const { t } = useTranslation()
+  const { print } = useIsPrint()
+  const countryIso = useCountryIso()
+  const cycle = useCycle()
+  const country = useAssessmentCountry()
+  const odpYears = useOriginalDataPointYears()
+
+  const showODP = useShowOriginalDatapoints()
+
+  const { odp } = table.props
+  const rowsHeader = table.rows.filter((row) => row.props.type === RowType.header)
+
+  return (
+    <thead>
+      {rowsHeader.map((row: TypeRow, rowIndex: number) => (
+        <tr key={row.uuid}>
+          {row.cols.map((col: TypeCol, colIndex: number) => {
+            const { index } = col.props
+            const { colSpan, rowSpan } = Cols.getStyle({ cycle, col })
+            const columnName = headers[colIndex]
+
+            let isOdpHeader = showODP && table.props.odp && !col.props.labels && odpYears?.includes(columnName)
+
+            if (table.props.name === 'forestCharacteristics')
+              isOdpHeader = isOdpHeader && country.props.forestCharacteristics.useOriginalDataPoint
+
+            const getColumnName = () => {
+              const label = isOdpHeader ? columnName : Cols.getLabel({ cycle, col, t })
+
+              if (isOdpHeader && !print) {
+                return (
+                  <Tooltip text={t('nationalDataPoint.clickOnNDP')}>
+                    <Link
+                      className="link"
+                      to={ClientRoutes.Assessment.OriginalDataPoint.Section.getLink({
+                        countryIso,
+                        assessmentName,
+                        cycleName: cycle.name,
+                        year: columnName,
+                        sectionName: table.props.name,
+                      })}
+                    >
+                      {label}
+                    </Link>
+                  </Tooltip>
+                )
+              }
+
+              return label
+            }
+
+            const headerLeft = (index === 0 && rowIndex === 0) || row.props?.readonly
+            let className = `fra-table__header-cell${headerLeft ? '-left' : ''}`
+            if (isOdpHeader && !print && rowIndex > 0) className = 'odp-header-cell'
+
+            return (
+              <th
+                key={col.uuid}
+                className={className}
+                colSpan={odp && !colSpan ? getODPColSpan({ headers, table, data }) : colSpan}
+                rowSpan={rowSpan}
+              >
+                {getColumnName()}
+              </th>
+            )
+          })}
+        </tr>
+      ))}
+    </thead>
+  )
+}
+
+export default TableHead

--- a/src/client/pages/AssessmentSection/DataTable/Table/TableHead/index.ts
+++ b/src/client/pages/AssessmentSection/DataTable/Table/TableHead/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TableHead'

--- a/src/client/pages/AssessmentSection/DataTable/Table/utils/parseTable.ts
+++ b/src/client/pages/AssessmentSection/DataTable/Table/utils/parseTable.ts
@@ -36,8 +36,9 @@ export const parseTable = (props: Props): { headers: Array<string>; table: Table
     return { headers, table }
   }
 
+  // Returns true if we are on header row that contains colNames (eg. '1990' or '% of forest area 2015')
   const isHeaderData = (row: TypeRow): boolean =>
-    row.props.type === RowType.header && headers && headers.length > 0 && row.cols[0].props.colName === headers[0]
+    row.props.type === RowType.header && headers && headers.length > 0 && headers.includes(row.cols[0].props.colName)
 
   const rows = table.rows.map((row) => {
     let cols = row.cols.map((c) => c)


### PR DESCRIPTION
Resolves #1874
Fix inconsistency in ODP Tables 1a and 1b:
Issue:
When adding a new original data point for year before 1990 the UI broke: first 'odp' year showed as 1990, even though selected year was 1985. Fix:
Updated the check to see if current row is included in headers, and not if first of both equal

Includes minor refactor where Table.tsx thead and tbody are separated in their own files

_**Note** video shows rendering still works for other tables and now also for 1a and 1b_

https://user-images.githubusercontent.com/5508251/208087319-b797e92d-d299-4f1c-84ca-750969970a02.mov

