### PR TITLE
3468 - Remove layers with opacity 0 and show layer options when error

### DIFF
--- a/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.tsx
+++ b/src/client/pages/Geo/GeoMap/GeoMapMenuData/MapVisualizerPanel/LayersSectionPanel/components/CustomAssetControl/CustomAssetControl.tsx
@@ -35,22 +35,32 @@ const CustomAssetControl: React.FC<Props> = ({
   const dispatch = useAppDispatch()
   const layerState = useGeoLayer(sectionKey, layerKey)
   const countryIso = useCountryIso()
-  const [validInput, setValidInput] = useState(true)
+
+  const [inputValue, setInputValue] = useState(layerState?.options?.assetId ?? '')
+  const [inputError, setInputError] = useState(false)
+
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
-    const newAssetId = event.target.value.trim()
-    dispatch(GeoActions.setAssetId({ sectionKey, layerKey, assetId: newAssetId }))
-    if (newAssetId !== '') {
-      setValidInput(true)
-    } else {
-      setValidInput(false)
+    setInputValue(event.target.value)
+    if (inputError && event.target.value.trim() !== '') {
+      setInputError(false)
     }
   }
+
   const handleSubmit = (): void => {
-    if ((layerState?.options?.assetId ?? '') === '') {
-      setValidInput(false)
+    if (inputValue.trim() === '') {
+      setInputError(true)
     } else {
-      setValidInput(true)
+      setInputError(false)
+      dispatch(GeoActions.setAssetId({ sectionKey, layerKey, assetId: inputValue.trim() }))
       dispatch(GeoActions.postLayer({ countryIso, sectionKey, layerKey }))
+    }
+  }
+
+  const handleToggle = (layerKey: LayerKey): void => {
+    if (!checked && (layerState?.options?.assetId ?? '') === '') {
+      setInputError(true)
+    } else {
+      onToggle(layerKey)
     }
   }
 
@@ -63,8 +73,8 @@ const CustomAssetControl: React.FC<Props> = ({
             role="checkbox"
             aria-checked={checked}
             tabIndex={0}
-            onClick={() => onToggle(layerKey)}
-            onKeyDown={() => onToggle(layerKey)}
+            onClick={() => handleToggle(layerKey)}
+            onKeyDown={() => handleToggle(layerKey)}
           >
             <div
               style={checked && loadingStatus !== LayerFetchStatus.Loading ? { backgroundColor } : {}}
@@ -79,10 +89,10 @@ const CustomAssetControl: React.FC<Props> = ({
           <div className="custom-input-container">
             <input
               type="text"
-              value={layerState?.options?.assetId ?? ''}
+              value={inputValue}
               onChange={handleInputChange}
               placeholder="GEE asset id"
-              className={classNames('custom-input', { error: !validInput })}
+              className={classNames('custom-input', { error: inputError })}
             />
             <button type="button" className="btn-primary" onClick={handleSubmit}>
               Load

--- a/src/client/pages/Geo/GeoMap/hooks/useFetchAgreementLevelLayer.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/useFetchAgreementLevelLayer.ts
@@ -19,33 +19,42 @@ export const useFetchAgreementLevelLayer = (sectionKey: LayerSectionKey, layerKe
   const countSelectedLayers = useCountSectionSelectedLayers({ sectionKey, ignoreAgreementLayer: true })
   const cacheKey = getAgreementLayerCacheKey(sectionState ?? ({} as LayersSectionState))
 
-  useEffect(() => {
-    if (!layerState?.selected) return
-    if (agreementLevel === undefined) {
-      dispatch(GeoActions.setAgreementLevel({ sectionKey, layerKey, level: 1 }))
-      return
-    }
-    if (countSelectedLayers < 2 || agreementLevel > countSelectedLayers) {
-      dispatch(GeoActions.setLayerSelected({ sectionKey, layerKey, selected: false }))
-      dispatch(GeoActions.setAgreementLevel({ sectionKey, layerKey, level: 1 }))
-      return
-    }
+  useEffect(
+    () => {
+      if (!layerState?.selected) return
+      if (agreementLevel === undefined) {
+        dispatch(GeoActions.setAgreementLevel({ sectionKey, layerKey, level: 1 }))
+        return
+      }
+      if (countSelectedLayers < 2 || agreementLevel > countSelectedLayers) {
+        dispatch(GeoActions.setLayerSelected({ sectionKey, layerKey, selected: false }))
+        dispatch(GeoActions.setAgreementLevel({ sectionKey, layerKey, level: 1 }))
+        return
+      }
 
-    const cachedMapId = layerState?.cache?.[cacheKey]
-    if (cachedMapId === undefined) {
-      dispatch(GeoActions.postLayer({ countryIso, sectionKey, layerKey }))
-    } else {
-      dispatch(GeoActions.setLayerMapId({ sectionKey, layerKey, mapId: cachedMapId, drawLayer: true }))
-    }
-  }, [
-    agreementLevel,
-    cacheKey,
-    countSelectedLayers,
-    countryIso,
-    dispatch,
-    layerKey,
-    layerState?.cache,
-    layerState?.selected,
-    sectionKey,
-  ])
+      const cachedMapId = layerState?.cache?.[cacheKey]
+      if (cachedMapId === undefined) {
+        if (layerState?.opacity > 0) {
+          dispatch(GeoActions.postLayer({ countryIso, sectionKey, layerKey }))
+        } else {
+          dispatch(GeoActions.resetLayerStatus({ sectionKey, layerKey }))
+        }
+      } else {
+        dispatch(GeoActions.setLayerMapId({ sectionKey, layerKey, mapId: cachedMapId, drawLayer: true }))
+      }
+    },
+    // Ignore opacity changes:
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      agreementLevel,
+      cacheKey,
+      countSelectedLayers,
+      countryIso,
+      dispatch,
+      layerKey,
+      layerState?.cache,
+      layerState?.selected,
+      sectionKey,
+    ]
+  )
 }

--- a/src/client/pages/Geo/GeoMap/hooks/useFetchNewLayerOption.ts
+++ b/src/client/pages/Geo/GeoMap/hooks/useFetchNewLayerOption.ts
@@ -18,30 +18,39 @@ export const useFetchNewLayerOption = (
   const layerState = useGeoLayer(sectionKey, layerKey)
   const layerOptionValue = layerState?.options?.[layerOptionKey]
 
-  useEffect(() => {
-    if (!layerState?.selected) return
-    if (layerOptionValue === undefined) {
-      if (layerOptionKey === 'gteTreeCoverPercent') {
-        const gteTreeCoverPercent = layer.options.gteTreeCoverPercent.at(0)
-        dispatch(GeoActions.setLayerGteTreeCoverPercent({ sectionKey, layerKey, gteTreeCoverPercent }))
+  useEffect(
+    () => {
+      if (!layerState?.selected) return
+      if (layerOptionValue === undefined) {
+        if (layerOptionKey === 'gteTreeCoverPercent') {
+          const gteTreeCoverPercent = layer.options.gteTreeCoverPercent.at(0)
+          dispatch(GeoActions.setLayerGteTreeCoverPercent({ sectionKey, layerKey, gteTreeCoverPercent }))
+        }
+        return
       }
-      return
-    }
-    const cachedMapId = layerState.cache?.[layerOptionValue]
-    if (cachedMapId === undefined) {
-      dispatch(GeoActions.postLayer({ countryIso, sectionKey, layerKey }))
-    } else {
-      dispatch(GeoActions.setLayerMapId({ sectionKey, layerKey, mapId: cachedMapId, drawLayer: true }))
-    }
-  }, [
-    countryIso,
-    dispatch,
-    layer,
-    layerKey,
-    layerOptionKey,
-    layerOptionValue,
-    layerState?.cache,
-    layerState?.selected,
-    sectionKey,
-  ])
+      const cachedMapId = layerState.cache?.[layerOptionValue]
+      if (cachedMapId === undefined) {
+        if (layerState?.opacity > 0) {
+          dispatch(GeoActions.postLayer({ countryIso, sectionKey, layerKey }))
+        } else {
+          dispatch(GeoActions.resetLayerStatus({ sectionKey, layerKey }))
+        }
+      } else {
+        dispatch(GeoActions.setLayerMapId({ sectionKey, layerKey, mapId: cachedMapId, drawLayer: true }))
+      }
+    },
+    // Ignore opacity changes:
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      countryIso,
+      dispatch,
+      layer,
+      layerKey,
+      layerOptionKey,
+      layerOptionValue,
+      layerState?.cache,
+      layerState?.selected,
+      sectionKey,
+    ]
+  )
 }

--- a/src/client/store/ui/geo/slice.ts
+++ b/src/client/store/ui/geo/slice.ts
@@ -156,9 +156,11 @@ const handlePostLayerStatus = (
     case LayerFetchStatus.Ready:
       if (mapId) {
         setMapIdCache(state, sectionKey, layerKey, mapId)
+        const opacity = layerState.opacity ?? 1
         if (layerState.selected) {
-          mapController.addEarthEngineLayer(mapLayerKey, mapId)
-          mapController.setEarthEngineLayerOpacity(mapLayerKey, layerState.opacity ?? 1)
+          mapController.addOrUpdateEarthEngineLayer(mapLayerKey, mapId, opacity)
+        } else {
+          mapController.removeLayer(mapLayerKey)
         }
       }
       break
@@ -261,9 +263,9 @@ export const geoSlice = createSlice({
       // Render or remove layer from the map
       const { selected: isLayerSelected, mapId } = state.sections[sectionKey][layerKey]
       const mapLayerKey: MapLayerKey = `${sectionKey}-${layerKey}`
-      if (isLayerSelected && mapId) {
-        mapController.addEarthEngineLayer(mapLayerKey, mapId)
-        mapController.setEarthEngineLayerOpacity(mapLayerKey, newLayerState.opacity ?? 1)
+      const opacity = newLayerState.opacity ?? 1
+      if (isLayerSelected) {
+        mapController.addOrUpdateEarthEngineLayer(mapLayerKey, mapId, opacity)
       } else {
         mapController.removeLayer(mapLayerKey)
       }
@@ -284,7 +286,9 @@ export const geoSlice = createSlice({
       const layerState = getLayerState(state, sectionKey, layerKey)
       state.sections[sectionKey][layerKey] = { ...layerState, opacity }
       const mapLayerKey: MapLayerKey = `${sectionKey}-${layerKey}`
-      mapController.setEarthEngineLayerOpacity(mapLayerKey, opacity)
+      const { mapId } = state.sections[sectionKey][layerKey]
+
+      mapController.addOrUpdateEarthEngineLayer(mapLayerKey, mapId, opacity)
     },
     setLayerMapId: (
       state: Draft<GeoState>,
@@ -303,8 +307,8 @@ export const geoSlice = createSlice({
 
       const mapLayerKey: MapLayerKey = `${sectionKey}-${layerKey}`
       mapController.removeLayer(mapLayerKey)
-      mapController.addEarthEngineLayer(mapLayerKey, mapId)
-      mapController.setEarthEngineLayerOpacity(mapLayerKey, layerState.opacity ?? 1)
+      const opacity = layerState.opacity ?? 0
+      mapController.addOrUpdateEarthEngineLayer(mapLayerKey, mapId, opacity)
     },
     setAssetId: (
       state: Draft<GeoState>,

--- a/src/client/store/ui/geo/slice.ts
+++ b/src/client/store/ui/geo/slice.ts
@@ -168,7 +168,7 @@ const handlePostLayerStatus = (
       mapController.removeLayer(mapLayerKey)
       break
     case LayerFetchStatus.Failed:
-      newLayerState = { ...newLayerState, selected: false }
+      if (layerState.options?.assetId) newLayerState = { ...newLayerState, selected: false }
       mapController.removeLayer(mapLayerKey)
       break
     default:

--- a/src/client/utils/mapController.ts
+++ b/src/client/utils/mapController.ts
@@ -99,6 +99,15 @@ export class MapController {
     // Insert at index 0 so it doesn't overlay the other layers.
     this.#map.overlayMapTypes.insertAt(0, layer)
   }
+
+  addOrUpdateEarthEngineLayer(mapLayerKey: MapLayerKey, mapId: string, opacity: number, overwrite = false): void {
+    if (mapId && opacity > 0) {
+      this.addEarthEngineLayer(mapLayerKey, mapId, overwrite)
+      this.setEarthEngineLayerOpacity(mapLayerKey, opacity)
+    } else {
+      this.removeLayer(mapLayerKey)
+    }
+  }
 }
 
 export default MapController


### PR DESCRIPTION
Introducing final changes to match the current dev branch:}

- Removing hidden layers from so they are not fetched while moving in the map.
- Allowing the layers with options to show menus even if the previous fetch failed.
- Changing the logic of custom asset id so redux is only updated when the user clicks "load".
- Preventing fetch of the layers with options when their opacity is 0. 