### PR TITLE
Geo refactor/add refetch on select to agreement layer

### DIFF
--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/AgreementLevelControl/AgreementLevelControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/AgreementLevelControl/AgreementLevelControl.tsx
@@ -74,6 +74,7 @@ const AgreementLevelControl: React.FC<Props> = ({
             countLayersSelected={countLayersSelected}
             layerState={layerState}
             section={section}
+            layerKey={layerKey}
             onChange={setAgreementLevel}
           />
         </div>

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/AgreementLevelControl/AgreementLevelSelector/AgreementLevelSelector.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/AgreementLevelControl/AgreementLevelSelector/AgreementLevelSelector.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { LayerSection } from '@meta/geo/layer'
+import { LayerKey, LayerSection } from '@meta/geo/layer'
 
 import { LayerState } from '@client/store/ui/geo/stateType'
 
@@ -11,16 +11,20 @@ interface Props {
   countLayersSelected: number
   layerState: LayerState
   section: LayerSection
+  layerKey: LayerKey
   onChange: (value: number) => void
 }
-const AgreementLevelSelector: React.FC<Props> = ({ countLayersSelected, layerState, section, onChange }) => {
+const AgreementLevelSelector: React.FC<Props> = ({ countLayersSelected, layerState, section, layerKey, onChange }) => {
+  const currentSelectedLevel = layerState?.options?.agreementLayer?.level
+  let palette = section.layers.find((layer) => layer.key === layerKey)?.metadata?.palette
+  palette =
+    palette && currentSelectedLevel !== undefined ? palette.slice(currentSelectedLevel - 1, countLayersSelected) : []
   return (
     <div className="geo-map-menu-data-visualizer-agreement-level-boxes">
       {Array(section.layers.length - 1) // Layers excluding Agreement
         .fill(undefined)
         .map((_, i) => {
-          const currentSelectedLevel = layerState?.options?.agreementLayer?.level
-          const currentAgreementPaletteLength = layerState?.options?.agreementLayer?.palette?.length
+          const currentAgreementPaletteLength = palette ? palette.length : 0
           const level = i + 1
           const id = `${section.key}-agreement-${level}`
           const disabled = level > countLayersSelected
@@ -31,14 +35,14 @@ const AgreementLevelSelector: React.FC<Props> = ({ countLayersSelected, layerSta
             level <= countLayersSelected &&
             agreementLevelOffset < currentAgreementPaletteLength
               ? {
-                  backgroundColor: `${layerState?.options?.agreementLayer?.palette?.[agreementLevelOffset]}`,
+                  backgroundColor: `${palette?.[agreementLevelOffset]}`,
                 }
               : {}
           const selectedStyle =
             currentAgreementPaletteLength > 0
               ? {
-                  backgroundColor: `${layerState?.options?.agreementLayer?.palette?.[agreementLevelOffset]}`,
-                  boxShadow: `0px 0px 3px 3px ${layerState?.options?.agreementLayer?.palette?.[agreementLevelOffset]}30`,
+                  backgroundColor: `${palette?.[agreementLevelOffset]}`,
+                  boxShadow: `0px 0px 3px 3px ${palette?.[agreementLevelOffset]}30`,
                 }
               : {}
 

--- a/src/client/pages/Geo/GeoMap/hooks/useCountSectionSelectedLayers.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/useCountSectionSelectedLayers.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+
+import { LayerKey, LayerSectionKey } from '@meta/geo'
+
+import { useGeoLayerSection } from '@client/store/ui/geo'
+
+export const useCountSectionSelectedLayers = (sectionKey: LayerSectionKey) => {
+  const [selectedLayersCount, setSelectedLayerCount] = useState(0)
+  const sectionState = useGeoLayerSection(sectionKey)
+
+  useEffect(() => {
+    if (sectionState === undefined) return
+    let count = 0
+    Object.keys(sectionState).forEach((layerKey) => {
+      if (sectionState[layerKey as LayerKey].selected) {
+        count += 1
+      }
+    })
+    setSelectedLayerCount(count)
+  }, [sectionState])
+
+  return selectedLayersCount
+}

--- a/src/client/pages/Geo/GeoMap/hooks/useFetchAgreementLevelLayer.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/useFetchAgreementLevelLayer.ts
@@ -6,15 +6,18 @@ import { useAppDispatch } from '@client/store'
 import { GeoActions, useGeoLayerSection } from '@client/store/ui/geo'
 import { useCountryIso } from '@client/hooks'
 
+import { useCountSectionSelectedLayers } from './useCountSectionSelectedLayers'
+
 export const useFetchAgreementLevelLayer = (sectionKey: LayerSectionKey, layerKey: LayerKey) => {
   const dispatch = useAppDispatch()
   const countryIso = useCountryIso()
   const sectionState = useGeoLayerSection(sectionKey)
   const layerState = sectionState?.[layerKey]
   const agreementLevel = layerState?.options?.agreementLayer?.level
+  const countSelectedLayers = useCountSectionSelectedLayers(sectionKey)
 
   useEffect(() => {
     if (agreementLevel === undefined) return // Skip when the property is not set
     dispatch(GeoActions.postLayer({ countryIso, sectionKey, layerKey }))
-  }, [countryIso, layerKey, agreementLevel, sectionKey, dispatch])
+  }, [countryIso, layerKey, agreementLevel, sectionKey, dispatch, countSelectedLayers])
 }

--- a/src/client/store/ui/geo/actions/postLayer.ts
+++ b/src/client/store/ui/geo/actions/postLayer.ts
@@ -1,7 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import axios from 'axios'
 
-import { LayerResponseData } from '@meta/api/request/geo/layer'
 import { CountryIso } from '@meta/area'
 import { LayerKey, LayerSectionKey, sectionsApiEndpoint } from '@meta/geo'
 
@@ -15,7 +14,7 @@ export interface PostLayerProps {
   layerKey: LayerKey
 }
 
-export const postLayer = createAsyncThunk<[LayerSectionKey, LayerKey, LayerResponseData], PostLayerProps>(
+export const postLayer = createAsyncThunk<[LayerSectionKey, LayerKey, string], PostLayerProps>(
   'geo/post/layer',
   async ({ countryIso, sectionKey, layerKey }, { getState }) => {
     const state = getState()
@@ -23,7 +22,9 @@ export const postLayer = createAsyncThunk<[LayerSectionKey, LayerKey, LayerRespo
     const layerState = sectionState?.[layerKey]
     const body = _getLayerRequestBody(countryIso, layerKey, layerState, sectionState)
     const url = sectionsApiEndpoint[sectionKey]
-    const { data } = await axios({ method: 'POST', url, data: body })
-    return [sectionKey, layerKey, data]
+    const {
+      data: { mapId },
+    } = await axios({ method: 'POST', url, data: body })
+    return [sectionKey, layerKey, mapId]
   }
 )

--- a/src/client/store/ui/geo/stateType.ts
+++ b/src/client/store/ui/geo/stateType.ts
@@ -11,7 +11,6 @@ export enum LayerFetchStatus {
 export type AgreementLevelState = {
   level: number
   reducerScale: number
-  palette: Array<string>
 }
 
 // Similar to the type LayerOptions, but in this case it has the selected

--- a/src/meta/api/request/geo/layer.ts
+++ b/src/meta/api/request/geo/layer.ts
@@ -10,13 +10,6 @@ export type LayerRequestBody = {
 
 export type LayerRequest = Request<never, never, LayerRequestBody, never>
 
-export type LayerResponseData = {
-  mapId: string
-  year?: number
-  scale?: number
-  palette?: string[]
-}
-
 export type ForestAgreementLayerRequest = Request<
   never,
   never,


### PR DESCRIPTION
Adding logic to re-fetch the agreement layer when selected layers change, and to get the palette from the layers config, as the backend will be modified to send back the mapId only. 

![Large GIF (762x762)](https://github.com/openforis/fra-platform/assets/41337901/defab320-fff9-491b-91af-9daffa0aab01)
