### PR TITLE
Center FRA Beta message in toolbar in geo page

### DIFF
--- a/src/client/components/PageLayout/Toolbar/Toolbar.scss
+++ b/src/client/components/PageLayout/Toolbar/Toolbar.scss
@@ -49,5 +49,8 @@
 
 .toolbar__geo-beta-message {
   font-size: $font-l;
-  margin-left: $spacing-l;
+  text-align: center;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
 }

--- a/src/client/components/PageLayout/Toolbar/Toolbar.tsx
+++ b/src/client/components/PageLayout/Toolbar/Toolbar.tsx
@@ -59,6 +59,7 @@ const Toolbar: React.FC = () => {
           <div className="toolbar__geo-beta-message">FRA GEO - Beta version</div>
         </MediaQuery>
       )}
+
       {isCountry && (
         <>
           <MediaQuery minWidth={Breakpoints.laptop}>


### PR DESCRIPTION
Centering the FRA Beta message in the toolbar in the geo page. Closes #3298 

Currently with the committed changes, centering across the entire toolbar:


https://github.com/openforis/fra-platform/assets/41337901/86e37b52-f8b9-4e50-8108-5681724b79ef

There is a little bit of overlap with the country selector right before the message is hidden.

I propose centering the message in between the items to its left and right, not across the entire toolbar:

https://github.com/openforis/fra-platform/assets/41337901/f26cc78f-1dc4-4f49-855a-e9b8fd62613c

This would require a couple of changes to the current verison.
