### PR TITLE
3331 - Navigate to Cycle home from tutorials page on assessment change

### DIFF
--- a/src/client/components/PageLayout/Header/CycleSwitcher/hooks/useNavigateTo.tsx
+++ b/src/client/components/PageLayout/Header/CycleSwitcher/hooks/useNavigateTo.tsx
@@ -5,13 +5,14 @@ import { Assessment, Cycle } from 'meta/assessment'
 import { Routes } from 'meta/routes'
 import { User, Users } from 'meta/user'
 
-import { useCountryIso, useIsAdminRoute } from 'client/hooks'
+import { useIsAdminRoute } from 'client/hooks'
+import { useCountryRouteParams } from 'client/hooks/useRouteParams'
 
 export const useNavigateTo = () => {
   const navigate = useNavigate()
   // const { countryIso } = useCountryRouteParams()
   const isAdminPage = useIsAdminRoute()
-  const countryIso = useCountryIso()
+  const { countryIso } = useCountryRouteParams()
 
   return useCallback(
     (props: { assessment: Assessment; cycle: Cycle; user: User }) => {


### PR DESCRIPTION
Closes #3331 

Changed the cycle switcher links to always point to the Cycle home if the user is in the the tutorials page. 

https://github.com/openforis/fra-platform/assets/41337901/7a75d662-acf5-4237-94be-d61a647d0a14

