### PR TITLE
1744 layers global opacity control

### DIFF
--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerAgreementLevelsControl/MapVisualizerAgreementLevelsControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerAgreementLevelsControl/MapVisualizerAgreementLevelsControl.tsx
@@ -38,21 +38,22 @@ const AgreementLevelsControl: React.FC = () => {
       onCheckboxClick={() => toggleAgreementLayer(!forestOptions.agreementLayerSelected)}
     >
       <>
-        {forestOptions.agreementLayerSelected && <LayerOptionsPanel layerKey={agreementLayerKey} />}
-        <div className="geo-map-menu-data-visualizer-agreement-levels-control">
-          <p>
-            <small>
-              Choose the agreement level between all map layers. Agreement level <i>N</i> means that at least <i>N</i>{' '}
-              of the selected data sources need to agree that a certain pixel is forest area.
-            </small>
-          </p>
-          <div className="geo-map-menu-data-visualizer-agreement-levels-boxes">
-            {Array(layers.length)
-              .fill(undefined)
-              .map((_, i) => {
-                const level = i + 1
-                const id = `agreement-${level}`
-                const disabled = level > forestOptions.selected.length
+        <LayerOptionsPanel layerKey={agreementLayerKey} checked={forestOptions.agreementLayerSelected} />
+        {forestOptions.agreementLayerSelected && (
+          <div className="geo-map-menu-data-visualizer-agreement-levels-control">
+            <p>
+              <small>
+                Choose the agreement level between all map layers. Agreement level <i>N</i> means that at least <i>N</i>{' '}
+                of the selected data sources need to agree that a certain pixel is forest area.
+              </small>
+            </p>
+            <div className="geo-map-menu-data-visualizer-agreement-levels-boxes">
+              {Array(layers.length)
+                .fill(undefined)
+                .map((_, i) => {
+                  const level = i + 1
+                  const id = `agreement-${level}`
+                  const disabled = level > forestOptions.selected.length
 
                 // Agreement layer color legend
                 const agreementLevelOffset = level - forestOptions.agreementLevel
@@ -65,26 +66,27 @@ const AgreementLevelsControl: React.FC = () => {
                       }
                     : {}
 
-                return (
-                  <span
-                    className={classNames('geo-map-menu-data-visualizer-agreement-level', { disabled })}
-                    key={level}
-                  >
-                    <input
-                      id={id}
-                      className="geo-map-menu-data-visualizer-agreement-levels-box"
-                      type="checkbox"
-                      checked={level <= forestOptions.agreementLevel}
-                      disabled={disabled}
-                      onChange={() => setAgreementLevel(level)}
-                      style={style}
-                    />
-                    <label htmlFor={id}>{level}</label>
-                  </span>
-                )
-              })}
+                  return (
+                    <span
+                      className={classNames('geo-map-menu-data-visualizer-agreement-level', { disabled })}
+                      key={level}
+                    >
+                      <input
+                        id={id}
+                        className="geo-map-menu-data-visualizer-agreement-levels-box"
+                        type="checkbox"
+                        checked={level <= forestOptions.agreementLevel}
+                        disabled={disabled}
+                        onChange={() => setAgreementLevel(level)}
+                        style={style}
+                      />
+                      <label htmlFor={id}>{level}</label>
+                    </span>
+                  )
+                })}
+            </div>
           </div>
-        </div>
+        )}
       </>
     </GeoMapMenuListElement>
   ) : null

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayerOptionsPanel/LayerOptionsPanel.scss
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayerOptionsPanel/LayerOptionsPanel.scss
@@ -1,6 +1,7 @@
 @import 'src/client/style/partials';
 
