### PR TITLE
Fix copying rows in table 2a

### DIFF
--- a/src/client/pages/AssessmentSection/DataTable/Table/ButtonCopyValues/ButtonCopyValues.tsx
+++ b/src/client/pages/AssessmentSection/DataTable/Table/ButtonCopyValues/ButtonCopyValues.tsx
@@ -22,7 +22,7 @@ const tableMappings: Record<string, Array<string>> = {
   ],
   [TableNames.growingStockAvg]: [
     'growingStock.naturallyRegeneratingForest',
-    'growingStock.plantedForest',
+    'fra.growingStock.plantedForest2025',
     'growingStock.plantationForest',
     'growingStock.otherPlantedForest',
   ],


### PR DESCRIPTION
Example output for all countries




123 | 121.53 | 113.33 | 109.66 | 106.29 | 106.29
-- | -- | -- | -- | -- | --
456 | 132.92 | 132.79 | 132.71 | 132.64 | 132.64
789 | 132.92 | 132.79 | 132.71 | 132.64 | 132.64
0 | 0 | 0 | 0 | 0 | 0
