### PR TITLE
3174 Contacts: Populate actual contributions

### DIFF
--- a/src/client/pages/Section/Contacts/hooks/useOptionsContributions.ts
+++ b/src/client/pages/Section/Contacts/hooks/useOptionsContributions.ts
@@ -19,27 +19,30 @@ export const useOptionsContributions = (): Options => {
   const cycle = useCycle()
   const sections = useSections()
 
-  return useMemo<Options>(
-    () =>
-      sections.flatMap((section) => {
-        const subSections = section.subSections.flatMap((subSection) => {
-          const anchor = t(
-            SubSections.getAnchorLabel({ assessment, cycle, subSection }),
-            SubSections.getAnchor({ cycle, subSection })
-          )
+  return useMemo<Options>(() => {
+    const sectionOptions = sections.flatMap((section) => {
+      const subSections = section.subSections.flatMap((subSection) => {
+        const anchor = t(
+          SubSections.getAnchorLabel({ assessment, cycle, subSection }),
+          SubSections.getAnchor({ cycle, subSection })
+        )
 
-          const _label = Labels.getCycleLabel({ cycle, labels: subSection.props.labels, t })
+        const _label = Labels.getCycleLabel({ cycle, labels: subSection.props.labels, t })
 
-          const label = { key: `${anchor} ${_label}` }
-          const value = subSection.uuid
+        const label = { key: `${anchor} ${_label}` }
+        const value = subSection.uuid
 
-          return { label, value }
-        })
+        return { label, value }
+      })
 
-        const label = { key: Labels.getCycleLabel({ cycle, labels: section.props.labels, t }) }
+      const label = { key: Labels.getCycleLabel({ cycle, labels: section.props.labels, t }) }
 
-        return [{ label, value: section.uuid, type: 'header' }, ...subSections]
-      }),
-    [assessment, cycle, sections, t]
-  )
+      return [{ label, value: section.uuid, type: 'header' }, ...subSections]
+    })
+
+    const all = { label: { key: t('contactPersons.all') }, value: 'all' }
+    const none = { label: { key: t('contactPersons.none') }, value: 'none' }
+
+    return [all, none, ...sectionOptions]
+  }, [assessment, cycle, sections, t])
 }


### PR DESCRIPTION
# RFC: ODP sections?

![image](https://github.com/openforis/fra-platform/assets/5508251/c764a401-e2ce-4c45-9cad-0cee5baa34ac)

```
Test query in REPL with populated variables:

select
    u.uuid,
    ur.country_iso,
    jsonb_build_object('readOnly', true) as props,
    jsonb_build_object(
            'role',ur.role,
            'appellation', lower(u.props ->> 'title'),
            'name',u.props ->> 'name',
            'surname',u.props ->> 'surname',
            'institution',ur.props ->> 'organization',
            'contributions',
            case when ur.role = 'COLLABORATOR'
                     then coalesce( jsonb_agg(s.uuid) filter (where s.uuid is not null), '["none"]'::jsonb)
                 else '["all"]'
                end
    ) as value
from public.users u
         left join public.users_role ur on (u.id = ur.user_id)
         left join assessment_fra_2025."activity_log_FIN"
    al on u.id::numeric = (al."user" ->> 'id')::numeric
         left join assessment_fra.section s on al.section = s.props ->> 'name'
where
    ur.role in ('COLLABORATOR','NATIONAL_CORRESPONDENT','ALTERNATE_NATIONAL_CORRESPONDENT')
  and ur.country_iso = 'FIN'
  and ur.cycle_uuid = '66da2217-da42-492f-9ff4-c99a59e6675c'
  and ur.assessment_id = 1
  and u.status = 'active'
group by u.id, ur.id
```


```
Test query in REPL with only contributions
select u.id, jsonb_agg(s.uuid) as sections
from public.users_role ur
    left join public.users u on ur.user_id = u.id
    left join assessment_fra_2025."activity_log_DEU"  al on u.id::numeric = (al."user" ->> 'id')::numeric
left join assessment_fra.section s on al.section = s.props ->> 'name'
where ur.country_iso = 'DEU'
and al.section not in ('users')
and s.uuid is not null
group by u.id
```