### PR TITLE
2519 - PrivateOwnership subcategories are valid when all are empty

### DIFF
--- a/src/meta/expressionEvaluator/functions/validatorPrivateOwnership.ts
+++ b/src/meta/expressionEvaluator/functions/validatorPrivateOwnership.ts
@@ -13,7 +13,11 @@ export const validatorPrivateOwnership: ExpressionFunction<Context> = {
     return (privateOwnership?: string, subCategoryValues?: Array<string>): NodeValueValidation => {
       const emptyValues = subCategoryValues.filter((value) => Objects.isEmpty(value))
 
-      let valid = Objects.isEmpty(privateOwnership) || Numbers.eq(privateOwnership, 0) || emptyValues.length === 2
+      let valid =
+        emptyValues.length === subCategoryValues.length ||
+        Objects.isEmpty(privateOwnership) ||
+        Numbers.eq(privateOwnership, 0) ||
+        emptyValues.length === 2
       let key = ''
 
       if (!valid) {


### PR DESCRIPTION
close #2519

https://user-images.githubusercontent.com/10047945/231136689-a4e77998-e127-4ae5-b7d2-9ba87bfb530f.mov

