### PR TITLE
3303 geo refactor Agreement Layer / Custom Assets

### DIFF
--- a/src/client/pages/Geo/GeoMap/GeoMap.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMap.tsx
@@ -4,9 +4,10 @@ import React, { useEffect, useRef, useState } from 'react'
 import { useAppDispatch } from 'client/store'
 import { GeoActions } from 'client/store/ui/geo'
 import { useCountryIso } from 'client/hooks'
-// import { useMapLayersHandler } from 'client/pages/Geo/GeoMap/hooks'
 import { getCountryBounds } from 'client/pages/Geo/utils/countryBounds'
 import { mapController } from 'client/utils'
+
+import { useMapLayersHandler } from './hooks'
 
 type Props = {
   viewport?: google.maps.LatLngBoundsLiteral
@@ -51,7 +52,7 @@ const GeoMap: React.FC<React.PropsWithChildren<Props>> = (props) => {
   }, [ref, map, zoom, viewport, countryIso, dispatch])
 
   // Add layers handler
-  // useMapLayersHandler()
+  useMapLayersHandler()
 
   // Move and center the map to the new country location.
   useEffect(() => {

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/LayersSectionPanel.tsx
@@ -95,7 +95,6 @@ const LayersSectionPanel: React.FC<React.PropsWithChildren<Props>> = ({ section 
                 layerKey={layer.key}
                 loadingStatus={loadingStatus}
                 section={section}
-                sectionState={sectionState}
               />
             )
           }

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/AgreementLevelControl/AgreementLevelControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/AgreementLevelControl/AgreementLevelControl.tsx
@@ -5,9 +5,10 @@ import { LayerKey, LayerSection, LayerSectionKey } from 'meta/geo/layer'
 
 import { useAppDispatch } from 'client/store'
 import { GeoActions, useGeoLayer } from 'client/store/ui/geo'
-import { LayerFetchStatus, LayersSectionState } from 'client/store/ui/geo/stateType'
+import { LayerFetchStatus } from 'client/store/ui/geo/stateType'
 import GeoMapMenuListElement from 'client/pages/Geo/GeoMap/GeoMapMenuListElement'
 import { useFetchAgreementLevelLayer } from 'client/pages/Geo/GeoMap/hooks'
+import { useCountSectionSelectedLayers } from 'client/pages/Geo/GeoMap/hooks/useCountSectionSelectedLayers'
 
 import LayerOpacityControl from '../LayerOpacityControl/LayerOpacityControl'
 import AgreementLevelSelector from './AgreementLevelSelector/AgreementLevelSelector'
@@ -21,7 +22,6 @@ interface Props {
   layerKey: LayerKey
   loadingStatus: LayerFetchStatus
   section: LayerSection
-  sectionState: LayersSectionState
 }
 const AgreementLevelControl: React.FC<Props> = ({
   checked,
@@ -32,7 +32,6 @@ const AgreementLevelControl: React.FC<Props> = ({
   layerKey,
   loadingStatus,
   section,
-  sectionState,
 }) => {
   const dispatch = useAppDispatch()
   const layerState = useGeoLayer(sectionKey, layerKey)
@@ -42,14 +41,7 @@ const AgreementLevelControl: React.FC<Props> = ({
     dispatch(GeoActions.setAgreementLevel({ sectionKey, layerKey, level }))
   }
 
-  let countLayersSelected = 0
-  if (sectionState) {
-    Object.keys(sectionState).forEach((layerKey) => {
-      if (layerKey === 'Agreement') return
-      const layerState = sectionState[layerKey as LayerKey]
-      if (layerState.selected) countLayersSelected += 1
-    })
-  }
+  const countLayersSelected = useCountSectionSelectedLayers({ ignoreAgreementLayer: true, sectionKey })
 
   if (countLayersSelected < 2) return null
 

--- a/src/client/pages/Geo/GeoMap/hooks/index.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/index.ts
@@ -3,7 +3,7 @@
 export { useDownloadChart } from './useDownloadChart'
 // export { useForestLayersHandler } from './useForestLayersHandler'
 export { useGeoStatisticsHandler } from './useGeoStatisticsHandler'
-// export { useMapLayersHandler } from './useMapLayersHandler'
+export { useMapLayersHandler } from './useMapLayersHandler'
 // export { useProtectedAreaLayersHandler } from './useProtectedAreaLayersHandler'
 // export { useRecipeLayerPropertyName } from './useRecipeLayerPropertyName'
 export { useFetchAgreementLevelLayer } from './useFetchAgreementLevelLayer'

--- a/src/client/pages/Geo/GeoMap/hooks/useCountSectionSelectedLayers.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/useCountSectionSelectedLayers.ts
@@ -1,23 +1,29 @@
-import { useEffect, useState } from 'react'
+import { useMemo } from 'react'
 
 import { LayerKey, LayerSectionKey } from 'meta/geo'
 
 import { useGeoLayerSection } from 'client/store/ui/geo'
 
-export const useCountSectionSelectedLayers = (sectionKey: LayerSectionKey) => {
-  const [selectedLayersCount, setSelectedLayerCount] = useState(0)
+export const useCountSectionSelectedLayers = (props: {
+  ignoreAgreementLayer?: boolean
+  sectionKey: LayerSectionKey
+}) => {
+  const { ignoreAgreementLayer = false, sectionKey } = props
   const sectionState = useGeoLayerSection(sectionKey)
 
-  useEffect(() => {
-    if (sectionState === undefined) return
+  const selectedLayersCount = useMemo<number>(() => {
+    if (sectionState === undefined) return 0
     let count = 0
+
     Object.keys(sectionState).forEach((layerKey) => {
+      if (ignoreAgreementLayer && layerKey === 'Agreement') return
+
       if (sectionState[layerKey as LayerKey].selected) {
         count += 1
       }
     })
-    setSelectedLayerCount(count)
-  }, [sectionState])
+    return count
+  }, [ignoreAgreementLayer, sectionState])
 
   return selectedLayersCount
 }

--- a/src/client/pages/Geo/GeoMap/hooks/useCountryIsoChangeHandler.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/useCountryIsoChangeHandler.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react'
+
+import { LayerKey, LayerSectionKey } from 'meta/geo'
+
+import { useAppDispatch } from 'client/store'
+import { GeoActions, useGeoLayerSections } from 'client/store/ui/geo'
+import { useCountryIso, usePrevious } from 'client/hooks'
+
+export const useCountryIsoChangeHandler = () => {
+  const countryIso = useCountryIso()
+  const prevCountryIso = usePrevious(countryIso)
+  const dispatch = useAppDispatch()
+  const allSectionsState = useGeoLayerSections()
+
+  useEffect(() => {
+    if (prevCountryIso === countryIso) return
+
+    dispatch(GeoActions.resetAllLayersStatus())
+
+    Object.keys(allSectionsState ?? {}).forEach((sectionKey) => {
+      Object.keys(allSectionsState[sectionKey as LayerSectionKey]).forEach((layerKey) => {
+        const layerState = allSectionsState[sectionKey as LayerSectionKey][layerKey as LayerKey]
+        if (!layerState.selected || (layerState.opacity ?? 0) === 0) {
+          dispatch(
+            GeoActions.setLayerMapId({
+              sectionKey: sectionKey as LayerSectionKey,
+              layerKey: layerKey as LayerKey,
+              mapId: null,
+            })
+          )
+          return
+        }
+
+        dispatch(
+          GeoActions.postLayer({
+            countryIso,
+            sectionKey: sectionKey as LayerSectionKey,
+            layerKey: layerKey as LayerKey,
+          })
+        )
+      })
+    })
+  }, [countryIso, prevCountryIso, allSectionsState, dispatch])
+}
+
+export default useCountryIsoChangeHandler

--- a/src/client/pages/Geo/GeoMap/hooks/useFetchAgreementLevelLayer.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/useFetchAgreementLevelLayer.ts
@@ -14,7 +14,7 @@ export const useFetchAgreementLevelLayer = (sectionKey: LayerSectionKey, layerKe
   const sectionState = useGeoLayerSection(sectionKey)
   const layerState = sectionState?.[layerKey]
   const agreementLevel = layerState?.options?.agreementLayer?.level
-  const countSelectedLayers = useCountSectionSelectedLayers(sectionKey)
+  const countSelectedLayers = useCountSectionSelectedLayers({ sectionKey, ignoreAgreementLayer: true })
 
   useEffect(() => {
     if (agreementLevel === undefined) return // Skip when the property is not set

--- a/src/client/pages/Geo/GeoMap/hooks/useMapLayersHandler.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/useMapLayersHandler.ts
@@ -1,13 +1,7 @@
-// import {
-//   useAgreementLayerHandler,
-//   useBurnedAreaLayersHandler,
-//   useForestLayersHandler,
-//   useProtectedAreaLayersHandler,
-// } from '.'
+import useCountryIsoChangeHandler from './useCountryIsoChangeHandler'
 
-// export const useMapLayersHandler = () => {
-//   useAgreementLayerHandler()
-//   useForestLayersHandler()
-//   useProtectedAreaLayersHandler()
-//   useBurnedAreaLayersHandler()
-// }
+export const useMapLayersHandler = () => {
+  useCountryIsoChangeHandler()
+}
+
+export default useMapLayersHandler

--- a/src/client/store/ui/geo/actions/toggleLayer.ts
+++ b/src/client/store/ui/geo/actions/toggleLayer.ts
@@ -23,20 +23,21 @@ export const toggleLayer = createAsyncThunk<void, Params>(
     const layerState = (state as RootState).geo?.sections?.[sectionKey]?.[layerKey]
 
     const currentLayerSelected = layerState?.selected ?? false
-    const currentMapId = layerState?.mapId
-
-    // If the layer is now selected and doesn't have a mapId cached, fetch it
-    if (!currentLayerSelected && !currentMapId && fetchLayerParams) {
-      dispatch(
-        GeoActions.postLayer({
-          sectionKey,
-          layerKey,
-          countryIso: fetchLayerParams.countryIso,
-          layerSource: fetchLayerParams.layerSource,
-        })
-      )
-    }
-
     dispatch(GeoActions.setLayerSelected({ sectionKey, layerKey, selected: !currentLayerSelected }))
+
+    // If the layer is now selected, doesn't have a mapId cached and is visible, fetch it
+    const currentMapId = layerState?.mapId
+    if (currentLayerSelected || currentMapId) return
+    if (layerState?.opacity === 0) return
+
+    if (!fetchLayerParams) return
+    dispatch(
+      GeoActions.postLayer({
+        sectionKey,
+        layerKey,
+        countryIso: fetchLayerParams.countryIso,
+        layerSource: fetchLayerParams.layerSource,
+      })
+    )
   }
 )

--- a/src/client/store/ui/geo/hooks/index.ts
+++ b/src/client/store/ui/geo/hooks/index.ts
@@ -59,3 +59,6 @@ export const useGeoProtectedAreas = () => {
 
 export const useGeoLayerSectionRecipeName = (sectionKey: LayerSectionKey): string | undefined =>
   useAppSelector((state) => state.geo.recipes[sectionKey])
+
+export const useGeoLayerSections = (): Record<LayerSectionKey, LayersSectionState> | undefined =>
+  useAppSelector((state) => state.geo?.sections)

--- a/src/client/store/ui/geo/index.ts
+++ b/src/client/store/ui/geo/index.ts
@@ -3,6 +3,7 @@ export {
   useGeoLayer,
   useGeoLayerSection,
   useGeoLayerSectionRecipeName,
+  useGeoLayerSections,
   useGeoStatistics,
   useIsGeoMapAvailable,
   useMosaicFailed,

--- a/src/client/store/ui/geo/slice.ts
+++ b/src/client/store/ui/geo/slice.ts
@@ -230,6 +230,14 @@ export const geoSlice = createSlice({
       const mapLayerKey: MapLayerKey = `${sectionKey}-${layerKey}`
       mapController.setEarthEngineLayerOpacity(mapLayerKey, opacity)
     },
+    setLayerMapId: (
+      state: Draft<GeoState>,
+      action: PayloadAction<{ sectionKey: LayerSectionKey; layerKey: LayerKey; mapId: string | null }>
+    ) => {
+      const { sectionKey, layerKey, mapId } = action.payload
+      const layerState = getLayerState(state, sectionKey, layerKey)
+      state.sections[sectionKey][layerKey] = { ...layerState, mapId }
+    },
     setAssetId: (
       state: Draft<GeoState>,
       action: PayloadAction<{ sectionKey: LayerSectionKey; layerKey: LayerKey; assetId: string }>

--- a/src/client/store/ui/geo/stateType.ts
+++ b/src/client/store/ui/geo/stateType.ts
@@ -27,7 +27,7 @@ export type LayerState = {
   opacity?: number
   status?: LayerFetchStatus
   options?: LayerStateOptions
-  mapId?: string
+  mapId?: string | null
 }
 
 export type LayersSectionState = Record<LayerKey, LayerState>


### PR DESCRIPTION
Closes #3303 [GEO Refactor: Agreement layer (partly) #](https://github.com/openforis/fra-platform/issues/3303)
Closes #3306 [GEO Refactor: Custom assets #3306](https://github.com/openforis/fra-platform/issues/3306)

- Added logic to re-fetch layers when the country ISO changes. Only layers with opacity > are re-fetched.
- Added logic to re-fecth the agreement layer when the selected layers change.
- Tested the Custom Asset feature with the Asset ID `users/geofra/protected_areas/v1/PAs_WDPA_Bin_30m_World_2020`


https://github.com/openforis/fra-platform/assets/41337901/c2987138-ddd3-4546-8ed3-506b969ff39c

