### PR TITLE
Geo: get estimated area property name for selected combination of layers 

### DIFF
--- a/src/meta/geo/forest.ts
+++ b/src/meta/geo/forest.ts
@@ -118,3 +118,79 @@ export const agreementPalette = [
   '#800080', // purple
   '#000000', // black
 ]
+
+const forestAgreementRecipes: Array<{
+  layers: Array<ForestSource>
+  gteHansenTreeCoverPerc?: number
+  forestAreaDataProperty: string
+}> = [
+  {
+    layers: [
+      ForestSource.TandemX,
+      ForestSource.JAXA,
+      ForestSource.GlobeLand,
+      ForestSource.ESAGlobCover,
+      ForestSource.Copernicus,
+      ForestSource.ESRI,
+      ForestSource.ESAWorldCover,
+      ForestSource.Hansen,
+    ],
+    gteHansenTreeCoverPerc: 10,
+    forestAreaDataProperty: 'faAgreementHansen10',
+  },
+  {
+    layers: [
+      ForestSource.JAXA,
+      ForestSource.TandemX,
+      ForestSource.GlobeLand,
+      ForestSource.ESAGlobCover,
+      ForestSource.Copernicus,
+      ForestSource.ESRI,
+      ForestSource.ESAWorldCover,
+      ForestSource.Hansen,
+    ],
+    gteHansenTreeCoverPerc: 20,
+    forestAreaDataProperty: 'faAgreementHansen20',
+  },
+  {
+    layers: [
+      ForestSource.JAXA,
+      ForestSource.TandemX,
+      ForestSource.GlobeLand,
+      ForestSource.ESAGlobCover,
+      ForestSource.Copernicus,
+      ForestSource.ESRI,
+      ForestSource.ESAWorldCover,
+      ForestSource.Hansen,
+    ],
+    gteHansenTreeCoverPerc: 30,
+    forestAreaDataProperty: 'faAgreementHansen30',
+  },
+  {
+    layers: [ForestSource.ESRI, ForestSource.ESAWorldCover, ForestSource.Hansen],
+    gteHansenTreeCoverPerc: 10,
+    forestAreaDataProperty: 'faAgreementEsriEsaGloHansen10',
+  },
+  {
+    layers: [ForestSource.ESRI, ForestSource.ESAWorldCover],
+    forestAreaDataProperty: 'faAgreementEsriEsa',
+  },
+]
+
+export const getRecipeAgreementAreaProperty = (
+  selectedLayers: Array<ForestSource>,
+  gteAgreementLevel: number,
+  gteHansenTreeCoverPerc?: number
+): string => {
+  for (let i = 0; i < forestAgreementRecipes.length; i += 1) {
+    const recipe = forestAgreementRecipes[i]
+    if (
+      recipe.layers.length === selectedLayers.length &&
+      (recipe.gteHansenTreeCoverPerc === gteHansenTreeCoverPerc || recipe.gteHansenTreeCoverPerc === undefined) &&
+      recipe.layers.every((layer) => selectedLayers.includes(layer))
+    ) {
+      return `${recipe.forestAreaDataProperty}Gte${gteAgreementLevel}`
+    }
+  }
+  return null
+}

--- a/src/meta/geo/forest.ts
+++ b/src/meta/geo/forest.ts
@@ -167,7 +167,7 @@ const forestAgreementRecipes: Array<{
     forestAreaDataProperty: 'faAgreementHansen30',
   },
   {
-    layers: [ForestSource.ESRI, ForestSource.ESAWorldCover, ForestSource.Hansen],
+    layers: [ForestSource.ESRI, ForestSource.ESAWorldCover, ForestSource.GlobeLand, ForestSource.Hansen],
     gteHansenTreeCoverPerc: 10,
     forestAreaDataProperty: 'faAgreementEsriEsaGloHansen10',
   },
@@ -182,15 +182,13 @@ export const getRecipeAgreementAreaProperty = (
   gteAgreementLevel: number,
   gteHansenTreeCoverPerc?: number
 ): string => {
-  for (let i = 0; i < forestAgreementRecipes.length; i += 1) {
-    const recipe = forestAgreementRecipes[i]
-    if (
+  const recipe = forestAgreementRecipes.find((recipe) => {
+    return (
       recipe.layers.length === selectedLayers.length &&
       (recipe.gteHansenTreeCoverPerc === gteHansenTreeCoverPerc || recipe.gteHansenTreeCoverPerc === undefined) &&
       recipe.layers.every((layer) => selectedLayers.includes(layer))
-    ) {
-      return `${recipe.forestAreaDataProperty}Gte${gteAgreementLevel}`
-    }
-  }
-  return null
+    )
+  })
+
+  return recipe === undefined ? null : `${recipe.forestAreaDataProperty}Gte${gteAgreementLevel}`
 }

--- a/src/meta/geo/index.ts
+++ b/src/meta/geo/index.ts
@@ -1,6 +1,12 @@
 export type { Layer } from './forest'
 export type { ForestOptions } from './forest'
-export { agreementPalette, ForestSource, precalForestAgreementSources, sourcesMetadata } from './forest'
+export {
+  agreementPalette,
+  ForestSource,
+  getRecipeAgreementAreaProperty,
+  precalForestAgreementSources,
+  sourcesMetadata,
+} from './forest'
 export type { ForestEstimations, ForestEstimationsData } from './forestEstimations'
 export type { MosaicOptions, MosaicSource } from './mosaic'
 export type { MapPanel } from './ui'


### PR DESCRIPTION
If selected combination of layers is one of the precalculated combinations, the function added returns the property that holds the estimated area for the combination and level of agreement. If the combination of layers selected is not one of the precalculated combinations the function returns null.  