### PR TITLE
3394 - Bug fix: prevent accepting an already accepted invitation

### DIFF
--- a/src/client/pages/Login/components/AcceptInvitationButtons/AcceptInvitationButtons.tsx
+++ b/src/client/pages/Login/components/AcceptInvitationButtons/AcceptInvitationButtons.tsx
@@ -7,7 +7,7 @@ import { LoginInvitationQueryParams, Routes } from 'meta/routes'
 import { AuthProvider } from 'meta/user'
 
 import { useInvitation } from 'client/store/login'
-import { useAcceptInvitationForm } from 'client/store/login/hooks'
+import { useAcceptInvitationForm, useLoginInfo } from 'client/store/login/hooks'
 import { useIsInvitationLocalRoute } from 'client/hooks/useIsRoute'
 import { useSearchParams } from 'client/hooks/useSearchParams'
 import Icon from 'client/components/Icon'
@@ -29,6 +29,8 @@ const AcceptInvitationButtons: React.FC = () => {
   const isInInvitationLocal = useIsInvitationLocalRoute()
 
   const formData = useAcceptInvitationForm()
+  const loginInfo = useLoginInfo()
+
   const showPassword2 =
     (invitedUser && !userProviders) || (userProviders && !userProviders.includes(AuthProvider.local))
 
@@ -44,6 +46,7 @@ const AcceptInvitationButtons: React.FC = () => {
         type="button"
         className="btn"
         onClick={isInInvitationLocal ? onAcceptInvitationLocal : goToAcceptInvitationLocal}
+        disabled={isInInvitationLocal ? loginInfo?.isLoading : false}
       >
         {t('login.acceptInvitationWithFra')}
       </button>

--- a/src/client/store/login/hooks/index.ts
+++ b/src/client/store/login/hooks/index.ts
@@ -1,7 +1,9 @@
 import { useAppSelector } from 'client/store'
-import { AcceptInvitationFormState, InvitationState } from 'client/store/login/stateType'
-
-export const useInvitation = (): InvitationState | undefined => useAppSelector((state) => state.login?.invitation)
+import { AcceptInvitationFormState, InvitationState, LoginInformationState } from 'client/store/login/stateType'
 
 export const useAcceptInvitationForm = (): AcceptInvitationFormState | undefined =>
   useAppSelector((state) => state.login?.invitation?.acceptForm)
+
+export const useInvitation = (): InvitationState | undefined => useAppSelector((state) => state.login?.invitation)
+
+export const useLoginInfo = (): LoginInformationState | undefined => useAppSelector((state) => state.login?.login)

--- a/src/client/store/login/slice.ts
+++ b/src/client/store/login/slice.ts
@@ -37,6 +37,16 @@ export const loginSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(localLogin.fulfilled, () => initialState)
 
+    builder.addCase(localLogin.pending, (state) => {
+      state.login ??= {}
+      state.login.isLoading = true
+    })
+
+    builder.addCase(localLogin.rejected, (state) => {
+      state.login ??= {}
+      state.login.isLoading = false
+    })
+
     builder.addCase(acceptInvitation.fulfilled, () => initialState)
 
     builder.addCase(fetchUserByInvitation.fulfilled, (state, { payload }) => {

--- a/src/client/store/login/stateType.ts
+++ b/src/client/store/login/stateType.ts
@@ -21,13 +21,16 @@ export interface InvitationState {
   acceptForm?: AcceptInvitationFormState
 }
 
+export interface LoginInformationState {
+  email?: string
+  isLoading?: boolean
+  password?: string
+  status?: string
+  type?: string
+}
+
 export interface LoginState {
-  login: {
-    status?: string
-    type?: string
-    email?: string
-    password?: string
-  }
+  login: LoginInformationState
   invitation: InvitationState
   resetPassword?: {
     error?: string

--- a/src/server/controller/user/acceptInvitation.ts
+++ b/src/server/controller/user/acceptInvitation.ts
@@ -23,7 +23,7 @@ export const acceptInvitation = async (
 
   return client.tx(async (t) => {
     if (UserRoles.isInvitationExpired(userRole)) throw new Error('login.invitationExpired')
-    if (!UserRoles.isInvitationPending(userRole)) throw new Error('login.alreadyAcceptedInvitation')
+    if (userRole.acceptedAt !== null) throw new Error('login.alreadyAcceptedInvitation')
 
     await UserRoleRepository.acceptInvitation({ userRole }, t)
 

--- a/src/server/controller/user/acceptInvitation.ts
+++ b/src/server/controller/user/acceptInvitation.ts
@@ -23,6 +23,7 @@ export const acceptInvitation = async (
 
   return client.tx(async (t) => {
     if (UserRoles.isInvitationExpired(userRole)) throw new Error('login.invitationExpired')
+    if (!UserRoles.isInvitationPending(userRole)) throw new Error('login.alreadyAcceptedInvitation')
 
     await UserRoleRepository.acceptInvitation({ userRole }, t)
 


### PR DESCRIPTION
While looking at the activity log, found a bug where a user can accept an invitation more than once.
Cause: The UI didn't handle loading state when the submit button was clicked, and the backend didn't check if the invitation was already accepted or not. 

Before:

https://github.com/openforis/fra-platform/assets/41337901/55941da5-7481-469f-89b9-00b93ac45c14


Now (the form looks like this because the branch doesn't have the latest dev changes):



https://github.com/openforis/fra-platform/assets/41337901/39deaf57-9da0-4700-b7dd-7b3d03068926



