### PR TITLE
2581 - Geo change UI texts 

### DIFF
--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.tsx
@@ -81,11 +81,11 @@ const CustomAssetControl: React.FC<Props> = ({
               type="text"
               value={layerState?.options?.assetId ?? ''}
               onChange={handleInputChange}
-              placeholder="Asset ID"
+              placeholder="GEE asset id"
               className={classNames('custom-input', { error: !validInput })}
             />
             <button type="button" className="btn-primary" onClick={handleSubmit}>
-              Submit
+              Load
             </button>
           </div>
         </div>

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuMosaic/MosaicControl/MosaicControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuMosaic/MosaicControl/MosaicControl.tsx
@@ -18,7 +18,7 @@ const MosaicControl: React.FC<Props> = ({ loadingStatus }) => {
   return (
     <div>
       <GeoMenuItem
-        title="Show mosaic layer"
+        title="Show satellite mosaic"
         checked={mosaicSelected}
         loadingStatus={loadingStatus}
         tabIndex={-1}

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/BurnedAreaPanel/BurnedAreaPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/BurnedAreaPanel/BurnedAreaPanel.tsx
@@ -4,7 +4,7 @@ import { Numbers } from 'utils/numbers'
 
 import { BurnedAreaModis } from 'meta/geo/forest'
 
-import StatisticsTable from '../../components/StatisticsTable'
+import StatisticsTable from 'client/pages/Geo/GeoMap/components/StatisticsTable'
 
 type Props = {
   geoBurnedAreaMODIS: BurnedAreaModis

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/ProtectedAreaPanel/ProtectedAreaPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/ProtectedAreaPanel/ProtectedAreaPanel.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 
 import { Numbers } from 'utils/numbers'
 
-import { ExtraEstimation, ForestKey } from 'meta/geo'
+import { ExtraEstimation, ForestKey, forestLayersMetadata } from 'meta/geo'
 
-import StatisticsTable from '../../components/StatisticsTable'
+import StatisticsTable from 'client/pages/Geo/GeoMap/components/StatisticsTable'
 
 type Props = {
   geoProtectedAreas: Record<string, number>
@@ -14,16 +14,16 @@ type Props = {
 
 // refactor
 const sourceName: Record<string, string> = {
-  faCopernicusProtected: ForestKey.Copernicus,
-  faEsa2009Protected: ForestKey.ESAGlobCover,
-  faEsa2020Protected: ForestKey.ESAWorldCover,
-  faEsriProtected: ForestKey.ESRI,
-  faGlobelandProtected: ForestKey.GlobeLand,
+  faCopernicusProtected: forestLayersMetadata[ForestKey.Copernicus].title,
+  faEsa2009Protected: forestLayersMetadata[ForestKey.ESAGlobCover].title,
+  faEsa2020Protected: forestLayersMetadata[ForestKey.ESAWorldCover].title,
+  faEsriProtected: forestLayersMetadata[ForestKey.ESRI].title,
+  faGlobelandProtected: forestLayersMetadata[ForestKey.GlobeLand].title,
   faHansen10Protected: 'All (GFC Hansen >=10%)',
   faHansen20Protected: 'All (GFC Hansen >=20%)',
   faHansen30Protected: 'All (GFC Hansen >=30%)',
-  faJaxaProtected: ForestKey.JAXA,
-  faTandemxProtected: ForestKey.TandemX,
+  faJaxaProtected: forestLayersMetadata[ForestKey.JAXA].title,
+  faTandemxProtected: forestLayersMetadata[ForestKey.TandemX].title,
   fra3bProtected: ExtraEstimation.ReportedToFRA,
 }
 

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/StatisticalGraphsPanel/StatisticalGraphsPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/StatisticalGraphsPanel/StatisticalGraphsPanel.tsx
@@ -1,8 +1,8 @@
 import './StatisticalGraphsPanel.scss'
 import React, { useEffect, useState } from 'react'
 
-import { Numbers } from 'utils/numbers'
 import { ChartOptions, Plugin } from 'chart.js'
+import { Numbers } from 'utils/numbers'
 
 import { ExtraEstimation, extraEstimationsMetadata, ForestKey, forestLayersMetadata } from 'meta/geo'
 
@@ -10,7 +10,7 @@ import Chart from 'client/components/Chart'
 import { displayPercentagesPlugin, whiteBackgroundplugin } from 'client/pages/Geo/utils/chartPlugins'
 
 type Props = {
-  data: [string, number, number][]
+  data: [string, number, number, string][]
   countryIso: string
   year: number
 }
@@ -42,12 +42,12 @@ const StatisticalGraphsPanel: React.FC<Props> = (props: Props) => {
     })
 
     const backgroundColors = data.map((row) => {
-      const source = row[0] as ForestKey | ExtraEstimation
-      if (Object.values(ExtraEstimation).includes(source as ExtraEstimation)) {
-        return extraEstimationsMetadata[source as ExtraEstimation].palette[0]
+      const sourceKey = row[3] as ForestKey | ExtraEstimation
+      if (Object.values(ExtraEstimation).includes(sourceKey as ExtraEstimation)) {
+        return extraEstimationsMetadata[sourceKey as ExtraEstimation].palette[0]
       }
-      if (source.toUpperCase().indexOf(ForestKey.Hansen.toUpperCase()) === -1) {
-        return forestLayersMetadata[source as ForestKey].palette[0]
+      if (sourceKey.toUpperCase().indexOf(ForestKey.Hansen.toUpperCase()) === -1) {
+        return forestLayersMetadata[sourceKey as ForestKey].palette[0]
       }
       return forestLayersMetadata.Hansen.palette[0]
     })

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/TreeCoverAreaPanel/TreeCoverAreaPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/TreeCoverAreaPanel/TreeCoverAreaPanel.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 
 import { Numbers } from 'utils/numbers'
 
-import StatisticsTable from '../../components/StatisticsTable'
+import { useGeoFra1aLandArea } from 'client/store/ui/geo/hooks'
+import StatisticsTable from 'client/pages/Geo/GeoMap/components/StatisticsTable'
 
 type Props = {
   data: [string, number, number, string][]
@@ -11,7 +12,17 @@ type Props = {
 }
 
 const TreeCoverAreaPanel: React.FC<Props> = (props: Props) => {
+  const fra1aLandArea = useGeoFra1aLandArea()
   const columns = ['Source', 'Forest area', 'Forest area % of land area']
+
+  const csvHeaders = [
+    { label: 'Source', key: 'source' },
+    { label: 'Land area', key: 'landArea' },
+    { label: 'Forest area, ha', key: 'forestAreaHa' },
+    { label: 'Forest area % of land area', key: 'forestAreaPercentage' },
+  ]
+  const csvData: { source: string; landArea: string; forestAreaHa: string; forestAreaPercentage: string }[] = []
+
   const units = ['', 'ha', '%']
   const loaded = true
   const { data, countryIso, year } = props
@@ -25,7 +36,18 @@ const TreeCoverAreaPanel: React.FC<Props> = (props: Props) => {
     const percentage = rowData[2]
     const formatedArea = Numbers.format(area, 0)
     formattedTableData.push([sourceName, formatedArea, percentage])
+
+    csvData.push({
+      source: sourceName,
+      landArea: fra1aLandArea.toString(),
+      forestAreaHa: formatedArea,
+      forestAreaPercentage: `${percentage} %`,
+    })
   })
+  const customCsvDownload = {
+    headers: csvHeaders,
+    data: csvData,
+  }
 
   return (
     <div>
@@ -36,6 +58,7 @@ const TreeCoverAreaPanel: React.FC<Props> = (props: Props) => {
         tableData={formattedTableData}
         countryIso={countryIso}
         year={year}
+        customCsvDownload={customCsvDownload}
       />
     </div>
   )

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/TreeCoverAreaPanel/TreeCoverAreaPanel.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/TreeCoverAreaPanel/TreeCoverAreaPanel.tsx
@@ -5,14 +5,13 @@ import { Numbers } from 'utils/numbers'
 import StatisticsTable from '../../components/StatisticsTable'
 
 type Props = {
-  data: [string, number, number][]
+  data: [string, number, number, string][]
   countryIso: string
   year: number
 }
 
 const TreeCoverAreaPanel: React.FC<Props> = (props: Props) => {
   const columns = ['Source', 'Forest area', 'Forest area % of land area']
-  const title = 'Extent of forest per source and reported on 2020 (1a)'
   const units = ['', 'ha', '%']
   const loaded = true
   const { data, countryIso, year } = props
@@ -30,7 +29,6 @@ const TreeCoverAreaPanel: React.FC<Props> = (props: Props) => {
 
   return (
     <div>
-      <h3 className="table-title">{title}</h3>
       <StatisticsTable
         columns={columns}
         units={units}

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/geoMapMenuStatistics.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuStatistics/geoMapMenuStatistics.tsx
@@ -27,8 +27,8 @@ const GeoMapMenuStatistics: React.FC = () => {
       <GeoMapMenuButton panel="statistics" text="Statistics" icon="histogram" />
       {selectedPanel === 'statistics' && (
         <div>
-          {/* Tree Cover Area */}
-          <GeoMenuItem title="Tree Cover Area" checked={null} tabIndex={-1}>
+          {/* Extent of forest/tree cover by source */}
+          <GeoMenuItem title="Extent of forest/tree cover by source" checked={null} tabIndex={-1}>
             {!isLoading && statisticsData.length > 0 && (
               <TreeCoverAreaPanel data={statisticsData} countryIso={countryIso} year={year} />
             )}

--- a/src/client/pages/Geo/GeoMap/components/ButtonStatisticsTableExport/ButtonStatisticsTableExport.tsx
+++ b/src/client/pages/Geo/GeoMap/components/ButtonStatisticsTableExport/ButtonStatisticsTableExport.tsx
@@ -4,15 +4,17 @@ import { CSVLink } from 'react-csv'
 
 import Icon from 'client/components/Icon'
 
+import { CustomCsvDownload } from './types'
 import * as Utils from './utils'
 
 type Props = {
+  customCsvDownload?: CustomCsvDownload
   tableRef: MutableRefObject<HTMLTableElement>
   filename?: string
 }
 
 const ButtonTableExport: React.FC<Props> = (props) => {
-  const { tableRef, filename } = props
+  const { tableRef, filename, customCsvDownload } = props
   const csvLink = useRef(null)
   const [tableData, setTableData] = useState('')
 
@@ -31,16 +33,25 @@ const ButtonTableExport: React.FC<Props> = (props) => {
         <span>&nbsp;</span>
         <Icon className="icon-sub icon-white" name="hit-down" />
       </button>
-      <CSVLink className="hidden" ref={csvLink} target="_blank" filename={`${filename}.csv`} data={tableData}>
-        <Icon className="icon-sub icon-white" name="hit-down" />
-        CSV
-      </CSVLink>
+      {customCsvDownload !== undefined ? (
+        <CSVLink
+          className="hidden"
+          ref={csvLink}
+          target="_blank"
+          filename={filename}
+          data={customCsvDownload.data}
+          headers={customCsvDownload.headers}
+        />
+      ) : (
+        <CSVLink className="hidden" ref={csvLink} target="_blank" filename={`${filename}.csv`} data={tableData} />
+      )}
     </div>
   )
 }
 
 ButtonTableExport.defaultProps = {
   filename: 'tableData',
+  customCsvDownload: undefined,
 }
 
 export default ButtonTableExport

--- a/src/client/pages/Geo/GeoMap/components/ButtonStatisticsTableExport/types.ts
+++ b/src/client/pages/Geo/GeoMap/components/ButtonStatisticsTableExport/types.ts
@@ -1,0 +1,7 @@
+export type CustomCsvDownload = {
+  headers: {
+    label: string
+    key: string
+  }[]
+  data: Record<string, string>[]
+}

--- a/src/client/pages/Geo/GeoMap/components/StatisticsTable/StatisticsTable.tsx
+++ b/src/client/pages/Geo/GeoMap/components/StatisticsTable/StatisticsTable.tsx
@@ -1,10 +1,12 @@
 import './statisticsTable.scss'
 import React, { useRef } from 'react'
 
-import ButtonStatisticsTableExport from '../ButtonStatisticsTableExport'
+import ButtonStatisticsTableExport from 'client/pages/Geo/GeoMap/components/ButtonStatisticsTableExport'
+import { CustomCsvDownload } from 'client/pages/Geo/GeoMap/components/ButtonStatisticsTableExport/types'
 
 type Props = {
   columns: string[]
+  customCsvDownload?: CustomCsvDownload
   units: string[]
   loaded: boolean
   tableData: (string | number)[][]
@@ -13,7 +15,7 @@ type Props = {
 }
 
 const StatisticsTable = (props: Props) => {
-  const { columns, units, loaded, tableData, countryIso, year } = props
+  const { columns, customCsvDownload, units, loaded, tableData, countryIso, year } = props
   const tableRef = useRef(null)
 
   if (!loaded) {
@@ -46,13 +48,19 @@ const StatisticsTable = (props: Props) => {
           })}
         </tbody>
       </table>
-      <ButtonStatisticsTableExport tableRef={tableRef} filename={`forest-estimations-${countryIso}-${year}`} />
+
+      <ButtonStatisticsTableExport
+        tableRef={tableRef}
+        filename={`forest-estimations-${countryIso}-${year}`}
+        customCsvDownload={customCsvDownload}
+      />
     </div>
   )
 }
 
 StatisticsTable.defaultProps = {
   year: undefined,
+  customCsvDownload: undefined,
 }
 
 export default StatisticsTable

--- a/src/client/pages/Geo/GeoMap/hooks/useGeoStatisticsHandler.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/useGeoStatisticsHandler.ts
@@ -18,7 +18,7 @@ export const useGeoStatisticsHandler = () => {
 
   useEffect(() => {
     if (!geoStatistics.forestEstimations) return
-    let data: [string, number, number][] = []
+    let data: [string, number, number, string][] = []
     try {
       data = builForestEstimationsDataTable(geoStatistics.forestEstimations)
     } catch (error) {

--- a/src/client/pages/Geo/utils/forestEstimations.ts
+++ b/src/client/pages/Geo/utils/forestEstimations.ts
@@ -11,10 +11,10 @@ import { hansenPercentages } from 'meta/geo/forest'
  */
 export const builForestEstimationsDataTable = (
   fetchedForestEstimations: ForestEstimations
-): [string, number, number][] => {
+): [string, number, number, string][] => {
   if (!fetchedForestEstimations) throw Error('Data unavailable.')
 
-  const estimationsData: [string, number, number][] = []
+  const estimationsData: [string, number, number, string][] = []
   const fra1ALandArea = fetchedForestEstimations.data.fra1aLandArea
   const reportedFra1aForestArea = fetchedForestEstimations.data.fra1aForestArea
 
@@ -24,7 +24,7 @@ export const builForestEstimationsDataTable = (
     if (!('forestAreaDataProperty' in metadata)) return
 
     if (key !== ForestKey.Hansen) {
-      const source = key
+      const label = metadata.title ?? key
       const area = fetchedForestEstimations.data[
         metadata.forestAreaDataProperty as keyof ForestEstimationsData
       ] as number
@@ -32,10 +32,10 @@ export const builForestEstimationsDataTable = (
       if (typeof area === 'undefined') return
 
       const percentage = (area * 100) / (fra1ALandArea * 1000)
-      estimationsData.push([source, Number(area.toFixed(2)), Number(percentage.toFixed(2))])
+      estimationsData.push([label, Number(area.toFixed(2)), Number(percentage.toFixed(2)), key])
     } else {
       hansenPercentages.forEach((number: number) => {
-        const source = `${key} ${number}`
+        const label = `${metadata.title ?? key} ${number} %`
         const area = fetchedForestEstimations.data[
           (metadata.forestAreaDataProperty + number) as keyof ForestEstimationsData
         ] as number
@@ -43,7 +43,7 @@ export const builForestEstimationsDataTable = (
         if (typeof area === 'undefined') return
 
         const percentage = (area * 100) / (fra1ALandArea * 1000)
-        estimationsData.push([source, Number(area.toFixed(2)), Number(percentage.toFixed(2))])
+        estimationsData.push([label, Number(area.toFixed(2)), Number(percentage.toFixed(2)), key])
       })
     }
   })
@@ -52,7 +52,12 @@ export const builForestEstimationsDataTable = (
   const reportedToFraLabel = ExtraEstimation.ReportedToFRA
   const reportedFra1aForestAreaHa = reportedFra1aForestArea * 1000 // Normalize to Ha. Instead of Thousands of Ha.
   const fra1aForestAreaPercentage = (reportedFra1aForestAreaHa * 100) / (fra1ALandArea * 1000)
-  estimationsData.push([reportedToFraLabel, reportedFra1aForestAreaHa, Number(fra1aForestAreaPercentage.toFixed(2))])
+  estimationsData.push([
+    reportedToFraLabel,
+    reportedFra1aForestAreaHa,
+    Number(fra1aForestAreaPercentage.toFixed(2)),
+    ExtraEstimation.ReportedToFRA,
+  ])
 
   return estimationsData
 }

--- a/src/client/store/ui/geo/actions/postExtraEstimation.ts
+++ b/src/client/store/ui/geo/actions/postExtraEstimation.ts
@@ -34,7 +34,12 @@ export const postExtraEstimation = createAsyncThunk<[ExtraEstimation, LayerSecti
       const label = extraEstimation
       const fra1ALandArea = (state as RootState).geo?.geoStatistics?.forestEstimations?.data?.fra1aLandArea ?? null
       const percentage = fra1ALandArea != null ? (area * 100) / (fra1ALandArea * 1000) : 0
-      const entry: [string, number, number] = [label, Number(area.toFixed(2)), Number(percentage.toFixed(2))]
+      const entry: [string, number, number, string] = [
+        label,
+        Number(area.toFixed(2)),
+        Number(percentage.toFixed(2)),
+        extraEstimation,
+      ]
 
       dispatch(GeoActions.insertTabularEstimationEntry([-1, entry]))
       return [extraEstimation, sectionKey, scale]

--- a/src/client/store/ui/geo/hooks/index.ts
+++ b/src/client/store/ui/geo/hooks/index.ts
@@ -69,3 +69,6 @@ export const useGeoExtaEstimation = (
   extraEstimation: ExtraEstimation
 ): ExtraEstimationState | undefined =>
   useAppSelector((state) => state.geo?.geoStatistics?.extraEstimations?.[sectionKey]?.[extraEstimation])
+
+export const useGeoFra1aLandArea = (): number | undefined =>
+  useAppSelector((state) => state.geo?.geoStatistics?.forestEstimations?.data?.fra1aLandArea)

--- a/src/client/store/ui/geo/slice.ts
+++ b/src/client/store/ui/geo/slice.ts
@@ -189,7 +189,7 @@ export const geoSlice = createSlice({
       state.geoStatistics.isLoading = false
       state.geoStatistics.error = null
     },
-    setTabularEstimationData: (state, { payload }: PayloadAction<[string, number, number][]>) => {
+    setTabularEstimationData: (state, { payload }: PayloadAction<[string, number, number, string][]>) => {
       state.geoStatistics.tabularEstimationData = payload
       state.geoStatistics.isLoading = false
       state.geoStatistics.error = null
@@ -203,11 +203,11 @@ export const geoSlice = createSlice({
     },
     insertTabularEstimationEntry: (
       state,
-      { payload: [index, entry] }: PayloadAction<[number, [string, number, number]]>
+      { payload: [index, entry] }: PayloadAction<[number, [string, number, number, string]]>
     ) => {
       let replaced = false
       state.geoStatistics.tabularEstimationData = state.geoStatistics.tabularEstimationData.map((row) => {
-        let newRow: [string, number, number] = [...row]
+        let newRow: [string, number, number, string] = [...row]
         if (newRow[0] === entry[0]) {
           newRow = entry
           replaced = true

--- a/src/meta/geo/forestEstimations.ts
+++ b/src/meta/geo/forestEstimations.ts
@@ -66,7 +66,7 @@ export interface ForestEstimations {
 }
 
 export enum ExtraEstimation {
-  ReportedToFRA = 'Reported to FRA',
+  ReportedToFRA = 'Reported to FRA 2020',
   PrecalculatedRecipe = 'Forest agreement selected',
   CustomRecipe = 'Custom agreement selected',
 }

--- a/src/meta/geo/geoStatistics.ts
+++ b/src/meta/geo/geoStatistics.ts
@@ -11,7 +11,7 @@ export type GeoStatisticsExtraEstimations = Record<LayerSectionKey, ExtraEstimat
 
 export interface GeoStatisticsState {
   forestEstimations: ForestEstimations | null
-  tabularEstimationData: [string, number, number][]
+  tabularEstimationData: [string, number, number, string][]
   isLoading: boolean
   error: string | null
   extraEstimations: GeoStatisticsExtraEstimations


### PR DESCRIPTION
Resolves #2581 
Changed Show mosaic layer' to 'Show satellite mosaic'

On Statistics:

- Changed 'Tree Cover Area' to 'Extent of forest/tree cover by source', remove subtitle
- Changed layer labels to match the layers section labels
- Changed label 'Reported to FRA' 'to 'Reported to FRA 2020'

On Download file, added a custom data csv download:

- Title of second column “Forest area, ha”
- Removed ha from forest area data column ( xxx ha -> xxx)
- Added land area on every row (also add it to table after 'Source' column)

On Custom asset:

Changed button label from 'Submit' to 'Load'
Changed 'Asset id' to 'GEE asset id'


https://github.com/openforis/fra-platform/assets/41337901/400e38ae-2056-4b15-9250-00b17710e2b3



