### PR TITLE
Allow collaborator to see resolved topics

### DIFF
--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -92,9 +92,7 @@ const requireEditMessageTopic = async (req: Request, _res: Response, next: NextF
     _next(
       topic.status === MessageTopicStatus.opened ||
         (topic.status === MessageTopicStatus.resolved &&
-          (Users.isAdministrator(user) ||
-            Users.isReviewer(user, countryIso as CountryIso, cycle) ||
-            Users.isCollaborator(user, countryIso as CountryIso, cycle))),
+          Users.hasEditorRole({ user, countryIso: countryIso as CountryIso, cycle })),
       next
     )
   } else {

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -92,7 +92,9 @@ const requireEditMessageTopic = async (req: Request, _res: Response, next: NextF
     _next(
       topic.status === MessageTopicStatus.opened ||
         (topic.status === MessageTopicStatus.resolved &&
-          (Users.isAdministrator(user) || Users.isReviewer(user, countryIso as CountryIso, cycle))),
+          (Users.isAdministrator(user) ||
+            Users.isReviewer(user, countryIso as CountryIso, cycle) ||
+            Users.isCollaborator(user, countryIso as CountryIso, cycle))),
       next
     )
   } else {


### PR DESCRIPTION
Issue caused when collaborator tries to see resolved topics
Collaborator had no rights to view resolved topics.
Only roles reviewer and admin were able to see resolved topics

Added collaborator to requireEditMessageTopic to allow him/her to see the topic