### PR TITLE
Geo refactor/handle custom asset layers

### DIFF
--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
@@ -88,6 +88,7 @@ const LayersSectionPanel: React.FC<React.PropsWithChildren<Props>> = ({ section 
                 sectionKey={section.key}
                 layerKey={layer.key}
                 backgroundColor={layer.metadata?.palette?.[0]}
+                loadingStatus={loadingStatus}
               />
             )
           return (

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.tsx
@@ -7,6 +7,7 @@ import { LayerKey, LayerSectionKey } from '@meta/geo'
 
 import { useAppDispatch } from '@client/store'
 import { GeoActions, useGeoLayer } from '@client/store/ui/geo'
+import { LayerFetchStatus } from '@client/store/ui/geo/stateType'
 
 import LayerOpacityControl from '../LayerOpacityControl'
 
@@ -18,6 +19,7 @@ interface Props {
   sectionKey: LayerSectionKey
   layerKey: LayerKey
   backgroundColor?: string
+  loadingStatus: LayerFetchStatus
 }
 
 const CustomAssetControl: React.FC<Props> = ({
@@ -28,11 +30,12 @@ const CustomAssetControl: React.FC<Props> = ({
   sectionKey,
   layerKey,
   backgroundColor,
+  loadingStatus,
 }) => {
   const dispatch = useAppDispatch()
   const layerState = useGeoLayer(sectionKey, layerKey)
 
-  const [inputValue, setInputValue] = useState<string>(layerState?.assetId ?? '')
+  const [inputValue, setInputValue] = useState<string>(layerState?.options?.assetId ?? '')
   const [inputError, setInputError] = useState(false)
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
@@ -64,7 +67,15 @@ const CustomAssetControl: React.FC<Props> = ({
             onClick={() => onToggle(layerKey)}
             onKeyDown={() => onToggle(layerKey)}
           >
-            <div style={checked ? { backgroundColor } : {}} className={classNames('fra-checkbox', { checked })} />
+            <div
+              style={checked && loadingStatus !== LayerFetchStatus.Loading ? { backgroundColor } : {}}
+              className={classNames({
+                'fra-checkbox': loadingStatus !== LayerFetchStatus.Loading,
+                checked,
+                'loading-spinner': loadingStatus === LayerFetchStatus.Loading,
+                failed: loadingStatus === LayerFetchStatus.Failed,
+              })}
+            />
           </div>
           <div className="custom-input-container">
             <input
@@ -72,7 +83,7 @@ const CustomAssetControl: React.FC<Props> = ({
               value={inputValue}
               onChange={handleInputChange}
               placeholder="Asset ID"
-              className={classNames('custom-input', inputError ? 'error' : '')}
+              className={classNames('custom-input', { error: inputError })}
             />
             <button type="button" className="btn-primary" onClick={handleSubmit}>
               Submit

--- a/src/client/store/ui/geo/slice.ts
+++ b/src/client/store/ui/geo/slice.ts
@@ -15,7 +15,7 @@ import { mapController } from '@client/utils'
 
 import { postMosaicOptions } from './actions/postMosaicOptions'
 import { getForestEstimationData, postLayer } from './actions'
-import { GeoState, LayerFetchStatus, LayersSectionState, LayerState } from './stateType'
+import { GeoState, LayerFetchStatus, LayersSectionState, LayerState, LayerStateOptions } from './stateType'
 
 const initialMosaicOptions: MosaicOptions = {
   sources: ['landsat'],
@@ -54,6 +54,16 @@ const getLayerState = (state: Draft<GeoState>, sectionKey: LayerSectionKey, laye
   const sectionState = getSectionState(state, sectionKey)
   sectionState[layerKey] ??= {}
   return sectionState[layerKey]
+}
+
+const getLayerStateOptions = (
+  state: Draft<GeoState>,
+  sectionKey: LayerSectionKey,
+  layerKey: LayerKey
+): LayerStateOptions => {
+  const layerState = getLayerState(state, sectionKey, layerKey)
+  layerState.options ??= {}
+  return layerState.options
 }
 
 const handlePostLayerStatus = (
@@ -195,8 +205,8 @@ export const geoSlice = createSlice({
       action: PayloadAction<{ sectionKey: LayerSectionKey; layerKey: LayerKey; assetId: string }>
     ) => {
       const { sectionKey, layerKey, assetId } = action.payload
-      const layerState = getLayerState(state, sectionKey, layerKey)
-      state.sections[sectionKey][layerKey] = { ...layerState, assetId }
+      const layerStateOptions = getLayerStateOptions(state, sectionKey, layerKey)
+      state.sections[sectionKey][layerKey].options = { ...layerStateOptions, assetId }
     },
     setLayerMinTreeCoverPercentage: (
       state,

--- a/src/client/store/ui/geo/stateType.ts
+++ b/src/client/store/ui/geo/stateType.ts
@@ -17,6 +17,7 @@ export type AgreementLevelState = {
 // Similar to the type LayerOptions, but in this case it has the selected
 // value instead of the list options.
 export type LayerStateOptions = {
+  assetId?: string
   minTreeCoverPercentage?: number
   agreementLayer?: AgreementLevelState
   year?: number
@@ -26,7 +27,6 @@ export type LayerState = {
   selected?: boolean
   opacity?: number
   status?: LayerFetchStatus
-  assetId?: string
   options?: LayerStateOptions
   mapId?: string
 }


### PR DESCRIPTION
Added logic to handle custom asset layers:


![Large GIF (736x662)](https://user-images.githubusercontent.com/41337901/236682922-bd274f31-a96c-4f38-b258-4e6b459a3c5b.gif)
