### PR TITLE
Metadata 2025 updates

### DIFF
--- a/.src.legacy/core/assessment/fra.ts
+++ b/.src.legacy/core/assessment/fra.ts
@@ -23,6 +23,9 @@ export const FRA: AssessmentFRA = {
         a: {
           name: 'contactPersons',
           anchor: '',
+          tables: {
+            contactPersons: 'contactPersons',
+          },
         },
       },
     },

--- a/src/client/pages/AssessmentSection/AssessmentSection.tsx
+++ b/src/client/pages/AssessmentSection/AssessmentSection.tsx
@@ -11,6 +11,7 @@ import { useIsSectionDataEmpty } from '@client/store/pages/assessmentSection/hoo
 import { useCanEditDescriptions, useCanEditTableData } from '@client/store/user/hooks'
 import { useCountryIso } from '@client/hooks'
 import { useIsPrint } from '@client/hooks/useIsPath'
+import CommentableDescription from '@client/pages/AssessmentSection/Descriptions/CommentableDescription'
 
 import DataTable from './DataTable'
 import Descriptions, { GeneralComments } from './Descriptions'
@@ -95,6 +96,15 @@ const AssessmentSection: React.FC<Props> = (props: Props) => {
         )
       })}
 
+      {descriptions.introductoryText && (
+        <CommentableDescription
+          sectionName={sectionName}
+          title={t('contactPersons.introductoryText')}
+          name="introductoryText"
+          template={{ text: t('contactPersons.introductoryTextSupport') }}
+          disabled={!canEditDescriptions}
+        />
+      )}
       {descriptions.comments && <GeneralComments sectionName={sectionName} disabled={!canEditDescriptions} />}
 
       <div className="page-break" />

