### PR TITLE
Geo refactor/add redux management to layers control

### DIFF
--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
@@ -1,7 +1,7 @@
 import './LayersSectionPanel.scss'
-import React from 'react'
+import React, { useState } from 'react'
 
-import { LayerKey, LayerSection } from '@meta/geo'
+import { GLOBAL_OPACITY_KEY, LayerKey, LayerSection } from '@meta/geo'
 
 import { useAppDispatch } from '@client/store'
 import { GeoActions, useGeoLayerSection } from '@client/store/ui/geo'
@@ -17,9 +17,15 @@ interface Props {
 const LayersSectionPanel: React.FC<React.PropsWithChildren<Props>> = ({ section }) => {
   const dispatch = useAppDispatch()
   const sectionState = useGeoLayerSection(section.key)
+  const [globalOpacity, setGlobalOpacity] = useState(0.5)
 
-  const handleOpacityChange = (value: number, layerKey: LayerKey | 'global') => {
-    return [value, layerKey] // Placeholder for logic
+  const handleOpacityChange = (opacity: number, layerKey: LayerKey | typeof GLOBAL_OPACITY_KEY) => {
+    if (layerKey === GLOBAL_OPACITY_KEY) {
+      setGlobalOpacity(opacity)
+      dispatch(GeoActions.setSectionGlobalOpacity({ sectionKey: section.key, opacity }))
+    } else {
+      dispatch(GeoActions.setLayerOpacity({ sectionKey: section.key, layerKey, opacity }))
+    }
   }
 
   const toggleLayer = (layerKey: LayerKey) => {
@@ -36,23 +42,29 @@ const LayersSectionPanel: React.FC<React.PropsWithChildren<Props>> = ({ section 
             tabIndex={0}
             checked={null}
           >
-            <LayerOpacityControl onChange={handleOpacityChange} checked layerKey="global" />
+            <LayerOpacityControl
+              onChange={handleOpacityChange}
+              checked
+              layerKey={GLOBAL_OPACITY_KEY}
+              opacity={globalOpacity}
+            />
           </GeoMapMenuListElement>
         )}
         {section.layers.map((layer) => {
           const isLayerSelected = sectionState?.[layer.key]?.selected || false // default to false
+          const opacity = sectionState?.[layer.key]?.opacity ?? 1
           if (layer.isCustomAsset)
             return (
               <CustomAssetControl
                 key={`${section.key}-${layer.key}`}
                 onToggle={toggleLayer}
                 onOpacityChange={handleOpacityChange}
+                opacity={opacity}
                 checked={isLayerSelected}
                 layerKey={layer.key}
                 backgroundColor={layer.metadata?.palette?.[0]}
               />
             )
-
           return (
             <GeoMapMenuListElement
               key={`${section.key}-${layer.key}`}
@@ -62,7 +74,12 @@ const LayersSectionPanel: React.FC<React.PropsWithChildren<Props>> = ({ section 
               onCheckboxClick={() => toggleLayer(layer.key)}
               backgroundColor={layer.metadata?.palette?.[0]}
             >
-              <LayerOpacityControl onChange={handleOpacityChange} checked={isLayerSelected} layerKey={layer.key} />
+              <LayerOpacityControl
+                onChange={handleOpacityChange}
+                checked={isLayerSelected}
+                layerKey={layer.key}
+                opacity={opacity}
+              />
             </GeoMapMenuListElement>
           )
         })}

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
@@ -61,6 +61,7 @@ const LayersSectionPanel: React.FC<React.PropsWithChildren<Props>> = ({ section 
                 onOpacityChange={handleOpacityChange}
                 opacity={opacity}
                 checked={isLayerSelected}
+                sectionKey={section.key}
                 layerKey={layer.key}
                 backgroundColor={layer.metadata?.palette?.[0]}
               />

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
@@ -1,7 +1,10 @@
 import './LayersSectionPanel.scss'
-import React, { useState } from 'react'
+import React from 'react'
 
 import { LayerKey, LayerSection } from '@meta/geo'
+
+import { useAppDispatch } from '@client/store'
+import { GeoActions, useGeoLayerSection } from '@client/store/ui/geo'
 
 import GeoMapMenuListElement from '../../../GeoMapMenuListElement'
 import CustomAssetControl from './components/CustomAssetControl'
@@ -12,14 +15,15 @@ interface Props {
 }
 
 const LayersSectionPanel: React.FC<React.PropsWithChildren<Props>> = ({ section }) => {
+  const dispatch = useAppDispatch()
+  const sectionState = useGeoLayerSection(section.key)
+
   const handleOpacityChange = (value: number, layerKey: LayerKey | 'global') => {
     return [value, layerKey] // Placeholder for logic
   }
-  const [checked, setChecked] = useState(false)
 
   const toggleLayer = (layerKey: LayerKey) => {
-    setChecked((current) => !current)
-    return layerKey // Placeholder for logic
+    dispatch(GeoActions.toggleLayer({ sectionKey: section.key, layerKey }))
   }
 
   return (
@@ -36,13 +40,14 @@ const LayersSectionPanel: React.FC<React.PropsWithChildren<Props>> = ({ section 
           </GeoMapMenuListElement>
         )}
         {section.layers.map((layer) => {
+          const isLayerSelected = sectionState?.[layer.key]?.selected || false // default to false
           if (layer.isCustomAsset)
             return (
               <CustomAssetControl
                 key={`${section.key}-${layer.key}`}
                 onToggle={toggleLayer}
                 onOpacityChange={handleOpacityChange}
-                checked={checked}
+                checked={isLayerSelected}
                 layerKey={layer.key}
                 backgroundColor={layer.metadata?.palette?.[0]}
               />
@@ -53,11 +58,11 @@ const LayersSectionPanel: React.FC<React.PropsWithChildren<Props>> = ({ section 
               key={`${section.key}-${layer.key}`}
               title={layer.key}
               tabIndex={0}
-              checked={checked}
+              checked={isLayerSelected}
               onCheckboxClick={() => toggleLayer(layer.key)}
               backgroundColor={layer.metadata?.palette?.[0]}
             >
-              <LayerOpacityControl onChange={handleOpacityChange} checked={checked} layerKey={layer.key} />
+              <LayerOpacityControl onChange={handleOpacityChange} checked={isLayerSelected} layerKey={layer.key} />
             </GeoMapMenuListElement>
           )
         })}

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.tsx
@@ -9,13 +9,21 @@ import LayerOpacityControl from '../LayerOpacityControl'
 
 interface Props {
   checked: boolean
+  opacity: number
   onOpacityChange: (value: number, layerKey: LayerKey) => void
   onToggle: (layerKey: LayerKey) => void
   layerKey: LayerKey
   backgroundColor?: string
 }
 
-const CustomAssetControl: React.FC<Props> = ({ checked, onToggle, onOpacityChange, layerKey, backgroundColor }) => {
+const CustomAssetControl: React.FC<Props> = ({
+  checked,
+  opacity,
+  onToggle,
+  onOpacityChange,
+  layerKey,
+  backgroundColor,
+}) => {
   const [inputValue, setInputValue] = useState<string>('')
   const [inputError, setInputError] = useState(false)
 
@@ -61,7 +69,7 @@ const CustomAssetControl: React.FC<Props> = ({ checked, onToggle, onOpacityChang
             </button>
           </div>
         </div>
-        <LayerOpacityControl layerKey={layerKey} checked={checked} onChange={onOpacityChange} />
+        <LayerOpacityControl layerKey={layerKey} checked={checked} onChange={onOpacityChange} opacity={opacity} />
       </div>
       <div className="custom-asset-list-element-bottom" />
     </>

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.tsx
@@ -3,7 +3,10 @@ import React, { ChangeEvent, useState } from 'react'
 
 import classNames from 'classnames'
 
-import { LayerKey } from '@meta/geo'
+import { LayerKey, LayerSectionKey } from '@meta/geo'
+
+import { useAppDispatch } from '@client/store'
+import { GeoActions, useGeoLayer } from '@client/store/ui/geo'
 
 import LayerOpacityControl from '../LayerOpacityControl'
 
@@ -12,6 +15,7 @@ interface Props {
   opacity: number
   onOpacityChange: (value: number, layerKey: LayerKey) => void
   onToggle: (layerKey: LayerKey) => void
+  sectionKey: LayerSectionKey
   layerKey: LayerKey
   backgroundColor?: string
 }
@@ -21,10 +25,14 @@ const CustomAssetControl: React.FC<Props> = ({
   opacity,
   onToggle,
   onOpacityChange,
+  sectionKey,
   layerKey,
   backgroundColor,
 }) => {
-  const [inputValue, setInputValue] = useState<string>('')
+  const dispatch = useAppDispatch()
+  const layerState = useGeoLayer(sectionKey, layerKey)
+
+  const [inputValue, setInputValue] = useState<string>(layerState?.assetId ?? '')
   const [inputError, setInputError] = useState(false)
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
@@ -39,6 +47,8 @@ const CustomAssetControl: React.FC<Props> = ({
       setInputError(true)
     } else {
       setInputError(false)
+      dispatch(GeoActions.setAssetId({ sectionKey, layerKey, assetId: inputValue.trim() }))
+      dispatch(GeoActions.resetLayerStatus({ sectionKey, layerKey }))
     }
   }
 

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/LayerOpacityControl/LayerOpacityControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/LayerOpacityControl/LayerOpacityControl.tsx
@@ -1,37 +1,31 @@
 import './LayerOpacityControl.scss'
-import React, { useState } from 'react'
+import React from 'react'
 
-import { LayerKey } from '@meta/geo'
+import { GLOBAL_OPACITY_KEY, LayerKey } from '@meta/geo'
 
 interface Props {
   checked: boolean
-  onChange: (value: number, layerKey: LayerKey | 'global') => void
-  layerKey: LayerKey | 'global'
+  onChange: (value: number, layerKey: LayerKey | typeof GLOBAL_OPACITY_KEY) => void
+  layerKey: LayerKey | typeof GLOBAL_OPACITY_KEY
+  opacity: number
 }
 
-const LayerOpacityControl: React.FC<Props> = ({ checked, onChange, layerKey }) => {
-  const [opacity, setOpacity] = useState(0.5) // This will be changed to use redux instead
-
+const LayerOpacityControl: React.FC<Props> = ({ checked, onChange, layerKey, opacity }) => {
   const handleOpacityChange = (event: React.FormEvent<HTMLInputElement>) => {
     const newValue = Math.round(Number(event.currentTarget.value) / 10) / 10
-    setOpacity(newValue)
     onChange(newValue, layerKey)
   }
+
+  // Avoid undefined warnings
+  const opacityValue = opacity !== undefined ? opacity * 100 : 100
 
   return (
     <div className="geo-map-menu-layer-opacity-input-container">
       <div className="geo-map-menu-layer-opacity-input">
-        <input
-          type="range"
-          min="0"
-          max="100"
-          value={opacity * 100}
-          onChange={handleOpacityChange}
-          disabled={!checked}
-        />
+        <input type="range" min="0" max="100" value={opacityValue} onChange={handleOpacityChange} disabled={!checked} />
       </div>
       <div className="geo-map-menu-opacity-percentage-container">
-        <small>{`${opacity * 100}%`}</small>
+        <small>{`${opacityValue}%`}</small>
       </div>
     </div>
   )

--- a/src/client/store/ui/geo/hooks/index.ts
+++ b/src/client/store/ui/geo/hooks/index.ts
@@ -1,7 +1,9 @@
 import { CountryIso } from '@meta/area'
-import { GeoStatisticsState, MapPanel, MosaicOptions } from '@meta/geo'
+import { GeoStatisticsState, LayerSectionKey, MapPanel, MosaicOptions } from '@meta/geo'
 
 import { useAppSelector } from '@client/store'
+
+import { LayersSectionState } from '../stateType'
 
 export const useMosaicUrl = (countryIso: CountryIso): string =>
   useAppSelector((state) => state.geo?.mosaicOptions.mosaicUrl[countryIso])
@@ -21,3 +23,6 @@ export const useSelectedPanel = (): MapPanel => useAppSelector((state) => state.
 export const useIsGeoMapAvailable = (): boolean => useAppSelector((state) => state.geo?.isMapAvailable)
 
 export const useGeoStatistics = (): GeoStatisticsState => useAppSelector((state) => state.geo?.geoStatistics)
+
+export const useGeoLayerSection = (sectionKey: LayerSectionKey): LayersSectionState | undefined =>
+  useAppSelector((state) => state.geo.sections[sectionKey])

--- a/src/client/store/ui/geo/hooks/index.ts
+++ b/src/client/store/ui/geo/hooks/index.ts
@@ -1,9 +1,9 @@
 import { CountryIso } from '@meta/area'
-import { GeoStatisticsState, LayerSectionKey, MapPanel, MosaicOptions } from '@meta/geo'
+import { GeoStatisticsState, LayerKey, LayerSectionKey, MapPanel, MosaicOptions } from '@meta/geo'
 
 import { useAppSelector } from '@client/store'
 
-import { LayersSectionState } from '../stateType'
+import { LayersSectionState, LayerState } from '../stateType'
 
 export const useMosaicUrl = (countryIso: CountryIso): string =>
   useAppSelector((state) => state.geo?.mosaicOptions.mosaicUrl[countryIso])
@@ -26,3 +26,6 @@ export const useGeoStatistics = (): GeoStatisticsState => useAppSelector((state)
 
 export const useGeoLayerSection = (sectionKey: LayerSectionKey): LayersSectionState | undefined =>
   useAppSelector((state) => state.geo.sections[sectionKey])
+
+export const useGeoLayer = (sectionKey: LayerSectionKey, layerKey: LayerKey): LayerState | undefined =>
+  useAppSelector((state) => state.geo.sections[sectionKey]?.[layerKey])

--- a/src/client/store/ui/geo/index.ts
+++ b/src/client/store/ui/geo/index.ts
@@ -1,5 +1,6 @@
 export {
   useAppliedMosaicOptions,
+  useGeoLayerSection,
   useGeoStatistics,
   useIsGeoMapAvailable,
   useMosaicFailed,

--- a/src/client/store/ui/geo/index.ts
+++ b/src/client/store/ui/geo/index.ts
@@ -1,5 +1,6 @@
 export {
   useAppliedMosaicOptions,
+  useGeoLayer,
   useGeoLayerSection,
   useGeoStatistics,
   useIsGeoMapAvailable,

--- a/src/client/store/ui/geo/slice.ts
+++ b/src/client/store/ui/geo/slice.ts
@@ -141,12 +141,12 @@ export const geoSlice = createSlice({
       state.sections[sectionKey][layerKey] = { ...layerState, opacity }
     },
     setAssetId: (
-      state,
-      {
-        payload: { sectionKey, layerKey, assetId },
-      }: PayloadAction<{ sectionKey: LayerSectionKey; layerKey: LayerKey; assetId: string }>
+      state: Draft<GeoState>,
+      action: PayloadAction<{ sectionKey: LayerSectionKey; layerKey: LayerKey; assetId: string }>
     ) => {
-      state.sections[sectionKey][layerKey].assetId = assetId
+      const { sectionKey, layerKey, assetId } = action.payload
+      const layerState = getLayerState(state, sectionKey, layerKey)
+      state.sections[sectionKey][layerKey] = { ...layerState, assetId }
     },
     setLayerMinTreeCoverPercentage: (
       state,
@@ -199,10 +199,12 @@ export const geoSlice = createSlice({
       })
     },
     resetLayerStatus: (
-      state,
-      { payload: { sectionKey, layerKey } }: PayloadAction<{ sectionKey: LayerSectionKey; layerKey: LayerKey }>
+      state: Draft<GeoState>,
+      action: PayloadAction<{ sectionKey: LayerSectionKey; layerKey: LayerKey }>
     ) => {
-      state.sections[sectionKey][layerKey].status = LayerFetchStatus.Unfetched
+      const { sectionKey, layerKey } = action.payload
+      const layerState = getLayerState(state, sectionKey, layerKey)
+      state.sections[sectionKey][layerKey] = { ...layerState, status: LayerFetchStatus.Unfetched }
     },
     resetAllLayersStatus: (state) => {
       Object.keys(state.sections).forEach((sectionKey) => {

--- a/src/client/store/ui/geo/stateType.ts
+++ b/src/client/store/ui/geo/stateType.ts
@@ -23,12 +23,12 @@ export type LayerStateOptions = {
 }
 
 export type LayerState = {
-  selected: boolean
-  opacity: number
-  status: LayerFetchStatus
+  selected?: boolean
+  opacity?: number
+  status?: LayerFetchStatus
   assetId?: string
   options?: LayerStateOptions
-  mapId: string | null
+  mapId?: string
 }
 
 export type LayersSectionState = Record<LayerKey, LayerState>

--- a/src/meta/geo/index.ts
+++ b/src/meta/geo/index.ts
@@ -15,5 +15,5 @@ export type { Layer, LayerConfig, LayerKey, LayerMetadata, LayerOptions, LayerSe
 export { LayerSectionKey } from './layer'
 export type { MosaicOptions, MosaicSource } from './mosaic'
 export { ProtectedAreaKey, protectedAreaLayers, protectedAreaLayersMetadata } from './protectedAreaSource'
-export { sections } from './sections'
+export { GLOBAL_OPACITY_KEY, sections } from './sections'
 export type { MapPanel } from './ui'

--- a/src/meta/geo/sections.ts
+++ b/src/meta/geo/sections.ts
@@ -1,3 +1,5 @@
 import { burnedAreaLayers, forestLayers, LayerSection, protectedAreaLayers } from '.'
 
 export const sections: Array<LayerSection> = [forestLayers, burnedAreaLayers, protectedAreaLayers]
+
+export const GLOBAL_OPACITY_KEY = 'global_opacity'


### PR DESCRIPTION
Adding redux state management to toggle layers, change opacity, and set the custom assets id.


![Large GIF (1074x478)](https://user-images.githubusercontent.com/41337901/236540111-b408eca1-7549-4d18-ab04-09e9008b6555.gif)



