### PR TITLE
3274 - National Data : Data Sources Grid Layout error

### DIFF
--- a/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSourceColumn/ColumnComments.tsx
+++ b/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSourceColumn/ColumnComments.tsx
@@ -6,8 +6,8 @@ import classNames from 'classnames'
 import { DataSource } from 'meta/assessment'
 import { TooltipId } from 'meta/tooltip'
 
-import DataColumn from 'client/components/DataGridDeprecated/DataColumn'
-import VerticallyGrowingTextField from 'client/components/VerticallyGrowingTextField'
+import { DataCell } from 'client/components/DataGrid'
+import TextArea from 'client/components/Inputs/TextArea'
 
 import { datasourceValidators } from './datasourceValidators'
 
@@ -15,10 +15,11 @@ type Props = {
   disabled: boolean
   dataSourceValue: DataSource
   onChange: (key: string, value: string) => void
+  lastRow: boolean
 }
 
 const ColumnComments: React.FC<Props> = (props: Props) => {
-  const { dataSourceValue, disabled, onChange } = props
+  const { dataSourceValue, disabled, onChange, lastRow } = props
   const { t } = useTranslation()
   const _onChange: React.ChangeEventHandler<HTMLTextAreaElement> = (event) => onChange('comments', event.target.value)
 
@@ -27,17 +28,17 @@ const ColumnComments: React.FC<Props> = (props: Props) => {
   }, [dataSourceValue.comments])
 
   return (
-    <DataColumn
+    <DataCell
+      lastCol
+      lastRow={lastRow}
       data-tooltip-id={TooltipId.error}
       data-tooltip-content={validationError ? t('generalValidation.shouldContainAtLeastOneCharacter') : ''}
-      className={classNames('data-source-column', {
+      className={classNames({
         'validation-error': validationError,
       })}
     >
-      <div className="data-source__text-area-wrapper">
-        <VerticallyGrowingTextField disabled={disabled} onChange={_onChange} value={dataSourceValue.comments} />
-      </div>
-    </DataColumn>
+      <TextArea disabled={disabled} onChange={_onChange} value={dataSourceValue.comments} />
+    </DataCell>
   )
 }
 export default ColumnComments

--- a/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSourceColumn/ColumnReference.tsx
+++ b/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSourceColumn/ColumnReference.tsx
@@ -6,9 +6,9 @@ import classNames from 'classnames'
 import { DataSource } from 'meta/assessment'
 import { TooltipId } from 'meta/tooltip'
 
-import DataColumn from 'client/components/DataGridDeprecated/DataColumn'
+import { DataCell } from 'client/components/DataGrid'
 import Icon from 'client/components/Icon'
-import VerticallyGrowingTextField from 'client/components/VerticallyGrowingTextField'
+import TextArea from 'client/components/Inputs/TextArea'
 
 import { datasourceValidators } from './datasourceValidators'
 
@@ -17,10 +17,11 @@ interface DataSourceReferenceColumnProps {
   placeholder: boolean
   disabled: boolean
   onChange: (key: string, value: Record<string, string>) => void
+  lastRow: boolean
 }
 
 const ColumnReference: React.FC<DataSourceReferenceColumnProps> = (props: DataSourceReferenceColumnProps) => {
-  const { dataSourceValue, placeholder, disabled, onChange } = props
+  const { dataSourceValue, placeholder, disabled, onChange, lastRow } = props
   const { t } = useTranslation()
 
   const [toggleLinkField, setToggleLinkField] = useState(false)
@@ -40,49 +41,48 @@ const ColumnReference: React.FC<DataSourceReferenceColumnProps> = (props: DataSo
   }, [dataSourceValue.reference?.text])
 
   return (
-    <DataColumn
+    <DataCell
+      lastRow={lastRow}
       data-tooltip-id={TooltipId.error}
       data-tooltip-content={validationError ? t('generalValidation.shouldContainAtLeastOneCharacter') : ''}
-      className={classNames('data-source-column', {
+      className={classNames('data-source__column-reference', {
         'validation-error': validationError,
       })}
     >
-      <div className="data-source__text-area-wrapper">
-        {!disabled && !toggleLinkField && (
-          <VerticallyGrowingTextField
-            disabled={disabled}
-            onChange={(event) => _onChange('text', event.target.value)}
-            value={dataSourceValue.reference?.text ?? ''}
-          />
-        )}
+      {!disabled && !toggleLinkField && (
+        <TextArea
+          disabled={disabled}
+          onChange={(event) => _onChange('text', event.target.value)}
+          value={dataSourceValue.reference?.text ?? ''}
+        />
+      )}
 
-        {!disabled && toggleLinkField && (
-          <VerticallyGrowingTextField
-            disabled={disabled}
-            onChange={(event) => _onChange('link', event.target.value)}
-            value={dataSourceValue.reference?.link ?? ''}
-          />
-        )}
+      {!disabled && toggleLinkField && (
+        <TextArea
+          disabled={disabled}
+          onChange={(event) => _onChange('link', event.target.value)}
+          value={dataSourceValue.reference?.link ?? ''}
+        />
+      )}
 
-        {disabled && (
-          <span className="text-input__readonly-view">
-            {dataSourceValue.reference?.link ? (
-              <a href={dataSourceValue.reference?.link} target="_blank" rel="noreferrer">
-                {dataSourceValue.reference?.text}
-              </a>
-            ) : (
-              dataSourceValue.reference?.text
-            )}
-          </span>
-        )}
+      {disabled && (
+        <span className="text-input__readonly-view">
+          {dataSourceValue.reference?.link ? (
+            <a href={dataSourceValue.reference?.link} target="_blank" rel="noreferrer">
+              {dataSourceValue.reference?.text}
+            </a>
+          ) : (
+            dataSourceValue.reference?.text
+          )}
+        </span>
+      )}
 
-        {!placeholder && !disabled && (
-          <button type="button" onClick={() => setToggleLinkField(!toggleLinkField)}>
-            {toggleLinkField ? <Icon name="text_fields" /> : <Icon name="insert_link" />}
-          </button>
-        )}
-      </div>
-    </DataColumn>
+      {!placeholder && !disabled && (
+        <button type="button" onClick={() => setToggleLinkField(!toggleLinkField)}>
+          {toggleLinkField ? <Icon name="text_fields" /> : <Icon name="insert_link" />}
+        </button>
+      )}
+    </DataCell>
   )
 }
 

--- a/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSourceColumn/ColumnTypeOfDataSource.tsx
+++ b/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSourceColumn/ColumnTypeOfDataSource.tsx
@@ -5,8 +5,8 @@ import { DataSource, DataSourceType } from 'meta/assessment'
 import { DataSourceDescription } from 'meta/assessment/description/nationalDataDataSourceDescription'
 
 import Autocomplete from 'client/components/Autocomplete'
-import DataColumn from 'client/components/DataGridDeprecated/DataColumn'
-import VerticallyGrowingTextField from 'client/components/VerticallyGrowingTextField'
+import { DataCell } from 'client/components/DataGrid'
+import TextArea from 'client/components/Inputs/TextArea'
 
 type Props = {
   disabled: boolean
@@ -17,11 +17,7 @@ type Props = {
 const TextInput: React.FC<Props> = (props: Props) => {
   const { dataSourceValue, disabled, onChange } = props
   const _onChange: React.ChangeEventHandler<HTMLTextAreaElement> = (event) => onChange('type', event.target.value)
-  return (
-    <div className="data-source__text-area-wrapper">
-      <VerticallyGrowingTextField disabled={disabled} onChange={_onChange} value={dataSourceValue.type} />
-    </div>
-  )
+  return <TextArea disabled={disabled} onChange={_onChange} value={dataSourceValue.type} />
 }
 
 const SelectInput: React.FC<Props> = (props: Props) => {
@@ -50,17 +46,17 @@ const SelectInput: React.FC<Props> = (props: Props) => {
   )
 }
 
-const ColumnTypeOfDataSource: React.FC<Props & { dataSourceMetadata: DataSourceDescription }> = (
-  props: Props & { dataSourceMetadata: DataSourceDescription }
+const ColumnTypeOfDataSource: React.FC<Props & { dataSourceMetadata: DataSourceDescription; lastRow: boolean }> = (
+  props: Props & { dataSourceMetadata: DataSourceDescription; lastRow: boolean }
 ) => {
-  const { dataSourceMetadata } = props
+  const { dataSourceMetadata, lastRow } = props
   const { typeOfDataSourceText } = dataSourceMetadata?.table || {}
 
   return (
-    <DataColumn className="data-source-column">
+    <DataCell lastRow={lastRow}>
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
       {typeOfDataSourceText ? <TextInput {...props} /> : <SelectInput {...props} />}
-    </DataColumn>
+    </DataCell>
   )
 }
 

--- a/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSourceColumn/ColumnVariables.tsx
+++ b/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSourceColumn/ColumnVariables.tsx
@@ -4,9 +4,9 @@ import { useTranslation } from 'react-i18next'
 import { DataSource, Labels } from 'meta/assessment'
 import { DataSourceDescription } from 'meta/assessment/description/nationalDataDataSourceDescription'
 
-import DataColumn from 'client/components/DataGridDeprecated/DataColumn'
+import { DataCell } from 'client/components/DataGrid'
+import TextArea from 'client/components/Inputs/TextArea'
 import MultiSelect from 'client/components/MultiSelect'
-import VerticallyGrowingTextField from 'client/components/VerticallyGrowingTextField'
 
 type Props = {
   disabled: boolean
@@ -21,7 +21,7 @@ const Variable: React.FC<Omit<Props, 'dataSourceMetadata'>> = (props: Omit<Props
     onChange('variables', event.target.value ? [event.target.value] : [])
   const [value] = dataSourceValue.variables ?? []
 
-  return <VerticallyGrowingTextField disabled={disabled} onChange={_onChange} value={value} />
+  return <TextArea disabled={disabled} onChange={_onChange} value={value} />
 }
 
 const Variables: React.FC<Props> = (props: Props) => {
@@ -57,14 +57,14 @@ const Variables: React.FC<Props> = (props: Props) => {
   )
 }
 
-const ColumnVariables: React.FC<Props> = (props: Props) => {
-  const { dataSourceMetadata } = props
+const ColumnVariables: React.FC<Props & { lastRow: boolean }> = (props: Props & { lastRow: boolean }) => {
+  const { dataSourceMetadata, lastRow } = props
   const multiSelect = dataSourceMetadata.table?.variables?.length > 0
   return (
-    <DataColumn className="data-source-column">
+    <DataCell lastRow={lastRow}>
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
       {multiSelect ? <Variables {...props} /> : <Variable {...props} />}
-    </DataColumn>
+    </DataCell>
   )
 }
 

--- a/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSourceColumn/ColumnYearForDataSource.tsx
+++ b/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSourceColumn/ColumnYearForDataSource.tsx
@@ -2,26 +2,25 @@ import React from 'react'
 
 import { DataSource } from 'meta/assessment'
 
-import DataColumn from 'client/components/DataGridDeprecated/DataColumn'
-import VerticallyGrowingTextField from 'client/components/VerticallyGrowingTextField'
+import { DataCell } from 'client/components/DataGrid'
+import TextArea from 'client/components/Inputs/TextArea'
 
 type Props = {
   disabled: boolean
   dataSourceValue: DataSource
   onChange: (key: string, value: string) => void
+  lastRow: boolean
 }
 
 const ColumnVariable: React.FC<Props> = (props: Props) => {
-  const { dataSourceValue, disabled, onChange } = props
+  const { dataSourceValue, disabled, onChange, lastRow } = props
 
   const _onChange: React.ChangeEventHandler<HTMLTextAreaElement> = (event) => onChange('year', event.target.value)
 
   return (
-    <DataColumn className="data-source-column">
-      <div className="data-source__text-area-wrapper">
-        <VerticallyGrowingTextField disabled={disabled} onChange={_onChange} value={dataSourceValue.year} />
-      </div>
-    </DataColumn>
+    <DataCell lastRow={lastRow}>
+      <TextArea disabled={disabled} onChange={_onChange} value={dataSourceValue.year} />
+    </DataCell>
   )
 }
 export default ColumnVariable

--- a/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSourceRow.tsx
+++ b/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSourceRow.tsx
@@ -4,6 +4,7 @@ import { DataSource } from 'meta/assessment'
 import { DataSourceDescription } from 'meta/assessment/description/nationalDataDataSourceDescription'
 
 import { useIsDataLocked } from 'client/store/ui/dataLock'
+import { DataCell } from 'client/components/DataGrid'
 import Icon from 'client/components/Icon'
 import ReviewIndicator from 'client/components/ReviewIndicator'
 
@@ -20,10 +21,11 @@ type Props = {
   placeholder: boolean
   onChange: (dataSource: DataSource) => void
   onDelete: () => void
+  lastRow: boolean
 }
 
 const DataSourceRow: React.FC<Props> = (props: Props) => {
-  const { dataSourceValue, dataSourceMetadata, disabled, onChange, onDelete, placeholder } = props
+  const { dataSourceValue, dataSourceMetadata, disabled, onChange, onDelete, placeholder, lastRow } = props
   const isDataLocked = useIsDataLocked()
 
   const _onChange = useCallback(
@@ -55,25 +57,33 @@ const DataSourceRow: React.FC<Props> = (props: Props) => {
         onChange={_onChange}
         disabled={disabled}
         placeholder={placeholder}
+        lastRow={lastRow}
       />
       <ColumnTypeOfDataSource
         dataSourceMetadata={dataSourceMetadata}
         dataSourceValue={dataSourceValue}
         onChange={_onChange}
         disabled={disabled}
+        lastRow={lastRow}
       />
       <ColumnVariables
         dataSourceValue={dataSourceValue}
         dataSourceMetadata={dataSourceMetadata}
         onChange={_onChange}
         disabled={disabled}
+        lastRow={lastRow}
       />
-      <ColumnYearForDataSource disabled={disabled} dataSourceValue={dataSourceValue} onChange={_onChange} />
-      <ColumnComments disabled={disabled} dataSourceValue={dataSourceValue} onChange={_onChange} />
+      <ColumnYearForDataSource
+        disabled={disabled}
+        dataSourceValue={dataSourceValue}
+        onChange={_onChange}
+        lastRow={lastRow}
+      />
+      <ColumnComments disabled={disabled} dataSourceValue={dataSourceValue} onChange={_onChange} lastRow={lastRow} />
 
-      <div className="data-source__relative-cell">
+      <DataCell review>
         {!isDataLocked && dataSourceValue.uuid && <ReviewIndicator title={title} topicKey={dataSourceValue.uuid} />}
-      </div>
+      </DataCell>
     </>
   )
 }

--- a/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSources.scss
+++ b/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSources.scss
@@ -4,14 +4,8 @@
   margin-top: $spacing-xs;
 }
 
-.data-source-grid {
-  grid-template-columns: 0px 400px 400px repeat(3, 1fr) 0px;
-  margin: $spacing-s 0;
-
-  .data-source-column {
-    position: relative;
-    min-height: 2rem;
-  }
+.data-source__relative-cell {
+  position: relative;
 
   .data-source__delete-button {
     position: absolute;
@@ -19,44 +13,23 @@
     top: 0;
     bottom: 0;
     border: 0;
+    align-items: center;
+
+    background-color: transparent;
     background-color: transparent;
 
     svg {
       color: $ui-destructive;
     }
   }
-
-  .data-source__relative-cell {
-    position: relative;
-
-    .review-indicator {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      align-items: center;
-    }
-  }
 }
 
-.data-source__text-area-wrapper {
+.data-source__column-reference {
   display: flex;
   height: 100%;
 
   > button {
     border: 0;
     background-color: transparent;
-  }
-
-  > div {
-    width: 100%;
-  }
-
-  textarea:focus {
-    box-shadow: none;
-  }
-
-  &:focus-within {
-    outline: none;
-    box-shadow: 0 0 0 1px $text-body;
   }
 }

--- a/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSources.tsx
+++ b/src/client/pages/Section/Descriptions/CommentableDescription/Description/DataSources/DataSources.tsx
@@ -9,8 +9,7 @@ import { CommentableDescriptionValue, DataSource } from 'meta/assessment'
 
 import { useAssessment, useCycle } from 'client/store/assessment'
 import { useSection } from 'client/store/metadata'
-import DataGrid from 'client/components/DataGridDeprecated'
-import DataColumn from 'client/components/DataGridDeprecated/DataColumn'
+import { DataCell, DataGrid } from 'client/components/DataGrid'
 
 import { useDescriptions } from '../../../Descriptions'
 import { useGetDataSourcesLinked } from './hooks/useGetDataSourcesLinked'
@@ -90,15 +89,16 @@ export const DataSources: React.FC<Props> = (props: Props) => {
           sectionName={sectionName}
         />
       )}
-
-      <DataGrid className="data-source-grid">
+      <DataGrid gridTemplateColumns="0px minmax(0, 400px) auto minmax(0, 300px) minmax(0, 100px) minmax(0, 400px) 0px">
         <div />
 
-        <DataColumn head>{t(`${keyPrefix}.referenceToTataSource`)}</DataColumn>
-        <DataColumn head>{t(`${keyPrefix}.typeOfDataSource`)}</DataColumn>
-        <DataColumn head>{t(`${keyPrefix}.variable`)}</DataColumn>
-        <DataColumn head>{t(`${keyPrefix}.yearForDataSource`)}</DataColumn>
-        <DataColumn head>{t(`${keyPrefix}.comments`)}</DataColumn>
+        <DataCell header>{t(`${keyPrefix}.referenceToTataSource`)}</DataCell>
+        <DataCell header>{t(`${keyPrefix}.typeOfDataSource`)}</DataCell>
+        <DataCell header>{t(`${keyPrefix}.variable`)}</DataCell>
+        <DataCell header>{t(`${keyPrefix}.yearForDataSource`)}</DataCell>
+        <DataCell header lastCol>
+          {t(`${keyPrefix}.comments`)}
+        </DataCell>
 
         <div />
 
@@ -112,6 +112,7 @@ export const DataSources: React.FC<Props> = (props: Props) => {
               onChange={() => ({})}
               onDelete={() => ({})}
               placeholder={false}
+              lastRow={i === dataSourcesLinked.length - 1}
             />
           ))}
 
@@ -125,6 +126,7 @@ export const DataSources: React.FC<Props> = (props: Props) => {
               onChange={_onChange}
               onDelete={() => _onDelete(dataSourceValue.uuid)}
               placeholder={!dataSourceValue.uuid}
+              lastRow={disabled ? i === dataSourceValues.length - 1 : i === dataSourceValues.length}
             />
           )
         })}


### PR DESCRIPTION
Fixing the layout of National Data : Data Sources by replacing the deprecated Datagrid and VerticallyGrowingTextField.


https://github.com/openforis/fra-platform/assets/41337901/7e1cd834-1af3-40aa-8eff-be78be003e46


Issue that arise from switching to the new Datagrid and TextArea components:

- With the new Datagrid, the border highlighting depends on the TextArea components, and due to the `useResize` hook, the height in the TextArea is set depending on the scrolling height. This is not working correctly in the cells, so the initial height is not the full height of the cell. And since the TextArea has a margin in the styles, the scrolling height + the margin make the border overflow. 
- The border highlighting also depends on  the Select and Autocomplete components in the cells, and changing those without breaking something else in the app has proven to be very hard to do. 

UPDATED VERSION:

https://github.com/openforis/fra-platform/assets/41337901/324d56d4-b090-46bc-b3cd-8ca4fb50e08a

