### PR TITLE
2643 - Fix greaterThanWithTolerance

### DIFF
--- a/src/meta/expressionEvaluator/functions/validatorOtherLandWithTreeCoverTotal.ts
+++ b/src/meta/expressionEvaluator/functions/validatorOtherLandWithTreeCoverTotal.ts
@@ -14,7 +14,7 @@ export const validatorOtherLandWithTreeCoverTotal: ExpressionFunction<Context> =
       const valid =
         Objects.isEmpty(otherLand) ||
         Objects.isEmpty(otherLandWithTreeCoverTotal) ||
-        Numbers.greaterThanWithTolerance(otherLand, otherLandWithTreeCoverTotal)
+        Numbers.greaterThanWithTolerance(otherLandWithTreeCoverTotal, otherLand)
 
       const messages: Array<NodeValueValidationMessage> = valid
         ? undefined

--- a/src/meta/expressionEvaluator/functions/validatorRemainingLandWithTreeCoverTotal.ts
+++ b/src/meta/expressionEvaluator/functions/validatorRemainingLandWithTreeCoverTotal.ts
@@ -14,7 +14,7 @@ export const validatorRemainingLandWithTreeCoverTotal: ExpressionFunction<Contex
       const valid =
         Objects.isEmpty(remainingLand) ||
         Objects.isEmpty(otherLandWithTreeCoverTotal) ||
-        !Numbers.greaterThanWithTolerance(remainingLand, otherLandWithTreeCoverTotal)
+        Numbers.greaterThanWithTolerance(otherLandWithTreeCoverTotal, remainingLand)
 
       const messages: Array<NodeValueValidationMessage> = valid
         ? undefined

--- a/src/meta/expressionEvaluator/functions/validatorSumNotGreaterThan.ts
+++ b/src/meta/expressionEvaluator/functions/validatorSumNotGreaterThan.ts
@@ -13,7 +13,7 @@ export const validatorSumNotGreaterThan: ExpressionFunction<Context> = {
     return (value?: string, maxValue?: string, tolerance?: boolean): NodeValueValidation => {
       const valid =
         Objects.isEmpty(value) || tolerance
-          ? !Numbers.greaterThanWithTolerance(value, maxValue)
+          ? Numbers.greaterThanWithTolerance(maxValue, value)
           : !Numbers.greaterThan(value, maxValue)
 
       const messages: Array<NodeValueValidationMessage> = valid

--- a/src/meta/expressionEvaluator/functions/validatorSumNotGreaterThanForest.ts
+++ b/src/meta/expressionEvaluator/functions/validatorSumNotGreaterThanForest.ts
@@ -16,7 +16,7 @@ export const validatorSumNotGreaterThanForest: ExpressionFunction<Context> = {
       _messages?: Array<NodeValueValidationMessage>
     ): NodeValueValidation => {
       const valid =
-        Objects.isEmpty(forestArea) || Objects.isEmpty(value) || !Numbers.greaterThanWithTolerance(value, forestArea)
+        Objects.isEmpty(forestArea) || Objects.isEmpty(value) || Numbers.greaterThanWithTolerance(forestArea, value)
 
       const messages: Array<NodeValueValidationMessage> = valid
         ? undefined

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -62,9 +62,8 @@ const lessThanOrEqualTo = (x: BigNumberInput, y: BigNumberInput) => applyCompari
 
 const greaterThan = (x: BigNumberInput, y: BigNumberInput) => applyComparison(x, y, 'gt')
 
-const greaterThanWithTolerance = (x: BigNumberInput, y: BigNumberInput, tolerance = 1) => {
-  return greaterThan(sub(x, y), tolerance)
-}
+const greaterThanWithTolerance = (x: BigNumberInput, y: BigNumberInput, tolerance = -1) =>
+  greaterThanOrEqualTo(sub(x, y), tolerance)
 
 const lessThan = (x: BigNumberInput, y: BigNumberInput) => applyComparison(x, y, 'lt')
 
@@ -74,6 +73,7 @@ const abs = (x: number | BigNumber): BigNumber | null => {
 }
 
 const eq = (x: BigNumberInput, y: BigNumberInput) => applyComparison(x, y, 'eq')
+
 const eqWithTolerance = (x: BigNumberInput, y: BigNumberInput, tolerance = 1) =>
   lessThanOrEqualTo(abs(sub(x, y)), tolerance)
 


### PR DESCRIPTION
close #2643

TEST:

- [x] validatorPrimaryForest | Numbers.greaterThanWithTolerance(naturalForestArea, primaryForest)
- [x] validatorSumNotGreaterThan | tolerance ? Numbers.greaterThanWithTolerance(maxValue, value) : !Numbers.greaterThan(value, maxValue)
- [x] validatorNotGreaterThanForest | Numbers.greaterThanWithTolerance(forestArea, value)
- [x] validatorNotGreaterThanLandArea | Numbers.greaterThanWithTolerance(landArea, value)
- [x] validatorNotGreaterThanLandAreaOrMaxLandArea | Numbers.greaterThanWithTolerance(maxLandArea, value)
- [x] validatorNotGreaterThanMaxForest | Numbers.greaterThanWithTolerance(maxForestArea, value)
- [x] validatorSumNotGreaterThanForest | Numbers.greaterThanWithTolerance(forestArea, value)
- [x] validatorOtherLandWithTreeCoverTotal | Numbers.greaterThanWithTolerance(otherLandWithTreeCoverTotal, otherLand)
- [x] validatorRemainingLandWithTreeCoverTotal | Numbers.greaterThanWithTolerance(otherLandWithTreeCoverTotal, remainingLand)
- [x] validatorSubCategory | Numbers.greaterThanWithTolerance(categoryValue, Numbers.sum(nonEmptySubCategoryValues))
