### PR TITLE
2720 - Definitive Global/Country file fix, support for UTF-8 filenames

### DIFF
--- a/src/server/api/file/createAssessmentFile.ts
+++ b/src/server/api/file/createAssessmentFile.ts
@@ -19,7 +19,7 @@ export const createAssessmentFile = async (req: CycleRequest<never, AssessmentFi
     const updatedAssessmentFile = await FileController.createAssessmentFile({
       assessment,
       assessmentFile,
-      countryIso: fileCountryIso && null,
+      countryIso: fileCountryIso,
       user,
     })
 

--- a/src/server/api/file/getAssessmentFile.ts
+++ b/src/server/api/file/getAssessmentFile.ts
@@ -16,9 +16,9 @@ export const getAssessmentFile = async (req: CycleRequest, res: Response) => {
 
     const assessmentFile = await FileController.getAssessmentFile({ assessment, uuid })
 
-    const fileName = encodeURIComponent(assessmentFile.fileName)
-
     if (assessmentFile && assessmentFile.file) {
+      const fileName = encodeURIComponent(assessmentFile.fileName)
+
       res.setHeader('Content-Disposition', `attachment; filename*=utf-8''${fileName}`)
 
       res.end(assessmentFile.file, 'binary')

--- a/src/server/api/file/getAssessmentFile.ts
+++ b/src/server/api/file/getAssessmentFile.ts
@@ -16,8 +16,11 @@ export const getAssessmentFile = async (req: CycleRequest, res: Response) => {
 
     const assessmentFile = await FileController.getAssessmentFile({ assessment, uuid })
 
+    const fileName = encodeURIComponent(assessmentFile.fileName)
+
     if (assessmentFile && assessmentFile.file) {
-      res.setHeader('Content-Disposition', `attachment; filename=${assessmentFile.fileName}`)
+      res.setHeader('Content-Disposition', `attachment; filename*=utf-8''${fileName}`)
+
       res.end(assessmentFile.file, 'binary')
     } else {
       Requests.send404(res)

--- a/src/server/api/file/index.ts
+++ b/src/server/api/file/index.ts
@@ -12,9 +12,15 @@ import { getAssessmentFile } from './getAssessmentFile'
 import { getAssessmentFiles } from './getAssessmentFiles'
 import { getBiomassStockFile } from './getBiomassStockFile'
 import { getDataDownloadFile } from './getDataDownloadFile'
-import { removeAssessmentFile } from './removeAssessmentFile'
 import { getSdgFocalPointsFile } from './getSdgFocalPointsFile'
+import { removeAssessmentFile } from './removeAssessmentFile'
 import multer = require('multer')
+
+const fileFilter = (_req: any, file: Express.Multer.File, callback: multer.FileFilterCallback) => {
+  // eslint-disable-next-line no-param-reassign
+  file.originalname = Buffer.from(file.originalname, 'latin1').toString('utf8')
+  callback(null, true)
+}
 
 export const FileApi = {
   init: (express: Express): void => {
@@ -31,7 +37,7 @@ export const FileApi = {
     // Files
     express.put(
       ApiEndPoint.File.Assessment.many(),
-      multer().single('file'),
+      multer({ fileFilter }).single('file'),
       AuthMiddleware.requireEditAssessmentFile,
       createAssessmentFile
     )

--- a/src/server/repository/assessment/assessment/getCreateSchemaDDL.ts
+++ b/src/server/repository/assessment/assessment/getCreateSchemaDDL.ts
@@ -60,7 +60,9 @@ create table ${schemaName}.file
     uuid             uuid default uuid_generate_v4() NOT NULL,
     country_iso      varchar(3) references public.country on update cascade on delete cascade,
     file_name        varchar(250) NOT NULL,
-    file             bytea NOT NULL
+    file             bytea NOT NULL,
+    PRIMARY KEY (id),
+    unique(uuid)
 );
 `
   return query

--- a/src/test/migrations/steps/20230607170529-step-primary-key-for-table-file.ts
+++ b/src/test/migrations/steps/20230607170529-step-primary-key-for-table-file.ts
@@ -1,7 +1,11 @@
 import { BaseProtocol } from 'server/db'
 
 export default async (client: BaseProtocol) => {
-  await client.query(`ALTER TABLE assessment_fra.file ADD PRIMARY KEY (id);`)
+  await client.query('ALTER TABLE assessment_fra.file ADD PRIMARY KEY (id);')
 
-  await client.query(`ALTER TABLE assessment_paneuropean.file ADD PRIMARY KEY (id);`)
+  await client.query('ALTER TABLE assessment_paneuropean.file ADD PRIMARY KEY (id);')
+
+  await client.query('ALTER TABLE assessment_fra.file ADD CONSTRAINT file_uuid_unique UNIQUE (uuid);')
+
+  await client.query('ALTER TABLE assessment_paneuropean.file ADD CONSTRAINT file_uuid_unique UNIQUE (uuid);')
 }

--- a/src/test/migrations/steps/20230607170529-step-primary-key-for-table-file.ts
+++ b/src/test/migrations/steps/20230607170529-step-primary-key-for-table-file.ts
@@ -1,0 +1,7 @@
+import { BaseProtocol } from 'server/db'
+
+export default async (client: BaseProtocol) => {
+  await client.query(`ALTER TABLE assessment_fra.file ADD PRIMARY KEY (id);`)
+
+  await client.query(`ALTER TABLE assessment_paneuropean.file ADD PRIMARY KEY (id);`)
+}


### PR DESCRIPTION
close #2720

upload: multer, due to busboy dependency, doesn't support utf-8 filenames by default. there is a workaround to fix it: https://github.com/expressjs/multer/issues/1104

download: nodejs doesn't support utf-8 on response header content-disposition: https://stackoverflow.com/questions/23895924/expressjs-download-filename-utf-8

primary key: pgadmin doesn't allow me to change file table on the fly because it hadn't a primary key. this problem can occurs with others sql clients. I just added a primary key as in the other tables (col, row)

https://github.com/openforis/fra-platform/assets/10047945/1a35b411-be16-4691-b221-214a3ece6660
