### PR TITLE
3211 NDP References: Minor UI update

### DIFF
--- a/src/client/pages/OriginalDataPoint/OriginalDataPoint.scss
+++ b/src/client/pages/OriginalDataPoint/OriginalDataPoint.scss
@@ -102,6 +102,10 @@
     border: unset !important;
     height: unset !important;
     min-height: unset !important;
+
+    .icon.jodit-icon {
+      stroke: none;
+    }
   }
 
   .jodit-workplace,

--- a/src/client/pages/OriginalDataPoint/components/DataSources/References/AddFromRepository/AddFromRepository.scss
+++ b/src/client/pages/OriginalDataPoint/components/DataSources/References/AddFromRepository/AddFromRepository.scss
@@ -1,6 +1,15 @@
+@import 'src/client/style/partials';
+
 .references-file-list {
   display: grid;
   grid-template-columns: auto 1fr;
   grid-gap: 10px;
   padding: 10px;
+}
+
+.repository-modal {
+  .modal-header span {
+    font-size: $font-s;
+    font-weight: initial;
+  }
 }

--- a/src/client/pages/OriginalDataPoint/components/DataSources/References/AddFromRepository/AddFromRepository.tsx
+++ b/src/client/pages/OriginalDataPoint/components/DataSources/References/AddFromRepository/AddFromRepository.tsx
@@ -82,7 +82,7 @@ const AddFromRepository: React.FC<Props> = (props: Props) => {
       </ModalBody>
 
       <ModalFooter>
-        <button type="button" className="btn btn-transparent" onClick={() => onClose(selectedFiles)}>
+        <button type="button" className="btn btn-primary" onClick={() => onClose(selectedFiles)}>
           {t('common.apply')}
         </button>
       </ModalFooter>

--- a/src/client/pages/OriginalDataPoint/components/DataSources/References/AddFromRepository/AddFromRepository.tsx
+++ b/src/client/pages/OriginalDataPoint/components/DataSources/References/AddFromRepository/AddFromRepository.tsx
@@ -48,9 +48,12 @@ const AddFromRepository: React.FC<Props> = (props: Props) => {
   }
 
   return (
-    <Modal isOpen={isOpen}>
+    <Modal className="repository-modal" isOpen={isOpen}>
       <ModalHeader>
-        <h3 className="subhead">{t('common.selectFiles')}</h3>
+        <div>
+          <h3 className="subhead">{t('common.selectFiles')}</h3>
+          <span>{t('nationalDataPoint.fileAddedWillBecomePublic')}</span>
+        </div>
       </ModalHeader>
 
       <ModalBody>
@@ -80,7 +83,7 @@ const AddFromRepository: React.FC<Props> = (props: Props) => {
 
       <ModalFooter>
         <button type="button" className="btn btn-transparent" onClick={() => onClose(selectedFiles)}>
-          {t('common.close')}
+          {t('common.apply')}
         </button>
       </ModalFooter>
     </Modal>

--- a/src/client/pages/OriginalDataPoint/components/DataSources/References/hooks/useEditorOptions.tsx
+++ b/src/client/pages/OriginalDataPoint/components/DataSources/References/hooks/useEditorOptions.tsx
@@ -1,8 +1,11 @@
-import { useMemo } from 'react'
+import React, { useMemo } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { useTranslation } from 'react-i18next'
 
 import type { IControlType } from 'jodit/src/types/toolbar'
 import type { Jodit } from 'jodit/types/jodit'
+
+import Icon from 'client/components/Icon'
 
 type ButtonType = IControlType
 
@@ -21,9 +24,9 @@ export const useEditorOptions = (props: Props) => {
       setIsOpen(true)
     }
     const label = t('landing.links.repository')
-    const name = label
     const tooltip = label
-    return { name, exec, tooltip }
+    const icon = renderToStaticMarkup(<Icon name="icon-files" />)
+    return { icon, exec, tooltip }
   }, [setEditor, setIsOpen, t])
 
   return useMemo(() => {

--- a/src/i18n/resources/en.js
+++ b/src/i18n/resources/en.js
@@ -531,6 +531,7 @@ The FRA team
       otherWoodedLand: 'Other wooded land',
       otherLand: 'Other land',
     },
+    fileAddedWillBecomePublic: 'A file added as reference will become publicly accessible',
   },
 
   userManagement: {

--- a/src/i18n/resources/en/common.js
+++ b/src/i18n/resources/en/common.js
@@ -4,7 +4,6 @@ module.exports = {
   areYouSureYouWantToDeleteAllTableData: 'Are you sure you want to delete all data from the table?',
   cancel: 'Cancel',
   clearTable: 'Clear table',
-  close: 'Close',
   column: 'Column',
   continue: 'Continue',
   copyToClipboard: 'Copy to clipboard',

--- a/web-resources/img/icons.svg
+++ b/web-resources/img/icons.svg
@@ -294,4 +294,7 @@
         <path d="M13.419 12.387h10.323v4.129h-10.323v-4.129z"></path>
         <path d="M13.419 18.581h6.194v4.129h-6.194v-4.129z"></path>
     </symbol>
+    <symbol id="icon-files" viewBox="0 0 24 24">
+        <path d="M5 0v3h-3v21h17v-3h3v-21h-17zM17 22h-13v-17h1v16h12v1zM20 19h-13v-17h13v17zM15 5h-6v2h6v-2zM18 8h-9v1h9v-1zM18 10h-9v1h9v-1zM18 12h-9v1h9v-1zM12 14h-3v1h3v-1z"></path>
+    </symbol>
 </svg>


### PR DESCRIPTION
- [x] In the NDP Reference Repository File Selector Dialog add a sentence on top: `A file added as reference will become automatically publicly accessible`

- [x] In NDP Reference Dialog, relablel 'Close' to 'Apply'

<img width="928" alt="image" src="https://github.com/openforis/fra-platform/assets/5508251/13ebf932-794b-4222-a2c0-fa7015814768">

- [x] In NDP Reference, before button 'Repository' add icon file 

_Note_: Jodit supports either icon or text
<img width="787" alt="image" src="https://github.com/openforis/fra-platform/assets/5508251/eef6d231-0373-451b-ae1d-1a4b668328ba">