--- a/src/client/pages/AssessmentSection/Descriptions/Descriptions.tsx
+++ b/src/client/pages/AssessmentSection/Descriptions/Descriptions.tsx
@@ -10,7 +10,6 @@ import AnalysisDescriptions from './AnalysisDescriptions'
 import NationalDataDescriptions from './NationalDataDescriptions'
 
 type Props = {
-  // eslint-disable-next-line react/no-unused-prop-types
   descriptions: DescriptionsType
   disabled: boolean
   sectionName: string
@@ -48,11 +47,15 @@ const useDescriptions = (props: Props): { nationalData: boolean; analysisAndProc
 }
 
 const Descriptions: React.FC<Props> = (props: Props) => {
-  const { disabled, sectionName } = props
+  const { disabled, sectionName, descriptions } = props
 
   const { print, onlyTables } = useIsPrint()
 
-  const { analysisAndProcessing, nationalData } = useDescriptions(props)
+  const { analysisAndProcessing, nationalData } = useDescriptions({
+    descriptions,
+    sectionName,
+    disabled,
+  })
 
   return (
     <>

--- a/src/client/pages/AssessmentSection/Descriptions/Descriptions.tsx
+++ b/src/client/pages/AssessmentSection/Descriptions/Descriptions.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react'
-import { useTranslation } from 'react-i18next'
 
 import { Descriptions as DescriptionsType, TableNames } from '@meta/assessment'
 
@@ -8,10 +7,10 @@ import { useHasOriginalDataPointData } from '@client/store/pages/assessmentSecti
 import { useIsPrint } from '@client/hooks/useIsPath'
 
 import AnalysisDescriptions from './AnalysisDescriptions'
-import CommentableDescription from './CommentableDescription'
 import NationalDataDescriptions from './NationalDataDescriptions'
 
 type Props = {
+  // eslint-disable-next-line react/no-unused-prop-types
   descriptions: DescriptionsType
   disabled: boolean
   sectionName: string
@@ -49,12 +48,10 @@ const useDescriptions = (props: Props): { nationalData: boolean; analysisAndProc
 }
 
 const Descriptions: React.FC<Props> = (props: Props) => {
-  const { descriptions, disabled, sectionName } = props
+  const { disabled, sectionName } = props
 
-  const { t } = useTranslation()
   const { print, onlyTables } = useIsPrint()
 
-  const { introductoryText } = descriptions
   const { analysisAndProcessing, nationalData } = useDescriptions(props)
 
   return (
@@ -74,16 +71,6 @@ const Descriptions: React.FC<Props> = (props: Props) => {
           disabled={disabled}
           showAlertEmptyContent={!print}
           showDashEmptyContent={print}
-        />
-      )}
-
-      {introductoryText && (
-        <CommentableDescription
-          sectionName={sectionName}
-          title={t('contactPersons.introductoryText')}
-          name="introductoryText"
-          template={{ text: t('contactPersons.introductoryTextSupport') }}
-          disabled={disabled}
         />
       )}
 

--- a/src/i18n/resources/en.js
+++ b/src/i18n/resources/en.js
@@ -836,13 +836,8 @@ The FRA team fra@fao.org
     totalLandAreaAffectedByFire: 'Total land area affected by fire',
     ofWhichForest: '…of which on forest',
   },
-
   degradedForest: {
     degradedForest: 'Degraded forest',
-    doesYourCountryMonitor: 'Does your country monitor area of degraded forest',
-    ifYes: 'If "yes"',
-    whatIsDefinition: 'What is the national definition of "Degraded forest"?',
-    howMonitored: 'Describe the monitoring process and results',
   },
 
   forestPolicy: {

--- a/src/i18n/resources/en/fra.js
+++ b/src/i18n/resources/en/fra.js
@@ -28,6 +28,10 @@ module.exports = {
     percentOfForestArea: '% of forest area',
   },
 
+  contactPersons: {
+    expectedDateForNextCountryReportUpdate: 'Expected date/year for next update of the country report',
+  },
+
   designatedManagementObjective: {
     noDesignation: 'No designation',
     unknown2025: 'Unknown',

--- a/src/i18n/resources/en/fra.js
+++ b/src/i18n/resources/en/fra.js
@@ -2,6 +2,7 @@
 module.exports = {
   // common
   area100HaYear: 'Area (1000 ha/year)',
+  area100Ha: 'Area (1000 ha)',
   categoryHeader2020: 'FRA 2020 categories',
   categoryHeader2025: 'FRA 2025 categories',
   forestArea100HaYear: 'Forest area (1000 ha)',

--- a/src/i18n/resources/en/fra.js
+++ b/src/i18n/resources/en/fra.js
@@ -32,6 +32,51 @@ module.exports = {
     expectedDateForNextCountryReportUpdate: 'Expected date/year for next update of the country report',
   },
 
+  degradedForest: {
+    // Title
+    degradedForest: 'Degraded forest',
+    degradedForestDefinition: 'Degraded forest definition',
+    forestDegradationMonitoringAndAssessment: 'Forest degradation monitoring and assessment',
+
+    degradedAreaForThatYear: 'Degraded forest area for that year (in 1 000 ha)',
+    doesYourCountryMonitor: 'Does your country monitor area of degraded forest',
+    hasNationalDefinitionOfDegradedForest: 'Has your country a national definition of "Degraded forest"',
+    hasNationalLevelData: 'If national level data are available',
+    howMonitored: 'Describe the monitoring process and results',
+    ifYes: 'If "yes"',
+    whatIsDefinition: 'What is the national definition of "Degraded forest"?',
+    yearOfLatestAssessment: 'Year of latest assessment',
+
+    // Multiple choice
+    // generic
+    other: 'Other (explain in comments)',
+    notSelected: '',
+
+    criteriaOfDegradedForest: 'Criteria applied in the definition of degraded forest',
+    changeInForestStructureDecreaseInForestCanopy: 'Change in forest structure / Decrease in forest canopy',
+    forestDisturbances: 'Forest disturbances',
+    lossOfProductivityAndForestGoods: 'Loss of productivity and forest goods',
+    lossOfForestServices: 'Loss of forest services',
+    lossOfCarbonBiomassAndGrowingStock: 'Loss of carbon, biomass and growing stock',
+    lossOfBiologicalDiversity: 'Loss of biological diversity',
+    soilDamageErosion: 'Soil damage / erosion',
+
+    mainMethods: 'Main methods applied to monitor degraded forest area',
+    fieldInventoryAndObservations: 'Field inventory and observations',
+    wallToWallRemoteSensingMapping: 'Wall-to-wall remote sensing mapping',
+    remoteSensingSurvey: 'Remote sensing survey',
+    expertOpinion: 'Expert opinion',
+    productionHarvestData: 'Production / Harvest data',
+    forestManagementPlanReport: 'Forest management plan report',
+    underDevelopment: 'Under development',
+
+    monitoringScale: 'Monitoring scale',
+    national: 'National',
+    subnational: 'Subnational',
+    biome: 'Biome',
+    standLocal: 'Stand / Local',
+  },
+
   designatedManagementObjective: {
     noDesignation: 'No designation',
     unknown2025: 'Unknown',

--- a/src/test/sectionSpec/fraSpecs.ts
+++ b/src/test/sectionSpec/fraSpecs.ts
@@ -60,7 +60,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
                     idx: 1,
                     colSpan: null,
                     rowSpan: 1,
-                    labelKey: 'fra.area100HaYear',
+                    labelKey: 'fra.area100Ha',
                     className: 'fra-table__header-cell',
                     type: 'header',
                   },

--- a/src/test/sectionSpec/fraSpecs.ts
+++ b/src/test/sectionSpec/fraSpecs.ts
@@ -19,7 +19,70 @@ export const FraSpecs: Record<string, SectionSpec> = {
   contactPersons: {
     sectionName: 'contactPersons',
     sectionAnchor: '',
-    tableSections: [],
+    tableSections: [
+      {
+        tableSpecs: [
+          {
+            name: 'contactPersons',
+            rows: [
+              {
+                idx: 'header_0',
+                cols: [
+                  {
+                    idx: 0,
+                    colSpan: 1,
+                    rowSpan: 1,
+                    labelKey: '',
+                    className: 'fra-table__header-cell',
+                    type: 'header',
+                  },
+                  {
+                    idx: 1,
+                    colSpan: 1,
+                    rowSpan: 1,
+                    labelKey: 'common.year',
+                    className: 'fra-table__header-cell',
+                    type: 'header',
+                  },
+                ],
+                type: 'header',
+              },
+              {
+                idx: 0,
+                type: 'data',
+                cols: [
+                  {
+                    idx: 'header_0',
+                    type: 'header',
+                    colSpan: 1,
+                    labelKey: 'fra.contactPersons.expectedDateForNextCountryReportUpdate',
+                    className: 'fra-table__category-cell',
+                  },
+                  {
+                    idx: 0,
+                    type: 'text',
+                    colName: 'expectedDateForNextCountryReportUpdate',
+                  },
+                ],
+                labelKey: 'contactPersons.expectedDateForNextCountryReportUpdate',
+                variableName: 'expectedDateForNextCountryReportUpdate',
+              },
+            ],
+            tableDataRequired: [],
+            print: {
+              colBreakPoints: [],
+              pageBreakAfter: false,
+            },
+            dataExport: false,
+            columnsExportAlways: [],
+            migration: {
+              cycles: ['2025'],
+              columnNames: { '2025': ['year'] },
+            },
+          },
+        ],
+      },
+    ],
     showTitle: false,
     descriptions: {
       analysisAndProcessing: false,

--- a/src/test/sectionSpec/fraSpecs.ts
+++ b/src/test/sectionSpec/fraSpecs.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { degradedForest } from './sections/degradedForest'
 import { SectionSpec } from './sectionSpec'
 
 const fraYears: Array<{ colName: string; cycles?: Array<string> }> = [
@@ -9705,113 +9706,7 @@ export const FraSpecs: Record<string, SectionSpec> = {
       included: true,
     },
   },
-  degradedForest: {
-    sectionName: 'degradedForest',
-    sectionAnchor: '5c',
-    tableSections: [
-      {
-        tableSpecs: [
-          {
-            name: 'degradedForest',
-            rows: [
-              {
-                idx: 0,
-                type: 'data',
-                cols: [
-                  {
-                    idx: 'header_0',
-                    type: 'header',
-                    colSpan: 2,
-                    labelKey: 'degradedForest.doesYourCountryMonitor',
-                    className: 'fra-table__header-cell-left',
-                  },
-                  {
-                    idx: 0,
-                    type: 'select',
-                    options: [
-                      {
-                        optionName: 'yes',
-                      },
-                      {
-                        optionName: 'no',
-                      },
-                    ],
-                    optionsLabelKeyPrefix: 'yesNoTextSelect',
-                  },
-                ],
-                labelKey: 'degradedForest.doesYourCountryMonitor',
-                variableExport: 'does_country_monitor',
-                colSpan: 2,
-                mainCategory: true,
-              },
-              {
-                idx: 1,
-                type: 'data',
-                cols: [
-                  {
-                    idx: 'header_0',
-                    type: 'header',
-                    colSpan: 1,
-                    rowSpan: 2,
-                    labelKey: 'degradedForest.ifYes',
-                    className: 'fra-table__category-cell',
-                  },
-                  {
-                    idx: -1,
-                    type: 'placeholder',
-                    labelKey: 'degradedForest.whatIsDefinition',
-                  },
-                  {
-                    idx: 1,
-                    type: 'textarea',
-                  },
-                ],
-                labelKey: 'degradedForest.ifYes',
-                variableExport: 'national_definition',
-                rowSpan: 2,
-              },
-              {
-                idx: 2,
-                type: 'data',
-                cols: [
-                  {
-                    idx: 'header_0',
-                    type: 'header',
-                    colSpan: 1,
-                    labelKey: 'degradedForest.howMonitored',
-                    className: 'fra-table__category-cell',
-                  },
-                  {
-                    idx: 0,
-                    type: 'textarea',
-                  },
-                ],
-                labelKey: 'degradedForest.howMonitored',
-                variableExport: 'how_monitored',
-              },
-            ],
-            tableDataRequired: [],
-            print: {
-              colBreakPoints: [],
-              pageBreakAfter: false,
-            },
-            dataExport: true,
-            columnsExportAlways: [],
-          },
-        ],
-      },
-    ],
-    showTitle: true,
-    descriptions: {
-      analysisAndProcessing: false,
-      comments: true,
-      introductoryText: false,
-      nationalData: false,
-    },
-    dataExport: {
-      included: false,
-    },
-  },
+  degradedForest,
   forestPolicy: {
     sectionName: 'forestPolicy',
     sectionAnchor: '6a',

--- a/src/test/sectionSpec/fraSpecs.ts
+++ b/src/test/sectionSpec/fraSpecs.ts
@@ -6721,6 +6721,9 @@ export const FraSpecs: Record<string, SectionSpec> = {
                     label: 2016,
                     className: 'fra-table__header-cell',
                     type: 'header',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 5,
@@ -6729,6 +6732,9 @@ export const FraSpecs: Record<string, SectionSpec> = {
                     label: 2017,
                     className: 'fra-table__header-cell',
                     type: 'header',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 6,
@@ -6737,6 +6743,9 @@ export const FraSpecs: Record<string, SectionSpec> = {
                     label: 2018,
                     className: 'fra-table__header-cell',
                     type: 'header',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 7,
@@ -6745,6 +6754,9 @@ export const FraSpecs: Record<string, SectionSpec> = {
                     label: 2019,
                     className: 'fra-table__header-cell',
                     type: 'header',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 8,
@@ -6787,18 +6799,30 @@ export const FraSpecs: Record<string, SectionSpec> = {
                   {
                     idx: 4,
                     type: 'decimal',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 5,
                     type: 'decimal',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 6,
                     type: 'decimal',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 7,
                     type: 'decimal',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 8,
@@ -6849,18 +6873,30 @@ export const FraSpecs: Record<string, SectionSpec> = {
                   {
                     idx: 4,
                     type: 'decimal',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 5,
                     type: 'decimal',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 6,
                     type: 'decimal',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 7,
                     type: 'decimal',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 8,
@@ -6909,18 +6945,30 @@ export const FraSpecs: Record<string, SectionSpec> = {
                   {
                     idx: 4,
                     type: 'decimal',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 5,
                     type: 'decimal',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 6,
                     type: 'decimal',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 7,
                     type: 'decimal',
+                    migration: {
+                      cycles: ['2020'],
+                    },
                   },
                   {
                     idx: 8,

--- a/src/test/sectionSpec/sections/degradedForest.ts
+++ b/src/test/sectionSpec/sections/degradedForest.ts
@@ -1,0 +1,402 @@
+// @ts-nocheck
+import { SectionSpec } from '../sectionSpec'
+
+export const degradedForest: SectionSpec = {
+  sectionName: 'degradedForest',
+  sectionAnchor: '5c',
+  tableSections: [
+    {
+      titleKey: 'fra.degradedForest.degradedForestDefinition',
+      tableSpecs: [
+        {
+          name: 'degradedForest',
+          rows: [
+            {
+              idx: 0,
+              type: 'data',
+              cols: [
+                {
+                  idx: 'header_0',
+                  type: 'header',
+                  colSpan: 2,
+                  labelKey: 'fra.degradedForest.doesYourCountryMonitor',
+                  className: 'fra-table__header-cell-left',
+                },
+                {
+                  idx: 0,
+                  type: 'select',
+                  options: [
+                    {
+                      optionName: 'yes',
+                    },
+                    {
+                      optionName: 'no',
+                    },
+                  ],
+                  optionsLabelKeyPrefix: 'yesNoTextSelect',
+                },
+              ],
+              labelKey: 'fra.degradedForest.doesYourCountryMonitor',
+              variableExport: 'does_country_monitor',
+              colSpan: 2,
+              mainCategory: true,
+            },
+            {
+              idx: 1,
+              type: 'data',
+              cols: [
+                {
+                  idx: 'header_0',
+                  type: 'header',
+                  colSpan: 1,
+                  rowSpan: 2,
+                  labelKey: 'fra.degradedForest.ifYes',
+                  className: 'fra-table__category-cell',
+                },
+                {
+                  idx: -1,
+                  type: 'placeholder',
+                  labelKey: 'fra.degradedForest.whatIsDefinition',
+                },
+                {
+                  idx: 1,
+                  type: 'textarea',
+                },
+              ],
+              labelKey: 'fra.degradedForest.ifYes',
+              variableExport: 'national_definition',
+              rowSpan: 2,
+            },
+            {
+              idx: 2,
+              type: 'data',
+              cols: [
+                {
+                  idx: 'header_0',
+                  type: 'header',
+                  colSpan: 1,
+                  labelKey: 'fra.degradedForest.howMonitored',
+                  className: 'fra-table__category-cell',
+                },
+                {
+                  idx: 0,
+                  type: 'textarea',
+                },
+              ],
+              labelKey: 'fra.degradedForest.howMonitored',
+              variableExport: 'how_monitored',
+            },
+          ],
+          tableDataRequired: [],
+          print: {
+            colBreakPoints: [],
+            pageBreakAfter: false,
+          },
+          dataExport: true,
+          columnsExportAlways: [],
+        },
+      ],
+      migration: {
+        cycles: ['2020'],
+      },
+    }, // 2020
+    {
+      titleKey: 'fra.degradedForest.degradedForestDefinition',
+      tableSpecs: [
+        {
+          name: 'degradedForest2025',
+          rows: [
+            {
+              idx: 0,
+              type: 'data',
+              cols: [
+                {
+                  idx: 'header_0',
+                  type: 'header',
+                  colSpan: 2,
+                  labelKey: 'fra.degradedForest.hasNationalDefinitionOfDegradedForest',
+                  className: 'fra-table__header-cell-left',
+                },
+                {
+                  idx: 0,
+                  type: 'select',
+                  options: [
+                    {
+                      optionName: 'yes',
+                    },
+                    {
+                      optionName: 'no',
+                    },
+                  ],
+                  optionsLabelKeyPrefix: 'yesNoTextSelect',
+                  colName: 'hasNationalDefinitionOfDegradedForest',
+                },
+              ],
+              labelKey: 'fra.degradedForest.hasNationalDefinitionOfDegradedForest',
+              variableExport: 'hasNationalDefinitionOfDegradedForest',
+              variableName: 'hasNationalDefinitionOfDegradedForest',
+              colSpan: 2,
+              mainCategory: true,
+            },
+            {
+              idx: 1,
+              type: 'data',
+              cols: [
+                {
+                  idx: 'header_0',
+                  type: 'header',
+                  colSpan: 1,
+                  rowSpan: 2,
+                  labelKey: 'fra.degradedForest.ifYes',
+                  className: 'fra-table__category-cell',
+                },
+                {
+                  idx: -1,
+                  type: 'placeholder',
+                  labelKey: 'fra.degradedForest.whatIsDefinition',
+                },
+                {
+                  idx: 1,
+                  type: 'textarea',
+                  colName: 'national_definition',
+                },
+              ],
+              labelKey: 'fra.degradedForest.ifYes',
+              variableExport: 'national_definition',
+              rowSpan: 2,
+              variableName: 'national_definition',
+            },
+            {
+              idx: 2,
+              type: 'data',
+              cols: [
+                {
+                  idx: 'header_0',
+                  type: 'header',
+                  colSpan: 1,
+                  labelKey: 'fra.degradedForest.criteriaOfDegradedForest',
+                  className: 'fra-table__category-cell',
+                },
+                {
+                  idx: 0,
+                  type: 'select',
+                  options: [
+                    { optionName: 'changeInForestStructureDecreaseInForestCanopy' },
+                    { optionName: 'forestDisturbances' },
+                    { optionName: 'lossOfProductivityAndForestGoods' },
+                    { optionName: 'lossOfForestServices' },
+                    { optionName: 'lossOfCarbonBiomassAndGrowingStock' },
+                    { optionName: 'lossOfBiologicalDiversity' },
+                    { optionName: 'soilDamageErosion' },
+                  ],
+                  optionsLabelKeyPrefix: 'fra.degradedForest',
+                  colName: 'criteriaOfDegradedForest',
+                },
+              ],
+              variableName: 'criteriaOfDegradedForest',
+              labelKey: 'fra.degradedForest.criteriaOfDegradedForest',
+              variableExport: 'criteriaOfDegradedForest',
+            },
+          ],
+          tableDataRequired: [],
+          print: {
+            colBreakPoints: [],
+            pageBreakAfter: false,
+          },
+          dataExport: true,
+          columnsExportAlways: [],
+          migration: {
+            columnNames: {
+              '2025': ['hasNationalDefinitionOfDegradedForest', 'national_definition', 'criteriaOfDegradedForest'],
+            },
+          },
+        },
+      ],
+      migration: {
+        cycles: ['2025'],
+      },
+    }, // 2025
+    {
+      titleKey: 'fra.degradedForest.forestDegradationMonitoringAndAssessment',
+      tableSpecs: [
+        {
+          name: 'degradedForestMonitoring2025',
+          rows: [
+            {
+              idx: 0,
+              type: 'data',
+              cols: [
+                {
+                  idx: 'header_0',
+                  type: 'header',
+                  colSpan: 2,
+                  labelKey: 'fra.degradedForest.doesYourCountryMonitor',
+                  className: 'fra-table__header-cell-left',
+                },
+                {
+                  idx: 0,
+                  type: 'select',
+                  options: [
+                    {
+                      optionName: 'yes',
+                    },
+                    {
+                      optionName: 'no',
+                    },
+                  ],
+                  optionsLabelKeyPrefix: 'yesNoTextSelect',
+                  colName: 'doesYourCountryMonitor',
+                },
+              ],
+              labelKey: 'fra.degradedForestMonitoring.doesYourCountryMonitor',
+              variableExport: 'doesYourCountryMonitor',
+              variableName: 'doesYourCountryMonitor',
+              colSpan: 2,
+              mainCategory: true,
+            },
+            {
+              idx: 1,
+              type: 'data',
+              cols: [
+                {
+                  idx: 'header_0',
+                  type: 'header',
+                  colSpan: 1,
+                  rowSpan: 2,
+                  labelKey: 'fra.degradedForest.ifYes',
+                  className: 'fra-table__category-cell',
+                },
+                {
+                  idx: -1,
+                  type: 'placeholder',
+                  labelKey: 'fra.degradedForest.mainMethods',
+                },
+                {
+                  idx: 1,
+                  type: 'select',
+                  options: [
+                    { optionName: 'fieldInventoryAndObservations' },
+                    { optionName: 'wallToWallRemoteSensingMapping' },
+                    { optionName: 'remoteSensingSurvey' },
+                    { optionName: 'expertOpinion' },
+                    { optionName: 'productionHarvestData' },
+                    { optionName: 'forestManagementPlanReport' },
+                    { optionName: 'underDevelopment' },
+                  ],
+                  optionsLabelKeyPrefix: 'fra.degradedForest',
+                  colName: 'mainMethods',
+                },
+              ],
+              labelKey: 'fra.degradedForest.mainMethods',
+              variableExport: 'mainMethods',
+              rowSpan: 2,
+              variableName: 'mainMethods',
+            },
+            {
+              idx: 2,
+              type: 'data',
+              cols: [
+                {
+                  idx: 'header_0',
+                  type: 'header',
+                  colSpan: 1,
+                  labelKey: 'fra.degradedForest.monitoringScale',
+                  className: 'fra-table__category-cell',
+                },
+                {
+                  idx: 0,
+                  type: 'select',
+                  options: [
+                    { optionName: 'national' },
+                    { optionName: 'subnational' },
+                    { optionName: 'biome' },
+                    { optionName: 'standLocal' },
+                  ],
+                  optionsLabelKeyPrefix: 'fra.degradedForest',
+                  colName: 'monitoringScale',
+                },
+              ],
+              variableName: 'monitoringScale',
+              labelKey: 'fra.degradedForest.monitoringScale',
+              variableExport: 'monitoringScale',
+            },
+            {
+              idx: 3,
+              type: 'data',
+              cols: [
+                {
+                  idx: 'header_0',
+                  type: 'header',
+                  colSpan: 1,
+                  rowSpan: 2,
+                  labelKey: 'fra.degradedForest.hasNationalLevelData',
+                  className: 'fra-table__category-cell',
+                },
+                {
+                  idx: -1,
+                  type: 'placeholder',
+                  labelKey: 'fra.degradedForest.yearOfLatestAssessment',
+                },
+                {
+                  idx: 1,
+                  type: 'textarea',
+                  colName: 'yearOfLatestAssessment',
+                },
+              ],
+              labelKey: 'fra.degradedForest.yearOfLatestAssessment',
+              variableExport: 'yearOfLatestAssessment',
+              rowSpan: 2,
+              variableName: 'yearOfLatestAssessment',
+            },
+            {
+              idx: 4,
+              type: 'data',
+              cols: [
+                {
+                  idx: 'header_0',
+                  type: 'header',
+                  colSpan: 1,
+                  labelKey: 'fra.degradedForest.degradedAreaForThatYear',
+                  className: 'fra-table__category-cell',
+                },
+                {
+                  idx: 0,
+                  type: 'textarea',
+                  colName: 'degradedAreaForThatYear',
+                },
+              ],
+              labelKey: 'fra.degradedForest.degradedAreaForThatYear',
+              variableExport: 'degradedAreaForThatYear',
+              variableName: 'degradedAreaForThatYear',
+            },
+          ],
+          tableDataRequired: [],
+          print: {
+            colBreakPoints: [],
+            pageBreakAfter: false,
+          },
+          dataExport: true,
+          columnsExportAlways: [],
+          migration: {
+            columnNames: {
+              '2025': ['hasNationalDefinitionOfDegradedForest', 'national_definition', 'criteriaOfDegradedForest'],
+            },
+          },
+        },
+      ],
+      migration: {
+        cycles: ['2025'],
+      },
+    }, // 2025
+  ],
+  showTitle: true,
+  descriptions: {
+    analysisAndProcessing: false,
+    comments: true,
+    introductoryText: false,
+    nationalData: false,
+  },
+  dataExport: {
+    included: false,
+  },
+}

--- a/tools/dataMigration/migrateData/_repos.ts
+++ b/tools/dataMigration/migrateData/_repos.ts
@@ -56,6 +56,8 @@ export const isBasicTable = (tableName: string): boolean =>
     'growingStockAvg',
     'growingStockTotal',
     'degradedForest',
+    'degradedForest2025',
+    'degradedForestMonitoring2025',
     'sustainableDevelopment15_1_1',
     'sustainableDevelopment15_2_1_1',
     'sustainableDevelopment15_2_1_2',

--- a/tools/dataMigration/migrateData/_repos.ts
+++ b/tools/dataMigration/migrateData/_repos.ts
@@ -50,6 +50,7 @@ export const isBasicTable = (tableName: string): boolean =>
   tableName &&
   tableName.trim() !== '' &&
   ![
+    'contactPersons',
     'extentOfForest',
     'forestCharacteristics',
     'growingStockAvg',

--- a/tools/dataMigration/migrateData/migrateFRATablesData.ts
+++ b/tools/dataMigration/migrateData/migrateFRATablesData.ts
@@ -17,10 +17,11 @@ export const migrateFRATablesData = async (
   const tableGrowingStockAvg = tables.find((t) => t.props.name === 'growingStockAvg')
   const tableGrowingStockTotal = tables.find((t) => t.props.name === 'growingStockTotal')
 
-  // non basic tables insert
-  values.push(
-    ...(await _getNodeInsertsDegradedForest({ assessment, cycle, countryISOs, table: tableDegradedForest }, client))
-  )
+  // non-basic tables insert
+  if (cycle.name === '2020')
+    values.push(
+      ...(await _getNodeInsertsDegradedForest({ assessment, cycle, countryISOs, table: tableDegradedForest }, client))
+    )
   values.push(
     ...(await getNodeInsertsTableWithODP(
       {


### PR DESCRIPTION
Part of #1869 

- [x] Table 5c 2025 [0da48fa](https://github.com/openforis/fra-platform/pull/1921/commits/0da48fa59051b99de974674927cc68c0b040f610)

no data
![image](https://user-images.githubusercontent.com/5508251/209319280-3d68fdaf-23b3-48b6-b065-0bd707613c9d.png)

with data
![image](https://user-images.githubusercontent.com/5508251/209319754-db2139af-209f-4f91-a6df-b5b663a34f10.png)


- [x] Introduction new table on top [22d73c4](https://github.com/openforis/fra-platform/pull/1921/commits/22d73c44fc6a7c5a0e44037a5f2fdf70058996ba)

![image](https://user-images.githubusercontent.com/5508251/209319809-26b0f088-6d4b-4e8e-b72c-9946140fd20f.png)


- [x] 3b forestAreaWithinProtectedAreas -> fraReportingYears . Remove 2016 2017 2018 2019 [925fce1](https://github.com/openforis/fra-platform/pull/1921/commits/925fce13ff4af6f18bb5513c4e6f27ea1c50aa6e)
![image](https://user-images.githubusercontent.com/5508251/209319861-532a4e3f-e0f7-430c-95e8-b8e96e0c944f.png)



- [x] fix 1a unit header label [1000ha]  [20d2f24](https://github.com/openforis/fra-platform/pull/1921/commits/20d2f24c13742fd3e671da0308c8b35e2ccb99ad)
![image](https://user-images.githubusercontent.com/5508251/209319890-1f646e9f-2bfc-4308-b7b6-9c1325c3f7f3.png)

