### PR TITLE
2584 - Remove pound/sharp sign workaround

### DIFF
--- a/src/client/pages/Login/LoginForm/LoginForm.tsx
+++ b/src/client/pages/Login/LoginForm/LoginForm.tsx
@@ -24,7 +24,7 @@ const LoginForm: React.FC = () => {
   const { t } = useTranslation()
   const { toaster } = useToaster()
 
-  const loginError = Urls.getRequestParam('loginError')
+  const loginError = Urls.getRequestParam('loginError')?.replace('#', '')
 
   const [isLocal, setIsLocal] = useState<boolean>(false)
   const [email, setEmail] = useState<string>('')

--- a/src/server/api/auth/strategy/google.ts
+++ b/src/server/api/auth/strategy/google.ts
@@ -87,10 +87,8 @@ const googleStrategyVerifyCallback = async (
 }
 
 export const googleStrategy = (passport: PassportStatic) => {
-  const GoogleOAuth2Strategy = GoogleStrategy.OAuth2Strategy
-
   passport.use(
-    new GoogleOAuth2Strategy(
+    new GoogleStrategy.OAuth2Strategy(
       {
         clientID: process.env.FRA_GOOGLE_CLIENT_ID,
         clientSecret: process.env.FRA_GOOGLE_CLIENT_SECRET,


### PR DESCRIPTION
close #2584

it seems to be a problem related only to Safari.

the redirect url composition is correct.

https://user-images.githubusercontent.com/10047945/236824409-08b607b9-0957-4687-9739-109b3d3db432.mov

