### PR TITLE
API for ODP Year

### DIFF
--- a/src/client/pages/OriginalDataPoint/components/YearSelection/YearSelection.tsx
+++ b/src/client/pages/OriginalDataPoint/components/YearSelection/YearSelection.tsx
@@ -24,7 +24,7 @@ const YearSelection: React.FC<Props> = (props) => {
   const { years, reservedYears } = useODPYears(cycleName)
 
   const validYear = ODPs.validateYear(originalDataPoint)
-  const disabled = Boolean(originalDataPoint.id || !canEditData)
+  const disabled = Boolean(!canEditData)
 
   return (
     <div className="odp__section">

--- a/src/client/pages/OriginalDataPoint/components/YearSelection/hooks/useOnChange.tsx
+++ b/src/client/pages/OriginalDataPoint/components/YearSelection/hooks/useOnChange.tsx
@@ -22,7 +22,7 @@ export const useOnChange = (): Returned => {
     (event) => {
       const { value: year } = event.target
 
-      const propsAction = {
+      const commonProps = {
         assessmentName,
         cycleName,
         countryIso,
@@ -31,7 +31,21 @@ export const useOnChange = (): Returned => {
           year: Number(year),
         },
       }
-      dispatch(OriginalDataPointActions.createOriginalDataPoint(propsAction))
+
+      // When creating ODP, year is -1
+      if (originalDataPoint.year === -1) {
+        dispatch(OriginalDataPointActions.createOriginalDataPoint(commonProps))
+        // Otherwise year already exists
+      } else {
+        const propsUpdateYear = {
+          ...commonProps,
+          id: originalDataPoint.id,
+          year: originalDataPoint.year,
+          targetYear: year,
+        }
+
+        dispatch(OriginalDataPointActions.updateOriginalDataPointOriginalYear(propsUpdateYear))
+      }
 
       // Update url but do not push new entry to state
       const routeParams = { assessmentName, cycleName, countryIso, sectionName, year }

--- a/src/client/pages/OriginalDataPoint/components/YearSelection/hooks/useOnChange.tsx
+++ b/src/client/pages/OriginalDataPoint/components/YearSelection/hooks/useOnChange.tsx
@@ -44,7 +44,7 @@ export const useOnChange = (): Returned => {
           targetYear: year,
         }
 
-        dispatch(OriginalDataPointActions.updateOriginalDataPointOriginalYear(propsUpdateYear))
+        dispatch(OriginalDataPointActions.updateOriginalDataPointYear(propsUpdateYear))
       }
 
       // Update url but do not push new entry to state

--- a/src/client/store/ui/originalDataPoint/actions/updateOriginalDataPointOriginalYear.ts
+++ b/src/client/store/ui/originalDataPoint/actions/updateOriginalDataPointOriginalYear.ts
@@ -1,0 +1,35 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axios from 'axios'
+import { Functions } from 'utils/functions'
+
+import { ApiEndPoint } from 'meta/api/endpoint'
+import { CycleParams } from 'meta/api/request'
+import { OriginalDataPoint } from 'meta/assessment'
+
+type Props = CycleParams & {
+  originalDataPoint: OriginalDataPoint
+  id: string
+  year: string
+  targetYear: string
+}
+
+const putOriginalDataPointYear = Functions.debounce(
+  async (props: Props) => {
+    const { countryIso, assessmentName, cycleName, year, targetYear, id } = props
+
+    const params = { countryIso, assessmentName, cycleName, sectionName: 'extentOfForest' }
+    const config = { params }
+    const data = { id, year, targetYear }
+    await axios.put(ApiEndPoint.CycleData.OriginalDataPoint.year(), data, config)
+  },
+  1000,
+  'updateOriginalDataPointYear'
+)
+
+export const updateOriginalDataPointOriginalYear = createAsyncThunk<OriginalDataPoint, Props>(
+  'originalDataPoint/year/update',
+  async (props) => {
+    putOriginalDataPointYear(props)
+    return props.originalDataPoint
+  }
+)

--- a/src/client/store/ui/originalDataPoint/actions/updateOriginalDataPointYear.ts
+++ b/src/client/store/ui/originalDataPoint/actions/updateOriginalDataPointYear.ts
@@ -26,7 +26,7 @@ const putOriginalDataPointYear = Functions.debounce(
   'updateOriginalDataPointYear'
 )
 
-export const updateOriginalDataPointOriginalYear = createAsyncThunk<OriginalDataPoint, Props>(
+export const updateOriginalDataPointYear = createAsyncThunk<OriginalDataPoint, Props>(
   'originalDataPoint/year/update',
   async (props) => {
     putOriginalDataPointYear(props)

--- a/src/client/store/ui/originalDataPoint/slice.ts
+++ b/src/client/store/ui/originalDataPoint/slice.ts
@@ -14,6 +14,7 @@ import { updateOriginalDataPointDataSources } from './actions/updateOriginalData
 import { updateOriginalDataPointDescription } from './actions/updateOriginalDataPointDescription'
 import { updateOriginalDataPointNationalClasses } from './actions/updateOriginalDataPointNationalClasses'
 import { updateOriginalDataPointOriginalData } from './actions/updateOriginalDataPointOriginalData'
+import { updateOriginalDataPointOriginalYear } from './actions/updateOriginalDataPointOriginalYear'
 import { setOriginalDataPoint } from './reducers/setOriginalDataPoint'
 import { OriginalDataPointState } from './stateType'
 
@@ -42,6 +43,7 @@ export const originalDataPointSlice = createSlice({
         updateOriginalDataPointNationalClasses.fulfilled,
         updateOriginalDataPointDescription.fulfilled,
         updateOriginalDataPointOriginalData.fulfilled,
+        updateOriginalDataPointOriginalYear.fulfilled,
         createOriginalDataPoint.fulfilled
       ),
       setOriginalDataPoint
@@ -54,7 +56,8 @@ export const originalDataPointSlice = createSlice({
         updateOriginalDataPointDataSources.pending,
         updateOriginalDataPointNationalClasses.pending,
         updateOriginalDataPointDescription.pending,
-        updateOriginalDataPointOriginalData.pending
+        updateOriginalDataPointOriginalData.pending,
+        updateOriginalDataPointOriginalYear.pending
       ),
       setUpdatingTrue
     )
@@ -71,6 +74,7 @@ export const OriginalDataPointActions = {
   updateOriginalDataPointDescription,
   updateOriginalDataPointNationalClasses,
   updateOriginalDataPointOriginalData,
+  updateOriginalDataPointOriginalYear,
   copyNationalClasses,
   getOriginalDataPointReservedYears,
 }

--- a/src/client/store/ui/originalDataPoint/slice.ts
+++ b/src/client/store/ui/originalDataPoint/slice.ts
@@ -14,7 +14,7 @@ import { updateOriginalDataPointDataSources } from './actions/updateOriginalData
 import { updateOriginalDataPointDescription } from './actions/updateOriginalDataPointDescription'
 import { updateOriginalDataPointNationalClasses } from './actions/updateOriginalDataPointNationalClasses'
 import { updateOriginalDataPointOriginalData } from './actions/updateOriginalDataPointOriginalData'
-import { updateOriginalDataPointOriginalYear } from './actions/updateOriginalDataPointOriginalYear'
+import { updateOriginalDataPointYear } from './actions/updateOriginalDataPointYear'
 import { setOriginalDataPoint } from './reducers/setOriginalDataPoint'
 import { OriginalDataPointState } from './stateType'
 
@@ -43,7 +43,7 @@ export const originalDataPointSlice = createSlice({
         updateOriginalDataPointNationalClasses.fulfilled,
         updateOriginalDataPointDescription.fulfilled,
         updateOriginalDataPointOriginalData.fulfilled,
-        updateOriginalDataPointOriginalYear.fulfilled,
+        updateOriginalDataPointYear.fulfilled,
         createOriginalDataPoint.fulfilled
       ),
       setOriginalDataPoint
@@ -57,7 +57,7 @@ export const originalDataPointSlice = createSlice({
         updateOriginalDataPointNationalClasses.pending,
         updateOriginalDataPointDescription.pending,
         updateOriginalDataPointOriginalData.pending,
-        updateOriginalDataPointOriginalYear.pending
+        updateOriginalDataPointYear.pending
       ),
       setUpdatingTrue
     )
@@ -74,7 +74,7 @@ export const OriginalDataPointActions = {
   updateOriginalDataPointDescription,
   updateOriginalDataPointNationalClasses,
   updateOriginalDataPointOriginalData,
-  updateOriginalDataPointOriginalYear,
+  updateOriginalDataPointYear,
   copyNationalClasses,
   getOriginalDataPointReservedYears,
 }

--- a/src/meta/api/endpoint/ApiEndPoint.ts
+++ b/src/meta/api/endpoint/ApiEndPoint.ts
@@ -47,6 +47,7 @@ export const ApiEndPoint = {
       originalData: () => apiPath('cycle-data', 'original-data-points', 'original-data-point', 'original-data'),
       nationalClasses: () => apiPath('cycle-data', 'original-data-points', 'original-data-point', 'national-classes'),
       nationalClass: () => apiPath('cycle-data', 'original-data-points', 'original-data-point', 'national-class'),
+      year: () => apiPath('cycle-data', 'original-data-points', 'original-data-point', 'year'),
 
       copyNationalClasses: () =>
         apiPath('cycle-data', 'original-data-points', 'original-data-point', 'copy-national-classes'),

--- a/src/server/api/cycleData/index.ts
+++ b/src/server/api/cycleData/index.ts
@@ -25,6 +25,7 @@ import { updateOriginalDataPointDataSources } from './originalDataPoint/updateOr
 import { updateOriginalDataPointDescription } from './originalDataPoint/updateOriginalDataPointDescription'
 import { updateOriginalDataPointNationalClasses } from './originalDataPoint/updateOriginalDataPointNationalClasses'
 import { updateOriginalDataPointOriginalData } from './originalDataPoint/updateOriginalDataPointOriginalData'
+import { updateOriginalDataPointYear } from './originalDataPoint/updateOriginalDataPointYear'
 import { getReviewStatus } from './review/getReviewStatus'
 import { getReviewSummary } from './review/getReviewSummary'
 import { estimateValues } from './table/estimateValues'
@@ -89,6 +90,11 @@ export const CycleDataApi = {
       ApiEndPoint.CycleData.OriginalDataPoint.originalData(),
       AuthMiddleware.requireEditTableData,
       updateOriginalDataPointOriginalData
+    )
+    express.put(
+      ApiEndPoint.CycleData.OriginalDataPoint.year(),
+      AuthMiddleware.requireEditTableData,
+      updateOriginalDataPointYear
     )
     // OriginalDataPoint NationalClasses
     express.put(

--- a/src/server/api/cycleData/originalDataPoint/updateOriginalDataPointYear.ts
+++ b/src/server/api/cycleData/originalDataPoint/updateOriginalDataPointYear.ts
@@ -1,0 +1,25 @@
+import { Response } from 'express'
+
+import { CycleRequest } from 'meta/api/request'
+
+import Requests from 'server/utils/requests'
+
+export const updateOriginalDataPointYear = async (
+  req: CycleRequest<never, { id: string; year: string; targetYear: string }>,
+  res: Response
+) => {
+  try {
+    const { assessmentName, cycleName } = req.query
+    const { id, targetYear, year } = req.body
+
+    Requests.send(res, {
+      assessmentName,
+      cycleName,
+      id,
+      targetYear,
+      year,
+    })
+  } catch (e) {
+    Requests.sendErr(res, e)
+  }
+}


### PR DESCRIPTION
Note:
API only returns given params currently

Next PR implements controller


- [x] add new action to dispatch to edit the ODP year
- [x] add new endpoint with body prevYear, nextYear, odpId (and odp if consistent with other endpoints? maybe not needed for this endpoint)