### PR TITLE
fix RowRedisRepository getRows with empty rowKeys argument

### DIFF
--- a/src/server/repository/redis/row/getRows.ts
+++ b/src/server/repository/redis/row/getRows.ts
@@ -42,7 +42,7 @@ export const getRows = async (props: Props): Promise<RecordRowCache> => {
   const redis = RedisData.getInstance()
 
   const key = getKeyRow({ assessment })
-  const keys = rowKeys ?? (await redis.hkeys(key))
+  const keys = rowKeys?.length ? rowKeys : await redis.hkeys(key)
   const values = await redis.hmget(key, ...keys)
 
   return keys.reduce<RecordRowCache>(


### PR DESCRIPTION
This is causing some job to fail in prod, when the queue is empty.
No harm is done, sino no nodes need to be updated in this case.
