### PR TITLE
3214 - Files and links per Cycle: FileUpload store

### DIFF
--- a/src/client/store/RootState.ts
+++ b/src/client/store/RootState.ts
@@ -1,5 +1,3 @@
-import { RepositorySlice, RepositoryState } from 'client/store/ui/repository'
-
 import { AreaState } from './area/state'
 import { AssessmentState } from './assessment/state'
 import { DataState } from './data/stateType'
@@ -9,12 +7,14 @@ import { AssessmentFilesState } from './ui/assessmentFiles/stateType'
 import { AssessmentSectionState } from './ui/assessmentSection'
 import { DataExportState } from './ui/dataExport'
 import { DataLockState } from './ui/dataLock'
+import { FileUploadSlice, FileUploadState } from './ui/fileUpload'
 import { GeoState } from './ui/geo/stateType'
 import { HomeState } from './ui/home/stateType'
 import { MessageCenterState } from './ui/messageCenter/stateType'
 import { NavigationState } from './ui/navigation/stateType'
 import { NotificationState } from './ui/notification/stateType'
 import { OriginalDataPointState } from './ui/originalDataPoint'
+import { RepositorySlice, RepositoryState } from './ui/repository'
 import { ReviewState } from './ui/review'
 import { TablePaginatedState } from './ui/tablePaginated/state'
 import { UserManagementState } from './ui/userManagement'
