### PR TITLE
3415 - geo refactor add multi cache for special layers agreement hansen and with year selector

### DIFF
--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/TreeCoverPercentageControl/TreeCoverPercentageControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/TreeCoverPercentageControl/TreeCoverPercentageControl.tsx
@@ -17,7 +17,7 @@ interface Props {
 const TreeCoverPercentageControl: React.FC<Props> = ({ sectionKey, layerKey, layerState, layer }) => {
   const dispatch = useAppDispatch()
 
-  useFetchNewLayerOption(sectionKey, layerKey, 'gteTreeCoverPercent')
+  useFetchNewLayerOption(sectionKey, layerKey, 'gteTreeCoverPercent', layer)
 
   const handlePercentageChange = (percentage: number) => {
     dispatch(GeoActions.setLayerGteTreeCoverPercent({ sectionKey, layerKey, gteTreeCoverPercent: percentage }))

--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/YearControl/YearControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/YearControl/YearControl.tsx
@@ -17,7 +17,7 @@ interface Props {
 const YearControl: React.FC<Props> = ({ sectionKey, layerKey, layerState, layer }) => {
   const dispatch = useAppDispatch()
 
-  useFetchNewLayerOption(sectionKey, layerKey, 'year')
+  useFetchNewLayerOption(sectionKey, layerKey, 'year', layer)
 
   const handleYearChange = (year: string) => {
     dispatch(GeoActions.setLayerYear({ sectionKey, layerKey, year: Number(year) }))

--- a/src/client/pages/Geo/GeoMap/hooks/useCountryIsoChangeHandler.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/useCountryIsoChangeHandler.ts
@@ -20,16 +20,7 @@ export const useCountryIsoChangeHandler = () => {
     Object.keys(allSectionsState ?? {}).forEach((sectionKey) => {
       Object.keys(allSectionsState[sectionKey as LayerSectionKey]).forEach((layerKey) => {
         const layerState = allSectionsState[sectionKey as LayerSectionKey][layerKey as LayerKey]
-        if (!layerState.selected || (layerState.opacity ?? 0) === 0) {
-          dispatch(
-            GeoActions.setLayerMapId({
-              sectionKey: sectionKey as LayerSectionKey,
-              layerKey: layerKey as LayerKey,
-              mapId: null,
-            })
-          )
-          return
-        }
+        if (!layerState.selected || (layerState.opacity ?? 0) === 0) return
 
         dispatch(
           GeoActions.postLayer({

--- a/src/client/pages/Geo/GeoMap/hooks/useFetchAgreementLevelLayer.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/useFetchAgreementLevelLayer.ts
@@ -25,6 +25,11 @@ export const useFetchAgreementLevelLayer = (sectionKey: LayerSectionKey, layerKe
       dispatch(GeoActions.setAgreementLevel({ sectionKey, layerKey, level: 1 }))
       return
     }
+    if (countSelectedLayers < 2 || agreementLevel > countSelectedLayers) {
+      dispatch(GeoActions.setLayerSelected({ sectionKey, layerKey, selected: false }))
+      dispatch(GeoActions.setAgreementLevel({ sectionKey, layerKey, level: 1 }))
+      return
+    }
 
     const cachedMapId = layerState?.cache?.[cacheKey]
     if (cachedMapId === undefined) {

--- a/src/client/pages/Geo/GeoMap/hooks/useFetchAgreementLevelLayer.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/useFetchAgreementLevelLayer.ts
@@ -17,7 +17,11 @@ export const useFetchAgreementLevelLayer = (sectionKey: LayerSectionKey, layerKe
   const countSelectedLayers = useCountSectionSelectedLayers({ sectionKey, ignoreAgreementLayer: true })
 
   useEffect(() => {
-    if (agreementLevel === undefined) return // Skip when the property is not set
+    if (!layerState?.selected) return
+    if (agreementLevel === undefined) {
+      dispatch(GeoActions.setAgreementLevel({ sectionKey, layerKey, level: 1 }))
+      return
+    }
     dispatch(GeoActions.postLayer({ countryIso, sectionKey, layerKey }))
-  }, [countryIso, layerKey, agreementLevel, sectionKey, dispatch, countSelectedLayers])
+  }, [countryIso, layerKey, layerState?.selected, agreementLevel, sectionKey, dispatch, countSelectedLayers])
 }

--- a/src/client/pages/Geo/GeoMap/hooks/useFetchNewLayerOption.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/useFetchNewLayerOption.ts
@@ -27,6 +27,21 @@ export const useFetchNewLayerOption = (
       }
       return
     }
-    dispatch(GeoActions.postLayer({ countryIso, sectionKey, layerKey }))
-  }, [countryIso, layer, layerKey, layerOptionKey, layerOptionValue, layerState?.selected, sectionKey, dispatch])
+    const cachedMapId = layerState.cache?.[layerOptionValue]
+    if (cachedMapId === undefined) {
+      dispatch(GeoActions.postLayer({ countryIso, sectionKey, layerKey }))
+    } else {
+      dispatch(GeoActions.setLayerMapId({ sectionKey, layerKey, mapId: cachedMapId, drawLayer: true }))
+    }
+  }, [
+    countryIso,
+    dispatch,
+    layer,
+    layerKey,
+    layerOptionKey,
+    layerOptionValue,
+    layerState?.cache,
+    layerState?.selected,
+    sectionKey,
+  ])
 }

--- a/src/client/pages/Geo/GeoMap/hooks/useFetchNewLayerOption.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/useFetchNewLayerOption.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 
-import { LayerKey, LayerSectionKey } from 'meta/geo'
+import { Layer, LayerKey, LayerSectionKey } from 'meta/geo'
 
 import { useAppDispatch } from 'client/store'
 import { GeoActions, useGeoLayer } from 'client/store/ui/geo'
@@ -10,7 +10,8 @@ import { useCountryIso } from 'client/hooks'
 export const useFetchNewLayerOption = (
   sectionKey: LayerSectionKey,
   layerKey: LayerKey,
-  layerOptionKey: keyof Omit<LayerStateOptions, 'agreementLayer'>
+  layerOptionKey: keyof Omit<LayerStateOptions, 'agreementLayer'>,
+  layer: Layer
 ) => {
   const dispatch = useAppDispatch()
   const countryIso = useCountryIso()
@@ -18,7 +19,14 @@ export const useFetchNewLayerOption = (
   const layerOptionValue = layerState?.options?.[layerOptionKey]
 
   useEffect(() => {
-    if (layerOptionValue === undefined) return // Skip when the property is not set
+    if (!layerState?.selected) return
+    if (layerOptionValue === undefined) {
+      if (layerOptionKey === 'gteTreeCoverPercent') {
+        const gteTreeCoverPercent = layer.options.gteTreeCoverPercent.at(0)
+        dispatch(GeoActions.setLayerGteTreeCoverPercent({ sectionKey, layerKey, gteTreeCoverPercent }))
+      }
+      return
+    }
     dispatch(GeoActions.postLayer({ countryIso, sectionKey, layerKey }))
-  }, [countryIso, layerKey, layerOptionValue, sectionKey, dispatch])
+  }, [countryIso, layer, layerKey, layerOptionKey, layerOptionValue, layerState?.selected, sectionKey, dispatch])
 }

--- a/src/client/store/ui/geo/actions/toggleLayer.ts
+++ b/src/client/store/ui/geo/actions/toggleLayer.ts
@@ -24,6 +24,7 @@ export const toggleLayer = createAsyncThunk<void, Params>(
 
     const currentLayerSelected = layerState?.selected ?? false
     dispatch(GeoActions.setLayerSelected({ sectionKey, layerKey, selected: !currentLayerSelected }))
+    dispatch(GeoActions.setLayerSectionRecipeName({ recipe: 'custom', sectionKey }))
 
     // If the layer is now selected, doesn't have a mapId cached and is visible, fetch it
     const currentMapId = layerState?.mapId

--- a/src/client/store/ui/geo/slice.ts
+++ b/src/client/store/ui/geo/slice.ts
@@ -263,6 +263,7 @@ export const geoSlice = createSlice({
       const mapLayerKey: MapLayerKey = `${sectionKey}-${layerKey}`
       if (isLayerSelected && mapId) {
         mapController.addEarthEngineLayer(mapLayerKey, mapId)
+        mapController.setEarthEngineLayerOpacity(mapLayerKey, newLayerState.opacity ?? 1)
       } else {
         mapController.removeLayer(mapLayerKey)
       }

--- a/src/client/store/ui/geo/stateType.ts
+++ b/src/client/store/ui/geo/stateType.ts
@@ -28,6 +28,7 @@ export type LayerState = {
   status?: LayerFetchStatus
   options?: LayerStateOptions
   mapId?: string | null
+  cache?: Record<string | number, string>
 }
 
 export type LayersSectionState = Record<LayerKey, LayerState>

--- a/src/client/store/ui/geo/utils.ts
+++ b/src/client/store/ui/geo/utils.ts
@@ -1,0 +1,35 @@
+import { Objects } from 'utils/objects'
+
+import { LayerKey } from 'meta/geo/layer'
+
+import { LayersSectionState, LayerState } from './stateType'
+
+const _getLayerCacheLabel = (layerKey: LayerKey, layerState: LayerState): string => {
+  if (Objects.isEmpty(layerState.options)) return layerKey
+  const { agreementLayer, assetId, year, gteTreeCoverPercent } = layerState.options
+  switch (true) {
+    case agreementLayer?.level !== undefined:
+      return `${layerKey}:${agreementLayer?.level}`
+    case assetId !== undefined:
+      return `${layerKey}:${assetId}`
+    case year !== undefined:
+      return `${layerKey}:${year}`
+    case gteTreeCoverPercent !== undefined:
+      return `${layerKey}:${gteTreeCoverPercent}`
+    default:
+      return layerKey
+  }
+}
+
+export const getAgreementLayerCacheKey = (sectionState: LayersSectionState): string => {
+  const layersCacheLabels: string[] = []
+
+  Object.keys(sectionState).forEach((layerKey) => {
+    const layerState = sectionState[layerKey as LayerKey]
+    if (layerState?.selected) {
+      layersCacheLabels.push(_getLayerCacheLabel(layerKey as LayerKey, layerState))
+    }
+  })
+
+  return layersCacheLabels.join('-')
+}


### PR DESCRIPTION
Closes #3415 

Adding cache for layers with options (agreement, hansen percent, year selector).

Additionally, added the following to comply with the current main branch behaviour:
 - When selecting Hansen, select first percentage by default
 - When selecting agreement, select level 1 by default
 - Change recipe to custom when toggling layers
 - Reset agreement layer if number of selected layers < selected level
 - When changing an option (percentage, year or asset id), refetch the agreement layer
 

https://github.com/openforis/fra-platform/assets/41337901/441b2af6-bf52-4d71-97f6-13cb1080c583

