### PR TITLE
3413 - Add tolerance of +-1 for forest ownership subcategories

### DIFF
--- a/src/meta/expressionEvaluator/functions/validatorPrivateOwnership.ts
+++ b/src/meta/expressionEvaluator/functions/validatorPrivateOwnership.ts
@@ -25,7 +25,7 @@ export const validatorPrivateOwnership: ExpressionFunction<Context> = {
           valid = Numbers.lessThan(Numbers.sum(subCategoryValues), privateOwnership)
           key = 'generalValidation.mustBeLessThanPrivateOwnership'
         } else {
-          valid = Numbers.eq(privateOwnership, Numbers.sum(subCategoryValues))
+          valid = Numbers.eqWithTolerance(privateOwnership, Numbers.sum(subCategoryValues))
           key = 'generalValidation.mustBeEqualToPrivateOwnership'
         }
       }


### PR DESCRIPTION
Edited the validator of the Forest ownership table in section 4a to match the expected behavior: "Tab 4a - sum of sub-category should allow±1 unit difference from the total"

https://github.com/openforis/fra-platform/assets/41337901/b0c2a529-6a18-4288-82ee-f5ef4ee406a3

