### PR TITLE
3214 - Files and links per Cycle: API: Upload one or more files

### DIFF
--- a/src/meta/api/endpoint/ApiEndPoint.ts
+++ b/src/meta/api/endpoint/ApiEndPoint.ts
@@ -88,7 +88,7 @@ export const ApiEndPoint = {
   },
 
   File: {
-    many: () => apiPath('file'),
+    many: () => apiPath('files'),
     biomassStock: ({
       assessmentName = ':assessmentName',
       cycleName = ':cycleName',

--- a/src/meta/api/endpoint/ApiEndPoint.ts
+++ b/src/meta/api/endpoint/ApiEndPoint.ts
@@ -88,6 +88,7 @@ export const ApiEndPoint = {
   },
 
   File: {
+    many: () => apiPath('file'),
     biomassStock: ({
       assessmentName = ':assessmentName',
       cycleName = ':cycleName',

--- a/src/server/api/file/createManyFiles.ts
+++ b/src/server/api/file/createManyFiles.ts
@@ -1,0 +1,28 @@
+import { Response } from 'express'
+
+import { CycleRequest } from 'meta/api/request'
+
+import { AssessmentController } from 'server/controller/assessment'
+import { FileController } from 'server/controller/file'
+import { Requests } from 'server/utils'
+
+type Request = CycleRequest & {
+  files: Array<Express.Multer.File>
+}
+
+export const createManyFiles = async (req: Request, res: Response) => {
+  try {
+    const { assessmentName, cycleName } = req.query
+    const { files } = req
+
+    const user = Requests.getUser(req)
+    const { assessment, cycle } = await AssessmentController.getOneWithCycle({ assessmentName, cycleName })
+
+    const createAssessmentFileProps = { assessment, cycle, files, user }
+    const createdFiles = await FileController.createMany(createAssessmentFileProps)
+
+    Requests.sendOk(res, createdFiles)
+  } catch (e) {
+    Requests.sendErr(res, e)
+  }
+}

--- a/src/server/api/file/index.ts
+++ b/src/server/api/file/index.ts
@@ -2,6 +2,7 @@ import { Express } from 'express'
 
 import { ApiEndPoint } from 'meta/api/endpoint'
 
+import { createManyFiles } from 'server/api/file/createManyFiles'
 import { AuthMiddleware } from 'server/middleware/auth'
 
 import { createAssessmentFile } from './createAssessmentFile'
@@ -38,18 +39,40 @@ export const FileApi = {
     express.get(ApiEndPoint.File.biomassStock({}), AuthMiddleware.requireEditTableData, getBiomassStockFile)
 
     // Files
+    express.post(
+      ApiEndPoint.File.many(),
+      multer({ fileFilter }).array('file'),
+      // AuthMiddleware.requireEditCountryFile,
+      createManyFiles
+    )
+
     // File list
+    /**
+     * @Deprecated
+     */
     express.get(ApiEndPoint.File.Assessment.many(), AuthMiddleware.requireView, getAssessmentFiles)
 
     // File operations
+    /**
+     * @Deprecated
+     */
     express.put(
       ApiEndPoint.File.Assessment.many(),
       multer({ fileFilter }).single('file'),
       AuthMiddleware.requireEditAssessmentFile,
       createAssessmentFile
     )
+    /**
+     * @Deprecated
+     */
     express.get(ApiEndPoint.File.Assessment.one(), /* Auth handled in controller */ getAssessmentFile)
+    /**
+     * @Deprecated
+     */
     express.delete(ApiEndPoint.File.Assessment.one(), AuthMiddleware.requireEditCountryFile, removeAssessmentFile)
+    /**
+     * @Deprecated
+     */
     express.put(
       ApiEndPoint.File.Assessment.access(),
       AuthMiddleware.requireEditAssessmentFileAccess,

--- a/src/server/api/file/index.ts
+++ b/src/server/api/file/index.ts
@@ -42,7 +42,7 @@ export const FileApi = {
     express.post(
       ApiEndPoint.File.many(),
       multer({ fileFilter }).array('file'),
-      // AuthMiddleware.requireEditCountryFile,
+      AuthMiddleware.requireEditAssessmentFile,
       createManyFiles
     )
 

--- a/src/server/controller/cycleData/repository/create.ts
+++ b/src/server/controller/cycleData/repository/create.ts
@@ -25,7 +25,7 @@ export const create = async (props: Props): Promise<RepositoryItem> => {
 
   return DB.tx(async (t: BaseProtocol) => {
     let fileUuid = null
-    if (props.file) fileUuid = await FileRepository.create(props, t)
+    if (props.file) fileUuid = (await FileRepository.create(props, t)).uuid
 
     const repositoryProps = { ...props, fileUuid }
     const target = await RepositoryRepository.create(repositoryProps, t)

--- a/src/server/controller/cycleData/repository/update.ts
+++ b/src/server/controller/cycleData/repository/update.ts
@@ -25,7 +25,7 @@ export const update = async (props: Props): Promise<RepositoryItem> => {
   return DB.tx(async (t: BaseProtocol) => {
     let fileUuid = repositoryItemProps.link ? undefined : repositoryItemProps.fileUuid
     if (props.file) {
-      fileUuid = await FileRepository.create(props, t)
+      fileUuid = (await FileRepository.create(props, t)).uuid
     }
 
     const repositoryItem = { ...repositoryItemProps, fileUuid }

--- a/src/server/controller/file/createAssessmentFile.ts
+++ b/src/server/controller/file/createAssessmentFile.ts
@@ -14,7 +14,9 @@ type Props = {
   props?: AssessmentFileProps
   user?: User
 }
-
+/**
+ * @Deprecated
+ */
 export const createAssessmentFile = async (props: Props, client: BaseProtocol = DB): Promise<AssessmentFile> => {
   const { assessment, countryIso, user } = props
 

--- a/src/server/controller/file/createMany.ts
+++ b/src/server/controller/file/createMany.ts
@@ -1,0 +1,34 @@
+import { ActivityLogMessage, Assessment, Cycle } from 'meta/assessment'
+import { File } from 'meta/file'
+import { User } from 'meta/user'
+
+import { BaseProtocol, DB } from 'server/db'
+import { ActivityLogRepository } from 'server/repository/public/activityLog'
+import { FileRepository } from 'server/repository/public/file'
+
+type Props = {
+  assessment: Assessment
+  cycle?: Cycle
+  files: Array<Express.Multer.File>
+  user: User
+}
+
+export const createMany = async (props: Props, client: BaseProtocol = DB): Promise<Array<File>> => {
+  const { assessment, cycle, files, user } = props
+
+  return client.tx(async (t) => {
+    return Promise.all(
+      files.map(async (multerFile) => {
+        const file = await FileRepository.create({ ...props, file: multerFile }, t)
+
+        const target = { fileName: file.fileName, uuid: file.uuid }
+        const message = ActivityLogMessage.assessmentFileCreate
+        const activityLog = { target, section: 'assessment', message, user }
+        const activityLogParams = { activityLog, assessment, cycle }
+        await ActivityLogRepository.insertActivityLog(activityLogParams, t)
+
+        return file
+      })
+    )
+  })
+}

--- a/src/server/controller/file/createMany.ts
+++ b/src/server/controller/file/createMany.ts
@@ -22,7 +22,7 @@ export const createMany = async (props: Props, client: BaseProtocol = DB): Promi
         const file = await FileRepository.create({ ...props, file: multerFile }, t)
 
         const target = { fileName: file.fileName, uuid: file.uuid }
-        const message = ActivityLogMessage.assessmentFileCreate
+        const message = ActivityLogMessage.fileCreate
         const activityLog = { target, section: 'assessment', message, user }
         const activityLogParams = { activityLog, assessment, cycle }
         await ActivityLogRepository.insertActivityLog(activityLogParams, t)

--- a/src/server/controller/file/getAssessmentFile.ts
+++ b/src/server/controller/file/getAssessmentFile.ts
@@ -14,7 +14,9 @@ type Props = {
   uuid?: string
   user?: User
 }
-
+/**
+ * @Deprecated
+ */
 export const getAssessmentFile = async (props: Props, client: BaseProtocol = DB): Promise<AssessmentFile> => {
   const { assessment, cycle, countryIso, user } = props
 

--- a/src/server/controller/file/index.ts
+++ b/src/server/controller/file/index.ts
@@ -1,3 +1,4 @@
+import { createMany } from 'server/controller/file/createMany'
 import { AssessmentFileRepository } from 'server/repository/assessment/file'
 
 import { createAssessmentFile } from './createAssessmentFile'
@@ -6,11 +7,22 @@ import { removeAssessmentFile } from './removeAssessmentFile'
 import { updateManyAssessmentFileAccess } from './updateManyAssessmentFileAccess'
 
 export const FileController = {
+  createMany,
+
   createAssessmentFile,
   getAssessmentFile,
+  /**
+   * @Deprecated
+   */
   getAssessmentFiles: AssessmentFileRepository.getMany,
   removeAssessmentFile,
+  /**
+   * @Deprecated
+   */
   getFileUsages: AssessmentFileRepository.getFileUsages,
+  /**
+   * @Deprecated
+   */
   getHiddenAssessmentFile: AssessmentFileRepository.getOne,
   updateManyAssessmentFileAccess,
 }

--- a/src/server/controller/file/removeAssessmentFile.ts
+++ b/src/server/controller/file/removeAssessmentFile.ts
@@ -10,7 +10,9 @@ type Props = {
   uuid: string
   user?: User
 }
-
+/**
+ * @Deprecated
+ */
 export const removeAssessmentFile = async (props: Props, client: BaseProtocol = DB): Promise<void> => {
   const { assessment, uuid, user } = props
 

--- a/src/server/controller/file/updateManyAssessmentFileAccess.ts
+++ b/src/server/controller/file/updateManyAssessmentFileAccess.ts
@@ -14,7 +14,9 @@ type Props = {
   user?: User
   UUIDs: Array<string>
 }
-
+/**
+ * @Deprecated
+ */
 export const updateManyAssessmentFileAccess = async (
   props: Props,
   client: BaseProtocol = DB

--- a/src/server/repository/public/file/create.ts
+++ b/src/server/repository/public/file/create.ts
@@ -1,15 +1,20 @@
+import { File } from 'meta/file'
+
 import { BaseProtocol, DB } from 'server/db'
+import { FileAdapter } from 'server/repository/adapter'
+
+import { fields } from './fields'
 
 type Props = {
   file: Express.Multer.File
 }
 
-export const create = async (props: Props, client: BaseProtocol = DB): Promise<string> => {
+export const create = async (props: Props, client: BaseProtocol = DB): Promise<File> => {
   const { file } = props
 
-  const result = await client.one(`insert into public.file (file_name, file) values ($1, $2) returning uuid`, [
-    file.originalname,
-    file.buffer,
-  ])
-  return result.uuid
+  return client.one(
+    `insert into public.file (file_name, file) values ($1, $2) returning ${fields.join(', ')}`,
+    [file.originalname, file.buffer],
+    FileAdapter
+  )
 }

--- a/src/server/repository/public/file/fields.ts
+++ b/src/server/repository/public/file/fields.ts
@@ -1,0 +1,1 @@
+export const fields = ['id', 'file_name', 'uuid', 'created_at']


### PR DESCRIPTION
Added support for uploading one or more files.
<details>
<summary>
Example of a response from the server when three files are uploaded.
The response is a JSON array of objects, each object representing a file.
</summary>

<pre>
[
  {
    "id": 1043,
    "fileName": "Näyttökuva 2024-01-24 130351.png",
    "uuid": "7a0894e9-0143-4b6f-b5fe-513d3b9cbbe7",
    "createdAt": "2024-02-08T11:56:55.343Z"
  },
  {
    "id": 1044,
    "fileName": "test file with normal characters.png",
    "uuid": "3ed02640-8d6b-4da2-ba6f-94a724173b0d",
    "createdAt": "2024-02-08T11:56:55.343Z"
  },
  {
    "id": 1045,
    "fileName": "third file.xlsx",
    "uuid": "7a750019-ad7c-4bca-b9a3-4097b6683de7",
    "createdAt": "2024-02-08T11:56:55.343Z"
  }
]
</pre>
</details>