### PR TITLE
Add missing cycle name to translation

### DIFF
--- a/src/client/pages/Print/FraPrint/TableOfContent/TableOfContent.tsx
+++ b/src/client/pages/Print/FraPrint/TableOfContent/TableOfContent.tsx
@@ -26,7 +26,11 @@ const TableOfContent: React.FC<Props> = (props) => {
 
       <div className="disclaimer">
         <p>{t('print.disclaimer')}</p>
-        <p>{deskStudy ? t('print.disclaimerGeneratedDeskStudy') : t('print.disclaimerGenerated')}</p>
+        <p>
+          {deskStudy
+            ? t('print.disclaimerGeneratedDeskStudy')
+            : t('print.disclaimerGenerated', { cycleName: cycle?.name })}
+        </p>
       </div>
 
       <div className="page-break" />


### PR DESCRIPTION
Closes #3310 

Added the missing `cycleName` param to the translation in the print view. 


https://github.com/openforis/fra-platform/assets/41337901/bab914bd-5cb5-4f0e-8c07-9bafae2ccd87

