### PR TITLE
Sort migrations

### DIFF
--- a/src/test/migrations/index.ts
+++ b/src/test/migrations/index.ts
@@ -23,6 +23,7 @@ describe(`Migrations:`, () => {
     await Promise.all(
       migrations
         .filter((migration: string) => !ranMigrations.includes(migration))
+        .sort()
         .map(async (file: string) => {
           console.log('Running migration', file)
           // eslint-disable-next-line @typescript-eslint/no-var-requires,global-require,import/no-dynamic-require


### PR DESCRIPTION
After running all current migrations, output:

| id | name | run\_on |
| :--- | :--- | :--- |
| 14 | 20230222121020-step-ext\_node-sustainableDevelopment15\_2\_1\_5\_forestAreaVerifiedForestManagement.ts | 2023-02-24 14:34:28.272819 |
| 15 | 20230223093323-step-recalculate-forest-ownership.ts | 2023-02-24 14:34:28.273980 |
| 16 | 20230223155728-step-odp-missing-methods.ts | 2023-02-24 14:34:28.273938 |
| 17 | 20230223184533-step-fix-mirror-tables-calc-formula.ts | 2023-02-24 14:34:28.274525 |
| 18 | 20230224111303-step-ext\_node-extentOfForest-totalLandArea.ts | 2023-02-24 14:34:28.274573 |
| 19 | 20230224150316-step-fix-fix-mirror-tables-calc-formula.ts | 2023-02-24 14:34:28.275083 |