-.geo-map-menu-forest-layer-options-panel {
+.geo-map-menu-forest-hansen-layer-inputs {
+  width: 100%;
   display: flex;
   flex-direction: column;
   padding: 0px 25px 0px 25px;
@@ -62,4 +63,26 @@
 .geo-map-menu-mosaic-btn-apply {
   width: 150px;
   margin: 40px 1px 0 auto;
+}
+
+.geo-map-menu-forest-layer-opacity-input {
+  margin: auto 5px auto auto;
+  min-width: 180px;
+  > div {
+    height: 100%;
+    vertical-align: middle;
+    display: inline-block;
+  }
+  input {
+    height: 100%;
+    width: 100%;
+    vertical-align: middle;
+  }
+  small {
+    height: 100%;
+    vertical-align: middle;
+    font-size: normal;
+    font-weight: bold;
+    margin-left: 15px;
+  }
 }

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayerOptionsPanel/LayerOptionsPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayerOptionsPanel/LayerOptionsPanel.tsx
@@ -11,9 +11,10 @@ import { MapController } from '@client/utils'
 
 interface Props {
   layerKey: string
+  checked: boolean
 }
 
-const LayerOptionsPanel: React.FC<Props> = ({ layerKey }) => {
+const LayerOptionsPanel: React.FC<Props> = ({ layerKey, checked }) => {
   const dispatch = useAppDispatch()
   const forestOptions = useForestSourceOptions()
   const map = useGeoMap()
@@ -34,12 +35,18 @@ const LayerOptionsPanel: React.FC<Props> = ({ layerKey }) => {
   }
 
   return (
-    <div className="geo-map-menu-forest-layer-options-panel">
-      <div>
+    <>
+      <div className="geo-map-menu-forest-layer-opacity-input">
         <div>
-          <input type="range" min="0" max="100" value={opacity * 100} onChange={handleChange} />
+          <input type="range" min="0" max="100" value={opacity * 100} onChange={handleChange} disabled={!checked} />{' '}
+        </div>
+        <div>
           <small>{`${opacity * 100}%`}</small>
-          {layerKey === ForestSource.Hansen ? (
+        </div>
+      </div>
+      {layerKey === ForestSource.Hansen && checked ? (
+        <div className="geo-map-menu-forest-hansen-layer-inputs">
+          <div>
             <div>
               <p>Select Hansen percentage:</p>
               <fieldset>
@@ -59,10 +66,10 @@ const LayerOptionsPanel: React.FC<Props> = ({ layerKey }) => {
                 })}
               </fieldset>
             </div>
-          ) : null}
+          </div>
         </div>
-      </div>
-    </div>
+      ) : null}
+    </>
   )
 }
 

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/MapVisualizerPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/MapVisualizerPanel.tsx
@@ -10,7 +10,7 @@ import { GeoActions, useForestSourceOptions } from '@client/store/ui/geo'
 import GeoMapMenuListElement from '../../GeoMapMenuListElement'
 import AgreementLevelsControl from '../MapVisualizerAgreementLevelsControl'
 import LayerOptionsPanel from './LayerOptionsPanel'
-import { layers, GLOBAL_OPACITY_KEY } from '.'
+import { GLOBAL_OPACITY_KEY, layers, LayerStatus } from '.'
 
 const RecipeSelector: React.FC = () => {
   const dispatch = useAppDispatch()
@@ -56,6 +56,11 @@ const MapVisualizerPanel: React.FC = () => {
         </div>
         {layers.map((layer, index) => {
           const isLayerChecked = forestOptions.selected.includes(layer.key)
+          let status = null
+          if (forestOptions.pendingLayers[layer.key] !== undefined) status = LayerStatus.loading
+          if (forestOptions.fetchedLayers[layer.key] !== undefined) status = LayerStatus.ready
+          if (forestOptions.failedLayers[layer.key] !== undefined) status = LayerStatus.failed
+          // If the status continues to be null, it means it has not been attempted to fetch the layer
           return (
             <div key={layer.key}>
               <GeoMapMenuListElement
@@ -64,6 +69,7 @@ const MapVisualizerPanel: React.FC = () => {
                 checked={isLayerChecked}
                 onCheckboxClick={() => toggleForestLayer(layer.key)}
                 backgroundColor={layer.key.toLowerCase()}
+                loadingStatus={status}
               >
                 <LayerOptionsPanel layerKey={layer.key} checked={isLayerChecked} />
               </GeoMapMenuListElement>

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/MapVisualizerPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/MapVisualizerPanel.tsx
@@ -10,7 +10,7 @@ import { GeoActions, useForestSourceOptions } from '@client/store/ui/geo'
 import GeoMapMenuListElement from '../../GeoMapMenuListElement'
 import AgreementLevelsControl from '../MapVisualizerAgreementLevelsControl'
 import LayerOptionsPanel from './LayerOptionsPanel'
-import { layers } from '.'
+import { layers, GLOBAL_OPACITY_KEY } from '.'
 
 const RecipeSelector: React.FC = () => {
   const dispatch = useAppDispatch()
@@ -39,7 +39,6 @@ const RecipeSelector: React.FC = () => {
 const MapVisualizerPanel: React.FC = () => {
   const dispatch = useAppDispatch()
   const forestOptions = useForestSourceOptions()
-
   const toggleForestLayer = (key: ForestSource) => {
     dispatch(GeoActions.setRecipe('custom'))
     dispatch(GeoActions.toggleForestLayer(key))
@@ -50,6 +49,11 @@ const MapVisualizerPanel: React.FC = () => {
       <RecipeSelector />
       <p>Forest Layers</p>
       <div className="geo-map-menu-data-visualizer-panel-layers">
+        <div key={GLOBAL_OPACITY_KEY}>
+          <GeoMapMenuListElement title="Global Opacity" tabIndex={-2}>
+            <LayerOptionsPanel layerKey={GLOBAL_OPACITY_KEY} checked />
+          </GeoMapMenuListElement>
+        </div>
         {layers.map((layer, index) => {
           const isLayerChecked = forestOptions.selected.includes(layer.key)
           return (

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/MapVisualizerPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/MapVisualizerPanel.tsx
@@ -61,7 +61,7 @@ const MapVisualizerPanel: React.FC = () => {
                 onCheckboxClick={() => toggleForestLayer(layer.key)}
                 backgroundColor={layer.key.toLowerCase()}
               >
-                {isLayerChecked && <LayerOptionsPanel layerKey={layer.key} />}
+                <LayerOptionsPanel layerKey={layer.key} checked={isLayerChecked} />
               </GeoMapMenuListElement>
             </div>
           )

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/MapVisualizerPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/MapVisualizerPanel.tsx
@@ -78,14 +78,14 @@ const MapVisualizerPanel: React.FC = () => {
         })}
         <AgreementLevelsControl />
       </div>
-      <div className="geo-map-menu-data-container-btn">
+      {/* <div className="geo-map-menu-data-container-btn">
         <button type="button" className="btn btn-secondary geo-map-menu-data-btn-recipe">
           Save Recipe
         </button>
         <button type="button" className="btn btn-primary geo-map-menu-data-btn-display">
           Display
         </button>
-      </div>
+      </div> */}
     </div>
   )
 }

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/index.ts
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/index.ts
@@ -1,3 +1,3 @@
 export type { Layer } from './layers'
-export { layers, GLOBAL_OPACITY_KEY } from './layers'
+export { GLOBAL_OPACITY_KEY, layers, LayerStatus } from './layers'
 export { default } from './MapVisualizerPanel'

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/index.ts
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/index.ts
@@ -1,3 +1,3 @@
 export type { Layer } from './layers'
-export { layers } from './layers'
+export { layers, GLOBAL_OPACITY_KEY } from './layers'
 export { default } from './MapVisualizerPanel'

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/layers.ts
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/layers.ts
@@ -48,3 +48,5 @@ export const layers: Layer[] = [
     opacity: 1,
   },
 ]
+
+export const GLOBAL_OPACITY_KEY = 'GLOBAL_OPACITY'

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/layers.ts
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/layers.ts
@@ -50,3 +50,9 @@ export const layers: Layer[] = [
 ]
 
 export const GLOBAL_OPACITY_KEY = 'GLOBAL_OPACITY'
+
+export enum LayerStatus {
+  loading = 'loading',
+  failed = 'failed',
+  ready = 'ready',
+}

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuListElement/GeoMapMenuListElement.scss
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuListElement/GeoMapMenuListElement.scss
@@ -26,6 +26,9 @@
     margin: 0 10px 0 5px;
     cursor: pointer;
   }
+  > .failed {
+    border-color: red;
+  }
 }
 
 // checkbox background colours
@@ -88,5 +91,31 @@
       margin: 0;
       vertical-align: middle;
     }
+  }
+}
+
+// Free to use from: https://loading.io/css/ (adapted)
+.geo-map-menu-list-element-loading-status-loading {
+  display: inline-block;
+  width: 14px;
+  height: 100%;
+  margin: 0 10px 0 5px;
+}
+.geo-map-menu-list-element-loading-status-loading:after {
+  content: ' ';
+  display: block;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid #1798a5;
+  border-color: #1798a5 transparent #1798a5 transparent;
+  animation: geo-map-menu-list-element-loading-status-loading 1.2s linear infinite;
+}
+@keyframes geo-map-menu-list-element-loading-status-loading {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
   }
 }

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuListElement/GeoMapMenuListElement.scss
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuListElement/GeoMapMenuListElement.scss
@@ -5,7 +5,9 @@
   flex-direction: row;
   align-items: center;
   font-weight: bold;
-  padding: 6px 0 4px;
+  padding: 6px 0 6px;
+  justify-content: space-between;
+  flex-wrap: wrap;
 }
 
 .geo-map-menu-list-element-bottom {
@@ -68,4 +70,23 @@
   margin: 0 0 0 auto;
   padding: 5px 10px 5px 10px;
   cursor: pointer;
+}
+
+.geo-map-menu-item-title {
+  max-width: 160px;
+  height: 100%;
+  white-space: pre-line;
+  margin: auto auto auto 0px;
+  padding-top: 3px;
+  > div {
+    height: 100%;
+    vertical-align: middle;
+    > p {
+      font-size: $font-m;
+      text-justify: left;
+      font-weight: bold;
+      margin: 0;
+      vertical-align: middle;
+    }
+  }
 }

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuListElement/GeoMapMenuListElement.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuListElement/GeoMapMenuListElement.tsx
@@ -3,12 +3,15 @@ import React from 'react'
 
 import classNames from 'classnames'
 
+import { LayerStatus } from '../GeoMapMenuData/MapVisualizerPanel'
+
 interface Props {
   title: string
   tabIndex: number
   checked?: boolean
   onCheckboxClick?: () => void
   backgroundColor?: string
+  loadingStatus?: string
 }
 
 const GeoMenuItem: React.FC<React.PropsWithChildren<Props>> = ({
@@ -18,7 +21,16 @@ const GeoMenuItem: React.FC<React.PropsWithChildren<Props>> = ({
   onCheckboxClick,
   children,
   backgroundColor,
+  loadingStatus,
 }) => {
+  let checkBoxContent = null
+  if (loadingStatus === LayerStatus.loading) {
+    checkBoxContent = <div className="geo-map-menu-list-element-loading-status-loading" />
+  } else if (loadingStatus === LayerStatus.failed) {
+    checkBoxContent = <div className={classNames('fra-checkbox', 'failed')} />
+  } else {
+    checkBoxContent = <div className={classNames('fra-checkbox', { checked })} />
+  }
   return (
     <>
       <div className="geo-map-menu-list-element">
@@ -32,7 +44,7 @@ const GeoMenuItem: React.FC<React.PropsWithChildren<Props>> = ({
               onClick={onCheckboxClick}
               onKeyDown={onCheckboxClick}
             >
-              <div className={classNames('fra-checkbox', { checked })} />
+              {checkBoxContent}
               <p>{title}</p>
             </div>
           ) : (
@@ -52,6 +64,7 @@ GeoMenuItem.defaultProps = {
   checked: null,
   onCheckboxClick: null,
   backgroundColor: null,
+  loadingStatus: null,
 }
 
 export default GeoMenuItem

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuListElement/GeoMapMenuListElement.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuListElement/GeoMapMenuListElement.tsx
@@ -8,39 +8,47 @@ interface Props {
   tabIndex: number
   checked?: boolean
   onCheckboxClick?: () => void
-  children?: JSX.Element
   backgroundColor?: string
 }
 
-const GeoMenuItem: React.FC<Props> = ({ title, tabIndex, checked, onCheckboxClick, children, backgroundColor }) => {
+const GeoMenuItem: React.FC<React.PropsWithChildren<Props>> = ({
+  title,
+  tabIndex,
+  checked,
+  onCheckboxClick,
+  children,
+  backgroundColor,
+}) => {
   return (
-    <div>
+    <>
       <div className="geo-map-menu-list-element">
-        {checked !== null ? (
-          <div
-            className={`geo-map-menu-list-element-checkbox ${backgroundColor}`}
-            role="checkbox"
-            aria-checked={checked}
-            tabIndex={tabIndex}
-            onClick={onCheckboxClick}
-            onKeyDown={onCheckboxClick}
-          >
-            <div className={classNames('fra-checkbox', { checked })} />
-            <p className="geo-map-menu-list-element-checkbox">{title}</p>
-          </div>
-        ) : (
-          <p className="geo-map-menu-list-element-title">{title}</p>
-        )}
+        <div className="geo-map-menu-item-title">
+          {checked !== null ? (
+            <div
+              className={`geo-map-menu-list-element-checkbox ${backgroundColor}`}
+              role="checkbox"
+              aria-checked={checked}
+              tabIndex={tabIndex}
+              onClick={onCheckboxClick}
+              onKeyDown={onCheckboxClick}
+            >
+              <div className={classNames('fra-checkbox', { checked })} />
+              <p>{title}</p>
+            </div>
+          ) : (
+            <p>{title}</p>
+          )}
+        </div>
+        {children}
       </div>
-      <div className="geo-map-menu-list-element-bottom">{children}</div>
-    </div>
+      <div className="geo-map-menu-list-element-bottom" />
+    </>
   )
 }
 
 GeoMenuItem.defaultProps = {
   checked: null,
   onCheckboxClick: null,
-  children: null,
   backgroundColor: null,
 }
 

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuListElement/GeoMapMenuListElement.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuListElement/GeoMapMenuListElement.tsx
@@ -36,7 +36,9 @@ const GeoMenuItem: React.FC<React.PropsWithChildren<Props>> = ({
               <p>{title}</p>
             </div>
           ) : (
-            <p>{title}</p>
+            <div>
+              <p>{title}</p>
+            </div>
           )}
         </div>
         {children}

--- a/src/client/pages/Geo/GeoMapWrapper/GeoMapWrapper.tsx
+++ b/src/client/pages/Geo/GeoMapWrapper/GeoMapWrapper.tsx
@@ -8,7 +8,7 @@ import Loading from '@client/components/Loading'
 import GeoMap from '../GeoMap'
 import GeoMapMenuData from '../GeoMap/GeoMapMenuData'
 import GeoMapMenuMosaic from '../GeoMap/GeoMapMenuMosaic'
-import GeoMapMenuRecipes from '../GeoMap/GeoMapMenuRecipes'
+// import GeoMapMenuRecipes from '../GeoMap/GeoMapMenuRecipes'
 import GeoMapMenuStatistics from '../GeoMap/GeoMapMenuStatistics'
 
 // @ts-ignore
@@ -29,7 +29,7 @@ const GeoMapWrapper: React.FC = () => {
             <div className="geo-map-menu-container">
               <GeoMapMenuMosaic />
               <GeoMapMenuData />
-              <GeoMapMenuRecipes />
+              {/* <GeoMapMenuRecipes /> */}
               <GeoMapMenuStatistics />
             </div>
           </GeoMap>

--- a/src/client/store/ui/geo/slice.ts
+++ b/src/client/store/ui/geo/slice.ts
@@ -127,6 +127,8 @@ export const geoSlice = createSlice({
       state.forestOptions.failedLayers = initialState.forestOptions.failedLayers
     },
     setRecipe: (state, { payload }: PayloadAction<string>) => {
+      // If the recipe is not custom, reset the failed layers so they are fetched again
+      if (payload !== 'custom') state.forestOptions.failedLayers = initialState.forestOptions.failedLayers
       const recipe = forestAgreementRecipes.find((r) => r.forestAreaDataProperty === payload)
       const opacity = 0
       const agreementLevel = 1
@@ -161,10 +163,18 @@ export const geoSlice = createSlice({
       })
       .addCase(getForestLayer.pending, (state, { meta }) => {
         state.forestOptions.pendingLayers[meta.arg.key] = meta.arg.uri
+        delete state.forestOptions.fetchedLayers[meta.arg.key]
+        delete state.forestOptions.failedLayers[meta.arg.key]
       })
       .addCase(getForestLayer.rejected, (state, { meta }) => {
-        delete state.forestOptions.pendingLayers[meta.arg.key]
         state.forestOptions.failedLayers[meta.arg.key] = meta.arg.uri
+        delete state.forestOptions.pendingLayers[meta.arg.key]
+        delete state.forestOptions.fetchedLayers[meta.arg.key]
+        // Un-select the layer if the fetching fails
+        const i = state.forestOptions.selected.findIndex((key) => key === meta.arg.key)
+        if (i !== -1) {
+          state.forestOptions.selected.splice(i, 1)
+        }
       })
   },
 })

--- a/src/client/store/ui/geo/slice.ts
+++ b/src/client/store/ui/geo/slice.ts
@@ -94,6 +94,11 @@ export const geoSlice = createSlice({
     setOpacity: (state, { payload: { key, opacity } }: PayloadAction<{ key: string; opacity: number }>) => {
       state.forestOptions.opacity[key] = opacity
     },
+    setGlobalOpacity: (state, { payload }: PayloadAction<number>) => {
+      state.forestOptions.selected.forEach((layerKey) => {
+        state.forestOptions.opacity[layerKey] = payload
+      })
+    },
     setHansenPercentage: (state, { payload }: PayloadAction<HansenPercentage>) => {
       state.forestOptions.hansenPercentage = payload
     },


### PR DESCRIPTION
Implements #1744 and #1895 by:
- Refactoring the layers list so that it is easier to navigate (excessive scrolling)
- Adding an opacity control for all layers at once
- Adding a loading status for the layers


![globalopacity](https://user-images.githubusercontent.com/41337901/219092875-c401d6da-be9e-484c-8366-1769b7ae4594.gif)