@@ -36,6 +36,7 @@ export type RootState = {
     assessmentSection: AssessmentSectionState
     dataExport: DataExportState
     dataLock: DataLockState
+    [FileUploadSlice.name]: FileUploadState
     home: HomeState
     messageCenter: MessageCenterState
     navigation: NavigationState

--- a/src/client/store/rootReducer.ts
+++ b/src/client/store/rootReducer.ts
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux'
 
+import { FileUploadSlice } from 'client/store/ui/fileUpload'
 import { RepositorySlice } from 'client/store/ui/repository'
 
 import AreaSlice from './area/slice'
@@ -37,6 +38,7 @@ export default {
     assessmentSection: AssessmentSectionSlice,
     dataExport: DataExportSlice,
     dataLock: DataLockSlice,
+    [FileUploadSlice.name]: FileUploadSlice.reducer,
     home: HomeSlice,
     messageCenter: MessageCenterSlice,
     navigation: NavigationSlice,

--- a/src/client/store/ui/fileUpload/actions/index.ts
+++ b/src/client/store/ui/fileUpload/actions/index.ts
@@ -1,0 +1,7 @@
+import { uploadFiles } from 'client/store/ui/fileUpload/actions/uploadFiles'
+import { FileUploadSlice } from 'client/store/ui/fileUpload/slice'
+
+export const FileUploadActions = {
+  ...FileUploadSlice.actions,
+  uploadFiles,
+}

--- a/src/client/store/ui/fileUpload/actions/uploadFiles.ts
+++ b/src/client/store/ui/fileUpload/actions/uploadFiles.ts
@@ -1,0 +1,28 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axios from 'axios'
+
+import { ApiEndPoint } from 'meta/api/endpoint'
+import { CycleParams } from 'meta/api/request'
+import { File as FileType } from 'meta/file'
+
+import { ThunkApiConfig } from 'client/store/types'
+
+type Props = CycleParams & {
+  files: Array<File>
+}
+
+export const uploadFiles = createAsyncThunk<Array<FileType>, Props, ThunkApiConfig>(
+  'fileUpload/uploadFiles',
+  async (props) => {
+    const { assessmentName, cycleName, countryIso, files } = props
+    const formData = new FormData()
+    files.forEach((file) => formData.append('file', file))
+
+    const headers = { 'Content-Type': 'multipart/form-data' }
+    const params = { assessmentName, cycleName, countryIso }
+    const config = { headers, params }
+    const { data } = await axios.post(ApiEndPoint.File.many(), formData, config)
+
+    return data
+  }
+)

--- a/src/client/store/ui/fileUpload/hooks/index.ts
+++ b/src/client/store/ui/fileUpload/hooks/index.ts
@@ -1,0 +1,8 @@
+import { File } from 'meta/file'
+
+import { useAppSelector } from 'client/store/store'
+import { FileUploadSelectors } from 'client/store/ui/fileUpload/selectors'
+
+export const useUploadedFiles = (): Array<File> => {
+  return useAppSelector(FileUploadSelectors.getFiles)
+}

--- a/src/client/store/ui/fileUpload/index.ts
+++ b/src/client/store/ui/fileUpload/index.ts
@@ -1,0 +1,3 @@
+export { FileUploadActions } from './actions'
+export { FileUploadSlice } from './slice'
+export type { FileUploadState } from './state'

--- a/src/client/store/ui/fileUpload/reducers/uploadFilesReducer.ts
+++ b/src/client/store/ui/fileUpload/reducers/uploadFilesReducer.ts
@@ -1,0 +1,19 @@
+import { ActionReducerMapBuilder } from '@reduxjs/toolkit'
+
+import { uploadFiles } from 'client/store/ui/fileUpload/actions/uploadFiles'
+import { FileUploadState } from 'client/store/ui/fileUpload/state'
+
+export const uploadFilesReducer = (builder: ActionReducerMapBuilder<FileUploadState>) => {
+  builder.addCase(uploadFiles.pending, (state) => {
+    state.loading = true
+  })
+
+  builder.addCase(uploadFiles.fulfilled, (state, action) => {
+    state.loading = false
+    state.files = action.payload
+  })
+
+  builder.addCase(uploadFiles.rejected, (state) => {
+    state.loading = false
+  })
+}

--- a/src/client/store/ui/fileUpload/selectors/index.ts
+++ b/src/client/store/ui/fileUpload/selectors/index.ts
@@ -1,0 +1,13 @@
+import { createSelector } from '@reduxjs/toolkit'
+
+import { RootState } from 'client/store/RootState'
+import { FileUploadSlice } from 'client/store/ui/fileUpload'
+
+const _getState = (state: RootState) => state.ui[FileUploadSlice.name]
+const isLoading = createSelector(_getState, (fileUpload) => fileUpload.loading)
+const getFiles = createSelector(_getState, (fileUpload) => fileUpload.files)
+
+export const FileUploadSelectors = {
+  isLoading,
+  getFiles,
+}

--- a/src/client/store/ui/fileUpload/slice.ts
+++ b/src/client/store/ui/fileUpload/slice.ts
@@ -1,0 +1,15 @@
+import { createSlice, Reducer } from '@reduxjs/toolkit'
+
+import { uploadFilesReducer } from 'client/store/ui/fileUpload/reducers/uploadFilesReducer'
+import { FileUploadState, initialState } from 'client/store/ui/fileUpload/state'
+
+export const FileUploadSlice = createSlice({
+  name: 'fileUpload',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    uploadFilesReducer(builder)
+  },
+})
+
+export default FileUploadSlice.reducer as Reducer<FileUploadState>

--- a/src/client/store/ui/fileUpload/state.ts
+++ b/src/client/store/ui/fileUpload/state.ts
@@ -1,0 +1,10 @@
+import { File } from 'meta/file'
+
+export type FileUploadState = {
+  loading: boolean
+  files?: Array<File>
+}
+
+export const initialState: FileUploadState = {
+  loading: false,
+}

--- a/src/client/store/ui/repository/slice.ts
+++ b/src/client/store/ui/repository/slice.ts
@@ -10,7 +10,7 @@ export const RepositorySlice = createSlice({
   name: 'repository',
   initialState,
   reducers: {
-    setRepositoryItem: (state: RepositoryState, action: PayloadAction<RepositoryItem>) => {
+    setRepositoryItem: (state: RepositoryState, action: PayloadAction<Partial<RepositoryItem>>) => {
       state.repositoryItem = action.payload
     },
   },

--- a/src/client/store/ui/repository/state.ts
+++ b/src/client/store/ui/repository/state.ts
@@ -2,7 +2,7 @@ import { RepositoryItem } from 'meta/cycleData'
 
 export type RepositoryState = {
   loading: boolean
-  repositoryItem?: RepositoryItem
+  repositoryItem?: Partial<RepositoryItem>
 }
 
 export const initialState: RepositoryState = {


### PR DESCRIPTION
<details>
<summary>
Example of redux store after successful upload (click to expand)
</summary>

<pre>
{
  fileUpload: {
    loading: false,
    files: [
      {
        id: 1060,
        fileName: 'Näyttökuva 2024-01-24 130351.png',
        uuid: '6dd0aca1-bc19-4b89-8b87-bfcdc1856cfd',
        createdAt: '2024-02-09T09:50:19.177Z'
      },
      {
        id: 1061,
        fileName: 'test file with normal characters.png',
        uuid: '2f32aa69-98d5-4a2a-a5d9-9848e9bafd7f',
        createdAt: '2024-02-09T09:50:19.177Z'
      },
      {
        id: 1062,
        fileName: 'third file.xlsx',
        uuid: '990b98ae-217b-43ec-be8f-b3a39f78cb70',
        createdAt: '2024-02-09T09:50:19.177Z'
      }
    ]
  }
}
</pre>
</details>