### PR TITLE
Meta/1686 wip

### DIFF
--- a/src/test/sectionSpec/sections/sustainableDevelopment.ts
+++ b/src/test/sectionSpec/sections/sustainableDevelopment.ts
@@ -1,21 +1,14 @@
 // @ts-nocheck
 
-const _interpolateForestAreaProportionLandArea = (idx: number) => {
+const interpolateForestAreaProportionLandArea = (idx: number) => {
   const variable1 = "extentOfForest.forestArea['2020'] / extentOfForest.totalLandArea['2020'] * 100"
   const variable2 = "extentOfForest.forestArea['2025'] / extentOfForest.totalLandArea['2025'] * 100"
   // check variables exist
   //    and interpolate between
   // else null
-  return `(${variable1} > 0 && ${variable2}) > 0 ? ${variable1} + (${variable2} - ${variable1}) / 5 * ${idx + 1} : null`
-}
-
-const interpolateForestAreaProportionLandArea = (idx: number) => {
-  const variable1 = "sustainableDevelopment15_1_1.forestAreaProportionLandArea2015['2020']"
-  const variable2 = "sustainableDevelopment15_1_1.forestAreaProportionLandArea2015['2025']"
-  // check variables exist
-  //    and interpolate between
-  // else null
-  return `${variable1} + (${variable2} - ${variable1}) / 5 * ${idx + 1}`
+  return `(${variable1} > 0 && ${variable2}) > 0 ? (${variable1} + ((${variable2} - ${variable1}) / 5 * ${
+    idx + 1
+  })) : null`
 }
 
 export const sustainableDevelopment = {
@@ -183,6 +176,8 @@ export const sustainableDevelopment = {
                   type: 'calculated',
                   colName: '2000',
                   migration: {
+                    calculateFn: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
+
                     cycles: ['2020'],
                   },
                 },
@@ -191,6 +186,8 @@ export const sustainableDevelopment = {
                   type: 'decimal',
                   colName: '2000',
                   migration: {
+                    calculateFn: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
+
                     cycles: ['2025'],
                   },
                 },
@@ -199,6 +196,8 @@ export const sustainableDevelopment = {
                   type: 'decimal',
                   colName: '2005',
                   migration: {
+                    calculateFn: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
+
                     cycles: ['2025'],
                   },
                 },
@@ -207,6 +206,8 @@ export const sustainableDevelopment = {
                   type: 'calculated',
                   colName: '2010',
                   migration: {
+                    calculateFn: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
+
                     cycles: ['2020'],
                   },
                 },
@@ -215,6 +216,8 @@ export const sustainableDevelopment = {
                   type: 'decimal',
                   colName: '2010',
                   migration: {
+                    calculateFn: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
+
                     cycles: ['2025'],
                   },
                 },
@@ -223,6 +226,8 @@ export const sustainableDevelopment = {
                   type: 'calculated',
                   colName: '2015',
                   migration: {
+                    calculateFn: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
+
                     cycles: ['2020'],
                   },
                 },
@@ -231,6 +236,8 @@ export const sustainableDevelopment = {
                   type: 'decimal',
                   colName: '2015',
                   migration: {
+                    calculateFn: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
+
                     cycles: ['2025'],
                   },
                 },
@@ -239,6 +246,8 @@ export const sustainableDevelopment = {
                   type: 'calculated',
                   colName: '2016',
                   migration: {
+                    calculateFn: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
+
                     cycles: ['2020'],
                   },
                 },
@@ -247,6 +256,8 @@ export const sustainableDevelopment = {
                   type: 'calculated',
                   colName: '2017',
                   migration: {
+                    calculateFn: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
+
                     cycles: ['2020'],
                   },
                 },
@@ -255,6 +266,8 @@ export const sustainableDevelopment = {
                   type: 'calculated',
                   colName: '2018',
                   migration: {
+                    calculateFn: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
+
                     cycles: ['2020'],
                   },
                 },
@@ -263,6 +276,8 @@ export const sustainableDevelopment = {
                   type: 'calculated',
                   colName: '2019',
                   migration: {
+                    calculateFn: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
+
                     cycles: ['2020'],
                   },
                 },
@@ -271,6 +286,8 @@ export const sustainableDevelopment = {
                   type: 'calculated',
                   colName: '2020',
                   migration: {
+                    calculateFn: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
+
                     cycles: ['2020'],
                   },
                 },
@@ -279,6 +296,8 @@ export const sustainableDevelopment = {
                   type: 'decimal',
                   colName: '2020',
                   migration: {
+                    calculateFn: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
+
                     cycles: ['2025'],
                   },
                 },
@@ -296,14 +315,15 @@ export const sustainableDevelopment = {
                   type: 'decimal',
                   colName: '2025',
                   migration: {
+                    calculateFn: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
                     cycles: ['2025'],
                   },
                 },
               ],
               labelKey: 'sustainableDevelopment.forestAreaProportionLandArea2015',
-              migration: {
-                calcFormula: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
-              },
+              // migration: {
+              //   calcFormula: 'extentOfForest.forestArea / extentOfForest.totalLandArea * 100',
+              // },
             },
           ],
           tableDataRequired: [

--- a/src/test/sectionSpec/sections/sustainableDevelopment.ts
+++ b/src/test/sectionSpec/sections/sustainableDevelopment.ts
@@ -1,4 +1,23 @@
 // @ts-nocheck
+
+const _interpolateForestAreaProportionLandArea = (idx: number) => {
+  const variable1 = "extentOfForest.forestArea['2020'] / extentOfForest.totalLandArea['2020'] * 100"
+  const variable2 = "extentOfForest.forestArea['2025'] / extentOfForest.totalLandArea['2025'] * 100"
+  // check variables exist
+  //    and interpolate between
+  // else null
+  return `(${variable1} > 0 && ${variable2}) > 0 ? ${variable1} + (${variable2} - ${variable1}) / 5 * ${idx + 1} : null`
+}
+
+const interpolateForestAreaProportionLandArea = (idx: number) => {
+  const variable1 = "sustainableDevelopment15_1_1.forestAreaProportionLandArea2015['2020']"
+  const variable2 = "sustainableDevelopment15_1_1.forestAreaProportionLandArea2015['2025']"
+  // check variables exist
+  //    and interpolate between
+  // else null
+  return `${variable1} + (${variable2} - ${variable1}) / 5 * ${idx + 1}`
+}
+
 export const sustainableDevelopment = {
   sectionName: 'sustainableDevelopment',
   sectionAnchor: '8a',
@@ -263,14 +282,23 @@ export const sustainableDevelopment = {
                     cycles: ['2025'],
                   },
                 },
-                ...['2021', '2022', '2023', '2024', '2025'].map((colName, idx) => ({
+                ...['2021', '2022', '2023', '2024'].map((colName, idx) => ({
                   idx: idx + 9,
                   type: 'decimal',
                   colName,
                   migration: {
                     cycles: ['2025'],
+                    calculateFn: interpolateForestAreaProportionLandArea(idx),
                   },
                 })),
+                {
+                  idx: 14,
+                  type: 'decimal',
+                  colName: '2025',
+                  migration: {
+                    cycles: ['2025'],
+                  },
+                },
               ],
               labelKey: 'sustainableDevelopment.forestAreaProportionLandArea2015',
               migration: {


### PR DESCRIPTION
Attempt to resolve issue where calculations do not trigger when changing

Issue:
calculations for Forest area as proportion of total land area years 2021-2024 do not trigger
Only these fields have col level calculations formula

public.assessment.meta_cache looks to be populated correctly (eg:
`calculations.dependencies.sustainableDevelopment15_1_1`
```
          "forestAreaProportionLandArea2015": [
            {
              "tableName": "extentOfForest",
              "variableName": "forestArea"
            },
            {
              "tableName": "extentOfForest",
              "variableName": "totalLandArea"
            }
          ]
        },
```

Metadata for column 2022:

```
{
  "index": 10,
  "style": {
    "77ed602c-7175-4297-aabb-c91183512376": {}
  },
  "cycles": [
    "77ed602c-7175-4297-aabb-c91183512376"
  ],
  "colName": "2022",
  "colType": "decimal",
  "calculateFn": {
    "77ed602c-7175-4297-aabb-c91183512376": "sustainableDevelopment15_1_1.forestAreaProportionLandArea2015['2020'] + (sustainableDevelopment15_1_1.forestAreaProportionLandArea2015['2025'] - sustainableDevelopment15_1_1.forestAreaProportionLandArea2015['2020']) / 5 * 2"
  }
}
```

## Findings

Issue might be related to generateMetaCache
https://github.com/openforis/fra-platform/blob/95743f3c5fd1ef7a35faaaf0c8f15aac2318cd1b/tools/dataMigration/generateMetaCache

Issue might be related to conflicting calculations (row, col)

<details>
<summary>Possible solution [Patch] </summary>

```
Index: tools/dataMigration/generateMetaCache/index.ts
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/tools/dataMigration/generateMetaCache/index.ts b/tools/dataMigration/generateMetaCache/index.ts
--- a/tools/dataMigration/generateMetaCache/index.ts	(revision 95743f3c5fd1ef7a35faaaf0c8f15aac2318cd1b)
+++ b/tools/dataMigration/generateMetaCache/index.ts	(date 1673009943225)
@@ -102,16 +102,18 @@
   )
 
   rows.forEach(({ tableName, ...row }) => {
+    // Evaluate row dependencies
     const context = { row, tableName, assessmentMetaCache }
     if (row.props.calculateFn?.[cycle.uuid]) {
       DependencyEvaluator.evalDependencies(row.props.calculateFn[cycle.uuid], { ...context, type: 'calculations' })
-    } else {
-      row.cols.forEach((col) => {
-        if (col.props.calculateFn?.[cycle.uuid]) {
-          DependencyEvaluator.evalDependencies(col.props.calculateFn[cycle.uuid], { ...context, type: 'calculations' })
-        }
-      })
-    }
+    }
+
+    // Evaluate col dependencies
+    row.cols.forEach((col) => {
+      if (col.props.calculateFn?.[cycle.uuid]) {
+        DependencyEvaluator.evalDependencies(col.props.calculateFn[cycle.uuid], { ...context, type: 'calculations' })
+      }
+    })
 
     if (row.props.validateFns?.[cycle.uuid]) {
       row.props.validateFns[cycle.uuid].forEach((validateFn) =>
```
</details>

Previous solution does not fix the issue, but is notable in finding the problem