### PR TITLE
3459 - Fix collaborator list crashing

### DIFF
--- a/src/client/components/UserList/CollaboratorListElement/CollaboratorListElement.tsx
+++ b/src/client/components/UserList/CollaboratorListElement/CollaboratorListElement.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import classNames from 'classnames'
+import { Objects } from 'utils/objects'
 
 import { RoleName, User, Users } from 'meta/user'
 import { UserRoles } from 'meta/user/userRoles'
@@ -20,7 +21,10 @@ const CollaboratorListElement: React.FC<{ user: User; readOnly: boolean }> = ({ 
   const currentUser = useUser()
   const isReviewer = Users.isReviewer(currentUser, countryIso, cycle)
   const userRole = Users.getRole(user, countryIso, cycle)
-  const { acceptedAt, invitationUuid } = userRole ?? {}
+
+  if (Objects.isEmpty(userRole)) return null
+
+  const { acceptedAt, invitationUuid } = userRole
 
   const showLink = !readOnly
 


### PR DESCRIPTION
Root cause:

When switching countries, the users of the new country are fetched, but there can be a delay before the Redux state updates. Then, when rendering the `CollaboratorListElement` with a user from the previous country, there are instances where `Users.getRole(user, countryIso, cycle)` returns undefined. After that, attempting to access `userRole.invitedAt` would crash the application.

Solution:
If the user in the list doesn't have a role in the country, the `CollaboratorListElement` should return null.

https://github.com/openforis/fra-platform/assets/41337901/cd82af0d-8dfd-433c-b6ac-7988b3cb66ce


Closes #3459 
