### PR TITLE
Geo refactor/Render layers section with empty redux state

### DIFF
--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.scss
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.scss
@@ -1,0 +1,17 @@
+@import 'src/client/style/partials';
+
+.geo-map-section-panel-container {
+  display: flex;
+  flex-direction: column;
+  padding: 5px 25px 30px 25px;
+
+  > p {
+    margin: 30px 0 20px 0;
+  }
+}
+
+.geo-map-section-panel-layers {
+  flex-direction: row;
+  margin: 0;
+  justify-content: space-between;
+}

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import { LayerKey, LayerSection } from '@meta/geo'
 
 import GeoMapMenuListElement from '../../../GeoMapMenuListElement'
+import CustomAssetControl from './components/CustomAssetControl'
 import LayerOpacityControl from './components/LayerOpacityControl'
 
 interface Props {
@@ -35,6 +36,18 @@ const LayersSectionPanel: React.FC<React.PropsWithChildren<Props>> = ({ section 
           </GeoMapMenuListElement>
         )}
         {section.layers.map((layer) => {
+          if (layer.isCustomAsset)
+            return (
+              <CustomAssetControl
+                key={`${section.key}-${layer.key}`}
+                onToggle={toggleLayer}
+                onOpacityChange={handleOpacityChange}
+                checked={checked}
+                layerKey={layer.key}
+                backgroundColor={layer.metadata?.palette?.[0]}
+              />
+            )
+
           return (
             <GeoMapMenuListElement
               key={`${section.key}-${layer.key}`}

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
@@ -1,0 +1,56 @@
+import './LayersSectionPanel.scss'
+import React, { useState } from 'react'
+
+import { LayerKey, LayerSection } from '@meta/geo'
+
+import GeoMapMenuListElement from '../../../GeoMapMenuListElement'
+import LayerOpacityControl from './components/LayerOpacityControl'
+
+interface Props {
+  section: LayerSection
+}
+
+const LayersSectionPanel: React.FC<React.PropsWithChildren<Props>> = ({ section }) => {
+  const handleOpacityChange = (value: number, layerKey: LayerKey | 'global') => {
+    return [value, layerKey] // Placeholder for logic
+  }
+  const [checked, setChecked] = useState(false)
+
+  const toggleLayer = (layerKey: LayerKey) => {
+    setChecked((current) => !current)
+    return layerKey // Placeholder for logic
+  }
+
+  return (
+    <div className="geo-map-section-panel-container">
+      <div className="geo-map-section-panel-layers">
+        {section.layers.length > 2 && (
+          <GeoMapMenuListElement
+            key={`${section.key}-global-opacity`}
+            title="Global Opacity"
+            tabIndex={0}
+            checked={null}
+          >
+            <LayerOpacityControl onChange={handleOpacityChange} checked layerKey="global" />
+          </GeoMapMenuListElement>
+        )}
+        {section.layers.map((layer) => {
+          return (
+            <GeoMapMenuListElement
+              key={`${section.key}-${layer.key}`}
+              title={layer.key}
+              tabIndex={0}
+              checked={checked}
+              onCheckboxClick={() => toggleLayer(layer.key)}
+              backgroundColor={layer.metadata?.palette?.[0]}
+            >
+              <LayerOpacityControl onChange={handleOpacityChange} checked={checked} layerKey={layer.key} />
+            </GeoMapMenuListElement>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default LayersSectionPanel

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.scss
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.scss
@@ -1,0 +1,86 @@
+@import 'src/client/style/partials';
+@import 'src/client/styles/spinner';
+@import 'src/client/styles/config';
+@import 'src/client/styles/buttons';
+
+.custom-input-container {
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+
+.custom-input-container input[type='text'] {
+  flex: 1;
+  width: 100%;
+  padding-right: 0px;
+}
+
+.custom-input-container button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 60px;
+  height: 100%;
+  border: none;
+}
+
+.custom-asset-list-element {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  font-weight: bold;
+  padding: 6px 0 6px;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.custom-asset-list-element-bottom {
+  flex-basis: 100%;
+  flex-wrap: wrap;
+  width: 100%;
+  border-bottom: 1px solid $ui-border;
+}
+
+.custom-asset-item-title {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 190px;
+  height: 100%;
+  white-space: pre-line;
+  margin: auto auto auto 0px;
+  padding-top: 3px;
+  > div {
+    height: 100%;
+    vertical-align: middle;
+    > p {
+      font-size: $font-m;
+      text-justify: left;
+      font-weight: bold;
+      margin: 0;
+      vertical-align: middle;
+    }
+  }
+}
+
+.custom-asset-list-element-checkbox {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  > .fra-checkbox {
+    margin: 0 10px 0 5px;
+    cursor: pointer;
+  }
+  > .failed {
+    border-color: $ui-destructive;
+  }
+}
+
+.custom-input {
+  border: 1px solid $ui-accent-light-extra;
+}
+
+.custom-input.error {
+  border: 1px solid $ui-destructive;
+}

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.tsx
@@ -1,0 +1,75 @@
+import './CustomAssetControl.scss'
+import React, { ChangeEvent, useState } from 'react'
+
+import classNames from 'classnames'
+
+import { LayerKey } from '@meta/geo'
+
+import LayerOpacityControl from '../LayerOpacityControl'
+
+interface Props {
+  checked: boolean
+  onOpacityChange: (value: number, layerKey: LayerKey) => void
+  onToggle: (layerKey: LayerKey) => void
+  layerKey: LayerKey
+  backgroundColor?: string
+}
+
+const CustomAssetControl: React.FC<Props> = ({ checked, onToggle, onOpacityChange, layerKey, backgroundColor }) => {
+  const [inputValue, setInputValue] = useState<string>('')
+  const [inputError, setInputError] = useState(false)
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    setInputValue(event.target.value)
+    if (inputError && event.target.value.trim() !== '') {
+      setInputError(false)
+    }
+  }
+
+  const handleSubmit = (): void => {
+    if (inputValue.trim() === '') {
+      setInputError(true)
+    } else {
+      setInputError(false)
+    }
+  }
+
+  return (
+    <>
+      <div className="custom-asset-list-element">
+        <div className="custom-asset-item-title">
+          <div
+            className="custom-asset-list-element-checkbox"
+            role="checkbox"
+            aria-checked={checked}
+            tabIndex={0}
+            onClick={() => onToggle(layerKey)}
+            onKeyDown={() => onToggle(layerKey)}
+          >
+            <div style={checked ? { backgroundColor } : {}} className={classNames('fra-checkbox', { checked })} />
+          </div>
+          <div className="custom-input-container">
+            <input
+              type="text"
+              value={inputValue}
+              onChange={handleInputChange}
+              placeholder="Asset ID"
+              className={classNames('custom-input', inputError ? 'error' : '')}
+            />
+            <button type="button" className="btn-primary" onClick={handleSubmit}>
+              Submit
+            </button>
+          </div>
+        </div>
+        <LayerOpacityControl layerKey={layerKey} checked={checked} onChange={onOpacityChange} />
+      </div>
+      <div className="custom-asset-list-element-bottom" />
+    </>
+  )
+}
+
+CustomAssetControl.defaultProps = {
+  backgroundColor: null,
+}
+
+export default CustomAssetControl

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/index.ts
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CustomAssetControl'

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/LayerOpacityControl/LayerOpacityControl.scss
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/LayerOpacityControl/LayerOpacityControl.scss
@@ -1,0 +1,33 @@
+@import 'src/client/style/partials';
+
+.geo-map-menu-layer-opacity-input-container {
+  display: flex;
+  margin: auto auto auto 5px;
+  width: 120px;
+  justify-content: space-between;
+  > div {
+    height: 100%;
+    vertical-align: middle;
+  }
+  .geo-map-menu-layer-opacity-input {
+    flex: 1;
+    margin-left: 0px;
+  }
+
+  .geo-map-menu-opacity-percentage-container {
+    margin-left: 15px;
+    width: 10px;
+  }
+
+  input {
+    height: 100%;
+    width: 100%;
+    vertical-align: middle;
+  }
+  small {
+    height: 100%;
+    vertical-align: middle;
+    font-size: normal;
+    font-weight: bold;
+  }
+}

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/LayerOpacityControl/LayerOpacityControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/LayerOpacityControl/LayerOpacityControl.tsx
@@ -1,0 +1,40 @@
+import './LayerOpacityControl.scss'
+import React, { useState } from 'react'
+
+import { LayerKey } from '@meta/geo'
+
+interface Props {
+  checked: boolean
+  onChange: (value: number, layerKey: LayerKey | 'global') => void
+  layerKey: LayerKey | 'global'
+}
+
+const LayerOpacityControl: React.FC<Props> = ({ checked, onChange, layerKey }) => {
+  const [opacity, setOpacity] = useState(0.5) // This will be changed to use redux instead
+
+  const handleOpacityChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const newValue = Math.round(Number(event.currentTarget.value) / 10) / 10
+    setOpacity(newValue)
+    onChange(newValue, layerKey)
+  }
+
+  return (
+    <div className="geo-map-menu-layer-opacity-input-container">
+      <div className="geo-map-menu-layer-opacity-input">
+        <input
+          type="range"
+          min="0"
+          max="100"
+          value={opacity * 100}
+          onChange={handleOpacityChange}
+          disabled={!checked}
+        />
+      </div>
+      <div className="geo-map-menu-opacity-percentage-container">
+        <small>{`${opacity * 100}%`}</small>
+      </div>
+    </div>
+  )
+}
+
+export default LayerOpacityControl

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/LayerOpacityControl/index.ts
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/LayerOpacityControl/index.ts
@@ -1,0 +1,1 @@
+export { default } from './LayerOpacityControl'

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/index.ts
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/index.ts
@@ -1,0 +1,1 @@
+export { default } from './LayersSectionPanel'

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/MapVisualizerPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/MapVisualizerPanel.tsx
@@ -1,10 +1,23 @@
 import './MapVisualizerPanel.scss'
 import React from 'react'
 
+import { sections } from '@meta/geo'
+
 import GeoMenuItem from '../../GeoMapMenuItem'
+import LayersSectionPanel from './LayersSectionPanel'
 
 const MapVisualizerPanel: React.FC = () => {
-  return <GeoMenuItem title="Section" checked={null} tabIndex={-1} />
+  return (
+    <div>
+      {sections.map((layerSection) => {
+        return (
+          <GeoMenuItem key={layerSection.key} title={layerSection.key} checked={null} tabIndex={0}>
+            <LayersSectionPanel section={layerSection} />
+          </GeoMenuItem>
+        )
+      })}
+    </div>
+  )
 }
 
 export default MapVisualizerPanel

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuListElement/GeoMapMenuListElement.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuListElement/GeoMapMenuListElement.tsx
@@ -24,12 +24,13 @@ const GeoMenuItem: React.FC<React.PropsWithChildren<Props>> = ({
   loadingStatus,
 }) => {
   let checkBoxContent = null
+  const style = checked ? { backgroundColor } : {}
   if (loadingStatus === LayerFetchStatus.Loading) {
     checkBoxContent = <div className="loading-spinner" />
   } else if (loadingStatus === LayerFetchStatus.Failed) {
     checkBoxContent = <div className={classNames('fra-checkbox', 'failed')} />
   } else {
-    checkBoxContent = <div className={classNames('fra-checkbox', { checked })} />
+    checkBoxContent = <div style={style} className={classNames('fra-checkbox', { checked })} />
   }
   return (
     <>
@@ -37,7 +38,7 @@ const GeoMenuItem: React.FC<React.PropsWithChildren<Props>> = ({
         <div className="geo-map-menu-item-title">
           {checked !== null ? (
             <div
-              className={`geo-map-menu-list-element-checkbox ${backgroundColor}`}
+              className="geo-map-menu-list-element-checkbox"
               role="checkbox"
               aria-checked={checked}
               tabIndex={tabIndex}

--- a/src/meta/geo/burnedAreaSource.ts
+++ b/src/meta/geo/burnedAreaSource.ts
@@ -19,6 +19,7 @@ export const burnedAreaLayers: LayerSection = {
     {
       key: BurnedAreaKey.MODIS_FIRE,
       options: { years: Arrays.range(2000, new Date().getFullYear() + 1, 1) },
+      metadata: burnedAreaLayersMetadata.MODIS_FIRE,
     },
   ],
 }


### PR DESCRIPTION
Added components to render the layers given the defined sections. The styles and structure of the components are taken from the previous implementation. The state of the components is local now, as they are simply a placeholder before implementing redux. This PR includes the component for inputting custom assets as well.

 

![Large GIF (1032x796)](https://user-images.githubusercontent.com/41337901/236264359-a6a70a5c-4456-4d61-aa2a-5f2d9ed8b1a8.gif)
