### PR TITLE
PR - #1746 - geo statistics

### DIFF
--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/MapVisualizerPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/MapVisualizerPanel.tsx
@@ -68,19 +68,22 @@ const MapVisualizerPanel: React.FC = () => {
     <div className="geo-map-menu-data-visualizer-panel">
       <p>Forest Layers</p>
       <div className="geo-map-menu-data-visualizer-panel-layers">
-        {layers.map((layer, index) => (
-          <div key={layer.key}>
-            <GeoMapMenuListElement
-              title={layer.title}
-              tabIndex={index * -1 - 1}
-              checked={forestOptions.selected.includes(layer.key)}
-              onCheckboxClick={() => dispatch(GeoActions.toggleForestLayer(layer.key))}
-              backgroundColor={layer.key.toLowerCase()}
-            >
-              <LayerOptionsPanel layerKey={layer.key} />
-            </GeoMapMenuListElement>
-          </div>
-        ))}
+        {layers.map((layer, index) => {
+          const isLayerChecked = forestOptions.selected.includes(layer.key)
+          return (
+            <div key={layer.key}>
+              <GeoMapMenuListElement
+                title={layer.title}
+                tabIndex={index * -1 - 1}
+                checked={isLayerChecked}
+                onCheckboxClick={() => dispatch(GeoActions.toggleForestLayer(layer.key))}
+                backgroundColor={layer.key.toLowerCase()}
+              >
+                {isLayerChecked && <LayerOptionsPanel layerKey={layer.key} />}
+              </GeoMapMenuListElement>
+            </div>
+          )
+        })}
         <AgreementLevelsControl />
       </div>
       <div className="geo-map-menu-data-container-btn">

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuItem/geoMapMenuItem.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuItem/geoMapMenuItem.tsx
@@ -12,7 +12,13 @@ interface Props {
   onCheckboxClick?: () => void
 }
 
-const GeoMenuItem: React.FC<Props> = ({ title, tabIndex, checked, onCheckboxClick, children }) => {
+const GeoMenuItem: React.FC<React.PropsWithChildren<Props>> = ({
+  title,
+  tabIndex,
+  checked,
+  onCheckboxClick,
+  children,
+}) => {
   const [isOpen, setIsOpen] = useState(false)
 
   const handleExpandClick = useCallback(() => {

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/StatisticalGraphsPanel/StatisticalGraphsPanel.scss
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/StatisticalGraphsPanel/StatisticalGraphsPanel.scss
@@ -1,0 +1,5 @@
+@import 'src/client/style/partials';
+
+.statistical-graph-panel-container {
+  padding: 0 2em 2em 2em;
+}

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/StatisticalGraphsPanel/StatisticalGraphsPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/StatisticalGraphsPanel/StatisticalGraphsPanel.tsx
@@ -1,0 +1,131 @@
+import './StatisticalGraphsPanel.scss'
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
+
+import { ChartOptions, Plugin } from 'chart.js'
+import Chart from 'chart.js/auto'
+
+import { ForestSource, sourcesMetadata } from '@meta/geo'
+
+import Icon from '@client/components/Icon'
+import { useDownloadChart } from '@client/pages/Geo/GeoMap/hooks'
+import { displayPercentagesPlugin, whiteBackgroundplugin } from '@client/pages/Geo/utils/chartPlugins'
+
+type Props = {
+  data: [string, number, number][]
+  countryIso: string
+  year: number
+}
+
+const StatisticalGraphsPanel: React.FC<Props> = (props: Props) => {
+  const { data, countryIso, year } = props
+  const chartTitle = `Extent of forest per source and reported on ${year} (1a)`
+  const canvasRef = useRef(null)
+  const [chart, setChart] = useState(null)
+
+  const labels = data.map((row) => {
+    // Extract the labels from the first column of the data.
+    return row[0]
+  })
+
+  const areas = data.map((row) => {
+    // Extract the areas from the second column of the data.
+    const area = row[1]
+    return area
+  })
+
+  const maximumArea = Math.max(...areas)
+
+  const percentages = data.map((row) => {
+    // Extract the percentages from the third column of the data.
+    const area = row[2]
+    return area
+  })
+
+  const backgroundColors = data.map((row) => {
+    const source = row[0] as ForestSource
+    if (source.toUpperCase().indexOf('REPORTED TO FRA') !== -1) {
+      return '#000000' // Black for the Reported To FRA Bar.
+    }
+    if (source.toUpperCase().indexOf('HANSEN') === -1) {
+      return sourcesMetadata[source].palette[0]
+    }
+    return sourcesMetadata.Hansen.palette[0]
+  })
+
+  const chartData = {
+    labels,
+    datasets: [
+      {
+        label: 'Area',
+        backgroundColor: backgroundColors,
+        data: areas,
+        yAxisID: 'Areas',
+      },
+    ],
+  }
+
+  const options = {
+    plugins: {
+      title: {
+        display: true,
+        text: chartTitle,
+      },
+      legend: {
+        display: false,
+      },
+    },
+    scales: {
+      Areas: {
+        type: 'linear',
+        display: true,
+        position: 'left',
+        suggestedMax: maximumArea * (1 + 0.2), // Add 20 % buffer area to the top of the bars
+        ticks: {
+          callback(value: number) {
+            return `${value / 1000000} Million`
+          },
+        },
+      },
+    },
+  } as unknown as ChartOptions<'bar'>
+
+  const plugins: Plugin[] = [
+    whiteBackgroundplugin(), // Pluging to get a white background color when downloading
+    displayPercentagesPlugin(percentages, backgroundColors), // Plugin to display the percentage on top of the bars.
+  ]
+
+  // On mount init chart
+  useLayoutEffect(() => {
+    const chartContext = canvasRef.current.getContext('2d')
+    setChart(new Chart(chartContext, { type: 'bar', data: chartData, options, plugins }))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // On unmount destroy chart
+  useEffect(() => {
+    return () => {
+      if (chart) chart.destroy()
+    }
+  }, [chart])
+
+  return (
+    <div className="statistical-graph-panel-container">
+      <div>
+        <div className="chart">
+          <canvas ref={canvasRef} />
+        </div>
+        <button
+          onClick={useDownloadChart(chart, `extend_of_forest_${countryIso}_${year}.png`)}
+          type="button"
+          className="btn btn-primary geo-map-menu-statistics-btn-download"
+        >
+          <span>Download</span>
+          <span>&nbsp;</span>
+          <Icon className="icon-sub icon-white" name="hit-down" />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default StatisticalGraphsPanel

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/StatisticalGraphsPanel/index.ts
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/StatisticalGraphsPanel/index.ts
@@ -1,0 +1,1 @@
+export { default } from './StatisticalGraphsPanel'

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/TreeCoverAreaPanel/TreeCoverAreaPanel.scss
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/TreeCoverAreaPanel/TreeCoverAreaPanel.scss
@@ -1,0 +1,12 @@
+@import 'src/client/style/partials';
+
+.geo-map-menu-statistics-btn-download {
+  float: right;
+  width: 150px;
+  margin: 2em 4em 2em;
+}
+
+.table-title {
+  padding: 0 0 2em 3em;
+  margin: auto;
+}

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/TreeCoverAreaPanel/TreeCoverAreaPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/TreeCoverAreaPanel/TreeCoverAreaPanel.tsx
@@ -1,0 +1,47 @@
+import './TreeCoverAreaPanel.scss'
+import React from 'react'
+
+import StatisticsTable from '../../components/StatisticsTable'
+
+type Props = {
+  data: [string, number, number][]
+  countryIso: string
+  year: number
+}
+
+const TreeCoverAreaPanel: React.FC<Props> = (props: Props) => {
+  const columns = ['Source', 'Forest area', 'Forest area % of land area']
+  const title = 'Extent of forest per source and reported on 2020 (1a)'
+  const units = ['', 'ha', '%']
+  const loaded = true
+  const { data, countryIso, year } = props
+
+  // Formatting the data.
+  const formattedTableData: (string | number)[][] = []
+  Object.entries(data).forEach((value) => {
+    const rowData = value[1] // First position is the id, and the second one is the data row.
+    const sourceName = rowData[0]
+    const area = rowData[1]
+    const percentage = rowData[2]
+    const formatedArea = Math.round(area)
+      .toString()
+      .replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',') // Comma separator for thousands.
+    formattedTableData.push([sourceName, formatedArea, percentage])
+  })
+
+  return (
+    <div>
+      <h3 className="table-title">{title}</h3>
+      <StatisticsTable
+        columns={columns}
+        units={units}
+        loaded={loaded}
+        tableData={formattedTableData}
+        countryIso={countryIso}
+        year={year}
+      />
+    </div>
+  )
+}
+
+export default TreeCoverAreaPanel

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/TreeCoverAreaPanel/index.ts
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/TreeCoverAreaPanel/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TreeCoverAreaPanel'

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/geoMapMenuStatistics.scss
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/geoMapMenuStatistics.scss
@@ -1,5 +1,12 @@
 @import 'src/client/style/partials';
 
+.statistics {
+  // Makes the statistics divs be the same length as the button.
+  > div {
+    width: 100%;
+  }
+}
+
 .geo-map-menu-button-statistics {
   &.selected {
     width: 700px;

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/geoMapMenuStatistics.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/geoMapMenuStatistics.tsx
@@ -1,14 +1,57 @@
 import './geoMapMenuStatistics.scss'
-import React from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
+
+import { useSelectedPanel } from '@client/store/ui/geo'
+import { useCountryIso } from '@client/hooks'
+import { getForestEstimationData } from '@client/pages/Geo/utils/forestEstimations'
 
 import GeoMapMenuButton from '../GeoMapMenuButton'
-
-// Placeholder for Data Layers menu
+import GeoMenuItem from '../GeoMapMenuItem'
+import TreeCoverAreaPanel from './TreeCoverAreaPanel'
 
 const GeoMapMenuStatistics: React.FC = () => {
+  const [statisticsData, setStatisticsData] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [year, setYear] = useState(2020)
+  const countryIso = useCountryIso()
+
+  const selectedPanel = useSelectedPanel()
+
+  const fetchStatisticsHandler = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+    let data: [string, number, number][] = []
+    try {
+      const forestEstimations = await getForestEstimationData(countryIso, year)
+      data = forestEstimations.data
+    } catch (error) {
+      setError(error.message)
+    }
+    setStatisticsData(data)
+    setIsLoading(false)
+  }, [countryIso, year])
+
+  useEffect(() => {
+    setYear(2020) // Default value is 2020 for now, assigned like this again to avoid typescript warnings.
+    fetchStatisticsHandler()
+  }, [fetchStatisticsHandler])
+
   return (
-    <div className="geo-map-menu-item">
+    <div className="geo-map-menu-item statistics">
       <GeoMapMenuButton panel="statistics" text="Statistics" icon="histogram" />
+      {selectedPanel === 'statistics' && (
+        <div>
+          <GeoMenuItem title="Tree Cover Area" checked={null} tabIndex={-1}>
+            {!isLoading && statisticsData.length > 0 && (
+              <TreeCoverAreaPanel data={statisticsData} countryIso={countryIso} year={year} />
+            )}
+            {!isLoading && statisticsData.length === 0 && !error && <p>Found no data.</p>}
+            {!isLoading && error && <p>An error has occured while fetching the statistics: {error}</p>}
+            {isLoading && <p>Loading...</p>}
+          </GeoMenuItem>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/geoMapMenuStatistics.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/geoMapMenuStatistics.tsx
@@ -7,6 +7,7 @@ import { getForestEstimationData } from '@client/pages/Geo/utils/forestEstimatio
 
 import GeoMapMenuButton from '../GeoMapMenuButton'
 import GeoMenuItem from '../GeoMapMenuItem'
+import StatisticalGraphsPanel from './StatisticalGraphsPanel'
 import TreeCoverAreaPanel from './TreeCoverAreaPanel'
 
 const GeoMapMenuStatistics: React.FC = () => {
@@ -45,6 +46,15 @@ const GeoMapMenuStatistics: React.FC = () => {
           <GeoMenuItem title="Tree Cover Area" checked={null} tabIndex={-1}>
             {!isLoading && statisticsData.length > 0 && (
               <TreeCoverAreaPanel data={statisticsData} countryIso={countryIso} year={year} />
+            )}
+            {!isLoading && statisticsData.length === 0 && !error && <p>Found no data.</p>}
+            {!isLoading && error && <p>An error has occured while fetching the statistics: {error}</p>}
+            {isLoading && <p>Loading...</p>}
+          </GeoMenuItem>
+          <div className="geo-map-menu-separator" />
+          <GeoMenuItem title="Statistical Graphs" checked={null} tabIndex={-3}>
+            {!isLoading && statisticsData.length > 0 && (
+              <StatisticalGraphsPanel data={statisticsData} countryIso={countryIso} year={year} />
             )}
             {!isLoading && statisticsData.length === 0 && !error && <p>Found no data.</p>}
             {!isLoading && error && <p>An error has occured while fetching the statistics: {error}</p>}

--- a/src/client/pages/Geo/GeoMap/components/ButtonStatisticsTableExport/ButtonStatisticsTableExport.scss
+++ b/src/client/pages/Geo/GeoMap/components/ButtonStatisticsTableExport/ButtonStatisticsTableExport.scss
@@ -1,0 +1,15 @@
+@import 'src/client/style/partials';
+
+.fra-table__btn-export {
+  font-size: $font-xs;
+
+  &.in-review {
+    margin-right: $spacing-m;
+  }
+
+  svg.icon {
+    width: 12px;
+    height: 12px;
+    margin-right: 4px;
+  }
+}

--- a/src/client/pages/Geo/GeoMap/components/ButtonStatisticsTableExport/ButtonStatisticsTableExport.tsx
+++ b/src/client/pages/Geo/GeoMap/components/ButtonStatisticsTableExport/ButtonStatisticsTableExport.tsx
@@ -1,0 +1,46 @@
+import './ButtonStatisticsTableExport.scss'
+import React, { MutableRefObject, useEffect, useRef, useState } from 'react'
+import { CSVLink } from 'react-csv'
+
+import Icon from '@client/components/Icon'
+
+import * as Utils from './utils'
+
+type Props = {
+  tableRef: MutableRefObject<HTMLTableElement>
+  filename?: string
+}
+
+const ButtonTableExport: React.FC<Props> = (props) => {
+  const { tableRef, filename } = props
+  const csvLink = useRef(null)
+  const [tableData, setTableData] = useState('')
+
+  useEffect(() => {
+    setTableData(Utils.getData(tableRef.current))
+  }, [tableRef])
+
+  const exportTableToCSV = () => {
+    csvLink.current.link.click()
+  }
+
+  return (
+    <div>
+      <button onClick={exportTableToCSV} type="button" className="btn btn-primary geo-map-menu-statistics-btn-download">
+        <span>Download</span>
+        <span>&nbsp;</span>
+        <Icon className="icon-sub icon-white" name="hit-down" />
+      </button>
+      <CSVLink className="hidden" ref={csvLink} target="_blank" filename={`${filename}.csv`} data={tableData}>
+        <Icon className="icon-sub icon-white" name="hit-down" />
+        CSV
+      </CSVLink>
+    </div>
+  )
+}
+
+ButtonTableExport.defaultProps = {
+  filename: 'tableData',
+}
+
+export default ButtonTableExport

--- a/src/client/pages/Geo/GeoMap/components/ButtonStatisticsTableExport/index.ts
+++ b/src/client/pages/Geo/GeoMap/components/ButtonStatisticsTableExport/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ButtonStatisticsTableExport'

--- a/src/client/pages/Geo/GeoMap/components/ButtonStatisticsTableExport/utils.ts
+++ b/src/client/pages/Geo/GeoMap/components/ButtonStatisticsTableExport/utils.ts
@@ -1,0 +1,55 @@
+// From the .src legacy ButtonTableExport
+
+const normalizeString = (string = '') => string.trim().replace(/\s/g, ' ')
+const getElementText = ({ element }: any): any => {
+  const { children, innerText } = element
+  if (element.nodeName === 'SELECT') {
+    return normalizeString(element.options[element.selectedIndex].text)
+  }
+  if (children.length > 0) {
+    return Array.from(children).reduce(
+      (text, child) => normalizeString(`${text} ${getElementText({ element: child })}`),
+      ''
+    )
+  }
+  return normalizeString(innerText)
+}
+export const getData = (tableElement: any, dupCols = true, dupRows = true, textMode = true, formatToNumber = true) => {
+  if (!tableElement) {
+    return []
+  }
+  // Initialize variables
+  const columns: any = []
+  let currentX = 0
+  let currentY = 0
+  Array.from(tableElement.rows).forEach((row) => {
+    currentY = 0
+    // Handle both table haders and table cells
+    Array.from((row as any).cells).forEach((column) => {
+      const { rowSpan, colSpan }: any = column
+      let content = textMode ? getElementText({ element: column }) : (column as any).innerHTML
+      if (formatToNumber)
+        content = Number.isNaN(Number.parseFloat(content.replace(/\s/g, ''))) ? content : content.replace(/\s/g, '')
+      // Handle spanning cells
+      for (let x = 0; x < rowSpan; x += 1) {
+        for (let y = 0; y < colSpan; y += 1) {
+          if (columns[currentY + y] === undefined) {
+            columns[currentY + y] = []
+          }
+          while (columns[currentY + y][currentX + x] !== undefined) {
+            currentY += 1
+            if (columns[currentY + y] === undefined) {
+              columns[currentY + y] = []
+            }
+          }
+          const condition = (x === 0 || dupRows) && (y === 0 || dupCols)
+          columns[currentY + y][currentX + x] = condition ? content : ''
+        }
+      }
+      currentY += 1
+    })
+    currentX += 1
+  })
+  // transpose matrix
+  return columns[0].map((_: any, i: any) => columns.map((row: any) => row[i]))
+}

--- a/src/client/pages/Geo/GeoMap/components/StatisticsTable/StatisticsTable.tsx
+++ b/src/client/pages/Geo/GeoMap/components/StatisticsTable/StatisticsTable.tsx
@@ -1,0 +1,54 @@
+import './statisticsTable.scss'
+import React, { useRef } from 'react'
+
+import ButtonStatisticsTableExport from '../ButtonStatisticsTableExport'
+
+type Props = {
+  columns: string[]
+  units: string[]
+  loaded: boolean
+  tableData: (string | number)[][]
+  countryIso: string
+  year: number
+}
+
+const StatisticsTable = (props: Props) => {
+  const { columns, units, loaded, tableData, countryIso, year } = props
+  const tableRef = useRef(null)
+
+  if (!loaded) {
+    return null
+  }
+
+  return (
+    <div className="statistics-table__container">
+      <table ref={tableRef} className="statistics-table" cellSpacing="0">
+        <thead>
+          <tr>
+            {columns.map((columnName) => (
+              <th key={`${columnName}`} className="statistics-table__header-cell">
+                {columnName}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {tableData.map((row, rowIdx) => {
+            return (
+              <tr key={`${[rowIdx]}`}>
+                {row.map((value, columnIdx: number) => (
+                  <td key={`${value}-${columns[columnIdx]}`} className="statistics-table__cell">
+                    {`${value} ${units[columnIdx]}`}
+                  </td>
+                ))}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <ButtonStatisticsTableExport tableRef={tableRef} filename={`forest-estimations-${countryIso}-${year}`} />
+    </div>
+  )
+}
+
+export default StatisticsTable

--- a/src/client/pages/Geo/GeoMap/components/StatisticsTable/index.ts
+++ b/src/client/pages/Geo/GeoMap/components/StatisticsTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from './StatisticsTable'

--- a/src/client/pages/Geo/GeoMap/components/StatisticsTable/statisticsTable.scss
+++ b/src/client/pages/Geo/GeoMap/components/StatisticsTable/statisticsTable.scss
@@ -1,0 +1,38 @@
+@import 'src/client/styles/config';
+
+$border-radius: 10px;
+
+.statistics-table__container {
+  padding: 0 2em 0 2em;
+  margin: auto;
+}
+.statistics-table {
+  margin: auto;
+  width: calc(100% - 2em);
+  border-collapse: separate;
+  border-spacing: 0 0.5em;
+  margin-top: -10px;
+}
+.statistics-table td {
+  font-size: $font-m;
+  border: solid 1px $ui-border;
+  border-style: solid none;
+  padding: 1em;
+}
+.statistics-table td:first-child {
+  border-left-style: solid;
+  border-top-left-radius: $border-radius;
+  border-bottom-left-radius: $border-radius;
+}
+
+.statistics-table td:last-child {
+  border-right-style: solid;
+  border-bottom-right-radius: $border-radius;
+  border-top-right-radius: $border-radius;
+}
+
+.statistics-table__header-cell {
+  font-size: $font-l;
+  text-align: left;
+  padding-left: 0.7em;
+}

--- a/src/client/pages/Geo/GeoMap/hooks/index.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useDownloadChart } from './useDownloadChart'

--- a/src/client/pages/Geo/GeoMap/hooks/useDownloadChart.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/useDownloadChart.ts
@@ -1,0 +1,11 @@
+export const useDownloadChart = (chart: any, filename: string) => {
+  return () => {
+    const image = chart.toBase64Image()
+    const a = document.createElement('a')
+    a.href = image
+    a.download = filename
+    // Trigger the download
+    a.click()
+    a.remove()
+  }
+}

--- a/src/client/pages/Geo/utils/chartPlugins.ts
+++ b/src/client/pages/Geo/utils/chartPlugins.ts
@@ -1,0 +1,35 @@
+import { Plugin } from 'chart.js'
+
+export const whiteBackgroundplugin = (): Plugin => {
+  return {
+    id: 'white-background-on-download',
+    beforeDraw: (chartCtx) => {
+      const ctx = chartCtx.canvas.getContext('2d')
+      ctx.save()
+      ctx.globalCompositeOperation = 'destination-over'
+      ctx.fillStyle = 'white'
+      ctx.fillRect(0, 0, chartCtx.width, chartCtx.height)
+      ctx.restore()
+    },
+  }
+}
+
+export const displayPercentagesPlugin = (percentages: Array<number>, backgroundColors: Array<string>): Plugin => {
+  return {
+    id: 'displayPercentages',
+    afterDraw: (chart) => {
+      const {
+        ctx,
+        data: { datasets },
+      } = chart
+      const _metasets = chart.getDatasetMeta(0)
+      datasets[0].data.forEach((dp, i) => {
+        const barValue = `${percentages[i]}%`
+        const lineHeight = ctx.measureText('M').width
+        ctx.fillStyle = backgroundColors[i]
+        ctx.textAlign = 'center'
+        ctx.fillText(barValue, _metasets.data[i].x, _metasets.data[i].y - lineHeight * 1.5)
+      })
+    },
+  }
+}

--- a/src/client/pages/Geo/utils/forestEstimations.ts
+++ b/src/client/pages/Geo/utils/forestEstimations.ts
@@ -1,0 +1,72 @@
+import axios from 'axios'
+
+import { ApiEndPoint } from '@meta/api/endpoint'
+import { ForestEstimations, ForestEstimationsData, ForestSource, sourcesMetadata } from '@meta/geo'
+import { hansenPercentages } from '@meta/geo/forest'
+
+/**
+ * Type for tabular data, consisting of an array of arrays with
+ * source, area, and coverage percentage.
+ */
+export type TabularForestEstimationData = {
+  data: [string, number, number][]
+  fra1ALandArea: number // fra1ALandArea reported in thousands of Ha.
+  fra1aForestArea: number // fra1aForestArea reported in thousands of Ha.
+}
+
+/**
+ * Makes an API call to get the Forest Estimations in a country in a year,
+ * in a tabular way.
+ *
+ * @param {string} countryIso The country to query the statistics data.
+ * @param {string} year The year to query the statistics data.
+ * @public
+ */
+export const getForestEstimationData = async (
+  countryIso: string,
+  year: number
+): Promise<TabularForestEstimationData> => {
+  const estimationsData: [string, number, number][] = []
+  const response = await axios.get(ApiEndPoint.Geo.Layers.getEstimations(), { params: { countryIso, year } })
+  const fetchedForestEstimations: ForestEstimations = response.data
+
+  if (!fetchedForestEstimations) throw Error('Data unavailable.')
+
+  const fra1ALandArea = fetchedForestEstimations.data.fra1aLandArea
+  const reportedFra1aForestArea = fetchedForestEstimations.data.fra1aForestArea
+
+  Object.keys(sourcesMetadata).forEach((key: ForestSource) => {
+    const metadata = sourcesMetadata[key]
+
+    if (!('forestAreaDataProperty' in metadata)) return
+
+    if (key !== ForestSource.Hansen) {
+      const source = key
+      const area = fetchedForestEstimations.data[metadata.forestAreaDataProperty as keyof ForestEstimationsData]
+
+      if (typeof area === 'undefined') return
+
+      const percentage = (area * 100) / (fra1ALandArea * 1000)
+      estimationsData.push([source, Number(area.toFixed(2)), Number(percentage.toFixed(2))])
+    } else {
+      hansenPercentages.forEach((number: number) => {
+        const source = `${key} ${number}`
+        const area =
+          fetchedForestEstimations.data[(metadata.forestAreaDataProperty + number) as keyof ForestEstimationsData]
+
+        if (typeof area === 'undefined') return
+
+        const percentage = (area * 100) / (fra1ALandArea * 1000)
+        estimationsData.push([source, Number(area.toFixed(2)), Number(percentage.toFixed(2))])
+      })
+    }
+  })
+
+  // Adding the reported Forest Area to the data.
+  const reportedFra1aForestAreaHa = reportedFra1aForestArea * 1000 // Normalize to Ha. Instead of Thousands of Ha.
+  const fra1aForestAreaPercentage = (reportedFra1aForestAreaHa * 100) / (fra1ALandArea * 1000)
+  const reportedToFraLabel = 'Reported to FRA'
+  estimationsData.push([reportedToFraLabel, reportedFra1aForestAreaHa, Number(fra1aForestAreaPercentage.toFixed(2))])
+
+  return { data: estimationsData, fra1ALandArea, fra1aForestArea: reportedFra1aForestArea }
+}


### PR DESCRIPTION
Implements [#1746](https://github.com/orgs/openforis/projects/9?pane=issue&itemId=14934099), by adding an util to get the data from the API, and by adding two panels to the statistics button: one for showing the data in a table and another one for displaying the data in a chart. 

To run this PR locally you need to run `yarn geo:forest-estimations-import` first.


![forestestimationsdemo](https://user-images.githubusercontent.com/41337901/212476140-06f0004a-9039-44d9-ab4b-f4d22f4044c0.gif)


