### PR TITLE
Geo refactor/fetch custom asset layer on submit

### DIFF
--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
@@ -2,11 +2,11 @@ import './LayersSectionPanel.scss'
 import React, { useState } from 'react'
 import { batch } from 'react-redux'
 
-import { LayerRequestBody } from '@meta/api/request/geo/layer'
 import { GLOBAL_OPACITY_KEY, LayerKey, LayerSection, sectionsApiEndpoint } from '@meta/geo'
 
 import { useAppDispatch } from '@client/store'
 import { GeoActions, useGeoLayerSection } from '@client/store/ui/geo'
+import { _getLayerRequestBody } from '@client/store/ui/geo/actions'
 import { LayerFetchStatus } from '@client/store/ui/geo/stateType'
 import { useCountryIso } from '@client/hooks'
 
@@ -40,13 +40,7 @@ const LayersSectionPanel: React.FC<React.PropsWithChildren<Props>> = ({ section 
     batch(() => {
       // If the layer is selected and doesn't have a mapId cached, fetch it
       if (newSelectedState && !currentMapId) {
-        const requestBody: LayerRequestBody = {
-          countryIso,
-          layer: {
-            key: layerKey as LayerKey,
-            ...(layerState?.options && { options: { ...layerState.options } }),
-          },
-        }
+        const requestBody = _getLayerRequestBody(countryIso, layerKey, layerState)
         const uri = sectionsApiEndpoint[section.key]
         dispatch(GeoActions.postLayer({ sectionKey: section.key, layerKey, uri, body: requestBody }))
       }

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
@@ -7,7 +7,6 @@ import { GLOBAL_OPACITY_KEY, LayerKey, LayerSection, sectionsApiEndpoint } from 
 
 import { useAppDispatch } from '@client/store'
 import { GeoActions, useGeoLayerSection } from '@client/store/ui/geo'
-import { postLayer } from '@client/store/ui/geo/actions'
 import { LayerFetchStatus } from '@client/store/ui/geo/stateType'
 import { useCountryIso } from '@client/hooks'
 
@@ -49,7 +48,7 @@ const LayersSectionPanel: React.FC<React.PropsWithChildren<Props>> = ({ section 
           },
         }
         const uri = sectionsApiEndpoint[section.key]
-        dispatch(postLayer({ sectionKey: section.key, layerKey, uri, body: requestBody }))
+        dispatch(GeoActions.postLayer({ sectionKey: section.key, layerKey, uri, body: requestBody }))
       }
       dispatch(GeoActions.toggleLayer({ sectionKey: section.key, layerKey }))
     })

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
@@ -2,11 +2,10 @@ import './LayersSectionPanel.scss'
 import React, { useState } from 'react'
 import { batch } from 'react-redux'
 
-import { GLOBAL_OPACITY_KEY, LayerKey, LayerSection, sectionsApiEndpoint } from '@meta/geo'
+import { GLOBAL_OPACITY_KEY, LayerKey, LayerSection } from '@meta/geo'
 
 import { useAppDispatch } from '@client/store'
 import { GeoActions, useGeoLayerSection } from '@client/store/ui/geo'
-import { _getLayerRequestBody } from '@client/store/ui/geo/actions'
 import { LayerFetchStatus } from '@client/store/ui/geo/stateType'
 import { useCountryIso } from '@client/hooks'
 
@@ -40,9 +39,7 @@ const LayersSectionPanel: React.FC<React.PropsWithChildren<Props>> = ({ section 
     batch(() => {
       // If the layer is selected and doesn't have a mapId cached, fetch it
       if (newSelectedState && !currentMapId) {
-        const requestBody = _getLayerRequestBody(countryIso, layerKey, layerState)
-        const uri = sectionsApiEndpoint[section.key]
-        dispatch(GeoActions.postLayer({ sectionKey: section.key, layerKey, uri, body: requestBody }))
+        dispatch(GeoActions.postLayer({ countryIso, sectionKey: section.key, layerKey, layerState }))
       }
       dispatch(GeoActions.toggleLayer({ sectionKey: section.key, layerKey }))
     })

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.tsx
@@ -3,11 +3,10 @@ import React, { ChangeEvent, useState } from 'react'
 
 import classNames from 'classnames'
 
-import { LayerKey, LayerSectionKey, sectionsApiEndpoint } from '@meta/geo'
+import { LayerKey, LayerSectionKey } from '@meta/geo'
 
 import { useAppDispatch } from '@client/store'
 import { GeoActions, useGeoLayer } from '@client/store/ui/geo'
-import { _getLayerRequestBody } from '@client/store/ui/geo/actions'
 import { LayerFetchStatus } from '@client/store/ui/geo/stateType'
 import { useCountryIso } from '@client/hooks'
 
@@ -51,9 +50,7 @@ const CustomAssetControl: React.FC<Props> = ({
       setValidInput(false)
     } else {
       setValidInput(true)
-      const requestBody = _getLayerRequestBody(countryIso, layerKey, layerState)
-      const uri = sectionsApiEndpoint[sectionKey]
-      dispatch(GeoActions.postLayer({ sectionKey, layerKey, uri, body: requestBody }))
+      dispatch(GeoActions.postLayer({ countryIso, sectionKey, layerKey, layerState }))
     }
   }
 

--- a/src/client/store/ui/geo/actions/_getLayerRequestBody.ts
+++ b/src/client/store/ui/geo/actions/_getLayerRequestBody.ts
@@ -1,0 +1,20 @@
+import { LayerRequestBody } from '@meta/api/request/geo/layer'
+import { CountryIso } from '@meta/area'
+import { LayerKey } from '@meta/geo'
+
+import { LayerState } from '../stateType'
+
+export const _getLayerRequestBody = (
+  countryIso: CountryIso,
+  layerKey: LayerKey,
+  layerState: LayerState
+): LayerRequestBody => {
+  const requestBody: LayerRequestBody = {
+    countryIso,
+    layer: {
+      key: layerKey,
+      ...(layerState?.options && { options: { ...layerState.options } }),
+    },
+  }
+  return requestBody
+}

--- a/src/client/store/ui/geo/actions/index.ts
+++ b/src/client/store/ui/geo/actions/index.ts
@@ -1,3 +1,4 @@
+export { _getLayerRequestBody } from './_getLayerRequestBody'
 export { getForestEstimationData } from './getForestEstimationData'
 export { postLayer } from './postLayer'
 export { postMosaicOptions } from './postMosaicOptions'

--- a/src/client/store/ui/geo/actions/postLayer.ts
+++ b/src/client/store/ui/geo/actions/postLayer.ts
@@ -1,22 +1,27 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import axios from 'axios'
 
-import { LayerRequestBody } from '@meta/api/request/geo/layer'
-import { LayerKey, LayerSectionKey } from '@meta/geo'
+import { CountryIso } from '@meta/area'
+import { LayerKey, LayerSectionKey, sectionsApiEndpoint } from '@meta/geo'
+
+import { LayerState } from '../stateType'
+import { _getLayerRequestBody } from '.'
 
 export interface PostLayerProps {
+  countryIso: CountryIso
   sectionKey: LayerSectionKey
   layerKey: LayerKey
-  uri: string
-  body: LayerRequestBody
+  layerState: LayerState
 }
 
 export const postLayer = createAsyncThunk<[LayerSectionKey, LayerKey, string], PostLayerProps>(
   'geo/post/layer',
-  async ({ sectionKey, layerKey, uri, body }) => {
+  async ({ countryIso, sectionKey, layerKey, layerState }) => {
+    const body = _getLayerRequestBody(countryIso, layerKey, layerState)
+    const url = sectionsApiEndpoint[sectionKey]
     const {
       data: { mapId },
-    } = await axios({ method: 'POST', url: uri, data: body })
+    } = await axios({ method: 'POST', url, data: body })
     return [sectionKey, layerKey, mapId]
   }
 )

--- a/src/client/store/ui/geo/slice.ts
+++ b/src/client/store/ui/geo/slice.ts
@@ -323,6 +323,7 @@ export const geoSlice = createSlice({
 export const GeoActions = {
   ...geoSlice.actions,
   postMosaicOptions,
+  postLayer,
 }
 
 export default geoSlice.reducer as Reducer<GeoState>

--- a/src/client/store/ui/geo/slice.ts
+++ b/src/client/store/ui/geo/slice.ts
@@ -1,15 +1,7 @@
 import type { Draft, PayloadAction } from '@reduxjs/toolkit'
 import { createSlice, Reducer } from '@reduxjs/toolkit'
 
-import {
-  ForestEstimations,
-  ForestKey,
-  LayerKey,
-  LayerSectionKey,
-  MapLayerKey,
-  MosaicOptions,
-  MosaicSource,
-} from '@meta/geo'
+import { ForestEstimations, LayerKey, LayerSectionKey, MapLayerKey, MosaicOptions, MosaicSource } from '@meta/geo'
 
 import { mapController } from '@client/utils'
 
@@ -250,7 +242,7 @@ export const geoSlice = createSlice({
       const sectionState = getSectionState(state, sectionKey)
 
       Object.keys(sectionState).forEach((layerKey) => {
-        if (layerKey === ForestKey.Agreement) return // Ignore the agreement layer
+        if (layerKey === 'Agreement') return // Ignore any agreement layer
 
         const layerSelectState = state.sections[sectionKey][layerKey as LayerKey].selected
         if (layerSelectState === undefined || !layerSelectState) return // Ignore non-selected layers


### PR DESCRIPTION
Added fixes:
- Call postLayer action from GeoActions
- Ignore any Agreement layer for global opacity changes

Also added a new function `_getLayerRequestBody`, and finally, added the logic to fetch the layer on submit and removed the local `assetId` state. The `validInput` state remained local as we don't store the validity of the `assetId` in redux, it is just a check to highlight the input field if it is empty. 


![Large GIF (736x662)](https://github.com/openforis/fra-platform/assets/41337901/9d22ac3b-0ab4-4c9f-8e5b-8672593c2a52)


