### PR TITLE
Fix col heading offset bug

### DIFF
--- a/src/client/components/ButtonTableExport/utils.ts
+++ b/src/client/components/ButtonTableExport/utils.ts
@@ -1,5 +1,6 @@
 // Inspiration/base from cheerio-tableparser
 //
+import { Objects } from 'utils/objects'
 
 const normalizeString = (string = '') => string.trim().replace(/\s/g, ' ')
 
@@ -52,13 +53,13 @@ export const getData = (
       // Handle spanning cells
       for (let x = 0; x < rowSpan; x += 1) {
         for (let y = 0; y < colSpan; y += 1) {
-          if (!columns[currentY + y]) {
+          if (Objects.isNil(columns[currentY + y])) {
             columns[currentY + y] = []
           }
 
-          while (columns[currentY + y][currentX + x]) {
+          while (!Objects.isNil(columns[currentY + y][currentX + x])) {
             currentY += 1
-            if (!columns[currentY + y]) {
+            if (Objects.isNil(columns[currentY + y])) {
               columns[currentY + y] = []
             }
           }


### PR DESCRIPTION
After debugging for a while I noticed that changing the non-breaking space character `&nbsp;` for a Zero-witdh space character `&#x200B;` would fix the issue. This didn't seem to be correct approach for a fix since it would make the logic working depend on a character. So, after further investigation, I found that the important difference between those characters in this context is that `&nbsp;` is trimmed by javascript while `&#x200B;` is not. This happens in line 4 at `src/client/components/ButtonTableExport/utils.ts`:

```
const normalizeString = (string = '') => string.trim().replace(/\s/g, ' ')

const _getElementText = (element: HTMLElement): string => {
                      {...}
  return normalizeString(innerText)
}
```

The problem with this is that the variable `content` becomes an empty string `""` and then In line 59: 

```
  59:     while (columns[currentY + y][currentX + x]) {
            currentY += 1
            if (columns[currentY + y] === undefined) {
              columns[currentY + y] = []
            }
          }
```

The while condition will evaluate `columns[currentY + y][currentX + x]` to False due to empty string being a falsy value. This explains why when the character was not fully trimmed the code would work. In those cases the while condition would evaluate to True and wouldn't skip the cell.

Fix:
Checking specifically for `undefined` values to avoid unexpected behaviour when evaluating other falsy values:
`if (columns[currentY + y] === undefined) {`
`while (columns[currentY + y][currentX + x] !== undefined) {`
`if (columns[currentY + y] === undefined) {`



https://github.com/openforis/fra-platform/assets/41337901/f114af01-a9a0-4a17-a23c-1a6828764da0

