### PR TITLE
Geo refactor/handle gte tree cover percent layers

### DIFF
--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/TreeCoverPercentageControl/TreeCoverPercentageControl.scss
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/TreeCoverPercentageControl/TreeCoverPercentageControl.scss
@@ -1,0 +1,63 @@
+@import 'src/client/style/partials';
+@import 'src/client/styles/config';
+@import 'src/client/styles/buttons';
+
+.geo-map-menu-tree-cover-inputs {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 0px 25px 0px 25px;
+
+  > div {
+    flex-direction: row;
+    margin: 0 0 0 0;
+    min-height: 40px;
+    justify-content: space-between;
+
+    > p {
+      font-size: $font-l;
+      text-justify: left;
+      width: 165px;
+      margin: 0 auto 0 0;
+      display: inline-block;
+      vertical-align: middle;
+    }
+
+    > div {
+      display: inline-block;
+      width: 80%;
+      vertical-align: middle;
+      margin: 0 0 10px 0;
+
+      input {
+        width: 200px;
+        vertical-align: middle;
+        margin: 0 10px 0 auto;
+      }
+      fieldset {
+        display: flex;
+        flex-direction: row;
+        border: 1px solid $ui-border;
+        justify-content: space-between;
+        > label {
+          display: flex;
+          margin: 10px 0 5px 0;
+          width: 15%;
+          flex-direction: column;
+          > input[type='radio'] {
+            display: flex;
+            padding: 5px;
+            width: 100%;
+            margin-left: 0px;
+            align-self: center;
+          }
+        }
+      }
+      small {
+        vertical-align: middle;
+        font-size: normal;
+        font-weight: bold;
+      }
+    }
+  }
+}

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/TreeCoverPercentageControl/TreeCoverPercentageControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/TreeCoverPercentageControl/TreeCoverPercentageControl.tsx
@@ -1,0 +1,50 @@
+import './TreeCoverPercentageControl.scss'
+import React from 'react'
+
+import { Layer, LayerKey, LayerSectionKey } from '@meta/geo'
+
+import { useAppDispatch } from '@client/store'
+import { GeoActions } from '@client/store/ui/geo'
+import { LayerState } from '@client/store/ui/geo/stateType'
+
+interface Props {
+  sectionKey: LayerSectionKey
+  layerKey: LayerKey
+  layer: Layer
+  layerState: LayerState
+}
+const TreeCoverPercentageControl: React.FC<Props> = ({ sectionKey, layerKey, layerState, layer }) => {
+  const dispatch = useAppDispatch()
+
+  const handlePercentageChange = (percentage: number) => {
+    dispatch(GeoActions.setLayerGteTreeCoverPercent({ sectionKey, layerKey, gteTreeCoverPercent: percentage }))
+  }
+
+  return (
+    <div className="geo-map-menu-tree-cover-inputs ">
+      <div>
+        <div>
+          <p>Select min. tree cover percentage:</p>
+          <fieldset>
+            {layer.options?.gteTreeCoverPercent.map((percentage) => {
+              const id = `${sectionKey}-${layerKey}-${percentage}`
+              return (
+                <label htmlFor={id} key={id}>
+                  <input
+                    type="radio"
+                    checked={layerState?.options?.gteTreeCoverPercent === percentage}
+                    id={id}
+                    onChange={() => handlePercentageChange(percentage)}
+                  />
+                  <small>{percentage} %</small>
+                </label>
+              )
+            })}
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default TreeCoverPercentageControl

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/TreeCoverPercentageControl/TreeCoverPercentageControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/TreeCoverPercentageControl/TreeCoverPercentageControl.tsx
@@ -5,6 +5,7 @@ import { Layer, LayerKey, LayerSectionKey } from '@meta/geo'
 
 import { useAppDispatch } from '@client/store'
 import { GeoActions } from '@client/store/ui/geo'
+import { useGteTreeCoverPercent } from '@client/store/ui/geo/hooks/'
 import { LayerState } from '@client/store/ui/geo/stateType'
 
 interface Props {
@@ -15,6 +16,8 @@ interface Props {
 }
 const TreeCoverPercentageControl: React.FC<Props> = ({ sectionKey, layerKey, layerState, layer }) => {
   const dispatch = useAppDispatch()
+
+  useGteTreeCoverPercent(sectionKey, layerKey)
 
   const handlePercentageChange = (percentage: number) => {
     dispatch(GeoActions.setLayerGteTreeCoverPercent({ sectionKey, layerKey, gteTreeCoverPercent: percentage }))

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/TreeCoverPercentageControl/index.ts
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/TreeCoverPercentageControl/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TreeCoverPercentageControl'

--- a/src/client/store/ui/geo/hooks/index.ts
+++ b/src/client/store/ui/geo/hooks/index.ts
@@ -29,3 +29,5 @@ export const useGeoLayerSection = (sectionKey: LayerSectionKey): LayersSectionSt
 
 export const useGeoLayer = (sectionKey: LayerSectionKey, layerKey: LayerKey): LayerState | undefined =>
   useAppSelector((state) => state.geo.sections[sectionKey]?.[layerKey])
+
+export { useGteTreeCoverPercent } from './useGteTreeCoverPercent'

--- a/src/client/store/ui/geo/hooks/useGteTreeCoverPercent.ts
+++ b/src/client/store/ui/geo/hooks/useGteTreeCoverPercent.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+
+import { LayerKey, LayerSectionKey } from '@meta/geo'
+
+import { useAppDispatch } from '@client/store'
+import { useCountryIso, usePrevious } from '@client/hooks'
+
+import { GeoActions } from '../slice'
+import { useGeoLayer } from '.'
+
+export const useGteTreeCoverPercent = (sectionKey: LayerSectionKey, layerKey: LayerKey) => {
+  const dispatch = useAppDispatch()
+  const countryIso = useCountryIso()
+  const layerState = useGeoLayer(sectionKey, layerKey)
+  const gteTreeCoverPercent = layerState?.options?.gteTreeCoverPercent
+  const prevGteTreeCoverPercent = usePrevious(gteTreeCoverPercent)
+
+  useEffect(() => {
+    if (prevGteTreeCoverPercent === gteTreeCoverPercent) return // Skip if no change
+    if (gteTreeCoverPercent === undefined) return // Skip when the property is not set
+    if (prevGteTreeCoverPercent === null) return // Skip with initial prev. value
+
+    dispatch(GeoActions.postLayer({ countryIso, sectionKey, layerKey, layerState }))
+  }, [countryIso, layerKey, layerState, gteTreeCoverPercent, prevGteTreeCoverPercent, sectionKey, dispatch])
+}

--- a/src/client/store/ui/geo/slice.ts
+++ b/src/client/store/ui/geo/slice.ts
@@ -200,13 +200,13 @@ export const geoSlice = createSlice({
       const layerStateOptions = getLayerStateOptions(state, sectionKey, layerKey)
       state.sections[sectionKey][layerKey].options = { ...layerStateOptions, assetId }
     },
-    setLayerMinTreeCoverPercentage: (
-      state,
-      {
-        payload: { sectionKey, layerKey, minTreeCoverPercentage },
-      }: PayloadAction<{ sectionKey: LayerSectionKey; layerKey: LayerKey; minTreeCoverPercentage: number }>
+    setLayerGteTreeCoverPercent: (
+      state: Draft<GeoState>,
+      action: PayloadAction<{ sectionKey: LayerSectionKey; layerKey: LayerKey; gteTreeCoverPercent: number }>
     ) => {
-      state.sections[sectionKey][layerKey].options.minTreeCoverPercentage = minTreeCoverPercentage
+      const { sectionKey, layerKey, gteTreeCoverPercent } = action.payload
+      const layerStateOptions = getLayerStateOptions(state, sectionKey, layerKey)
+      state.sections[sectionKey][layerKey].options = { ...layerStateOptions, gteTreeCoverPercent }
     },
     setAgreementLevel: (
       state,

--- a/src/client/store/ui/geo/stateType.ts
+++ b/src/client/store/ui/geo/stateType.ts
@@ -18,7 +18,7 @@ export type AgreementLevelState = {
 // value instead of the list options.
 export type LayerStateOptions = {
   assetId?: string
-  minTreeCoverPercentage?: number
+  gteTreeCoverPercent?: number
   agreementLayer?: AgreementLevelState
   year?: number
 }

--- a/src/meta/geo/forest.ts
+++ b/src/meta/geo/forest.ts
@@ -210,7 +210,7 @@ export const forestLayers: LayerSection = {
     {
       key: ForestKey.Hansen,
       options: {
-        minTreeCoverPercentage: [...hansenPercentages],
+        gteTreeCoverPercent: [...hansenPercentages],
       },
       metadata: forestLayersMetadata.Hansen,
     },

--- a/src/meta/geo/layer.ts
+++ b/src/meta/geo/layer.ts
@@ -40,7 +40,7 @@ export type LayerMetadata = {
 }
 
 export type LayerOptions = {
-  minTreeCoverPercentage?: Array<number>
+  gteTreeCoverPercent?: Array<number>
   agreementLayer?: { agreementLevels: Array<number>; reducerScales: Array<number> }
   years?: Array<number>
 }


### PR DESCRIPTION
Added a component to handle layers with a gteTreeCoverPercent picker, and in the LayerSectionPanel added a 'fetch' flag to 'toggleLayer', so we can prevent fetching the layer when toggling. This is because when the user selects a layer, they should be able to see its menu before it is fetched (not only for the percentage but for the year too in coming features).

Also added a hook to fetch the layer when the gteTreeCoverPercent changes.


![Large GIF (846x762)](https://github.com/openforis/fra-platform/assets/41337901/af5ad736-8564-49b9-8c49-ed0d3b7e95e4)

