### PR TITLE
3496 - Geo UI Refactor - Add recipe selector

### DIFF
--- a/src/client/components/Inputs/Select/Select.tsx
+++ b/src/client/components/Inputs/Select/Select.tsx
@@ -11,7 +11,7 @@ import { useValue } from './hooks/useValue'
 import { SelectProps } from './types'
 
 const Select: React.FC<SelectProps> = (props) => {
-  const { disabled, isMulti, options } = props
+  const { disabled, isClearable, isMulti, options } = props
 
   const value = useValue(props)
   const onChange = useOnChange(props)
@@ -35,7 +35,7 @@ const Select: React.FC<SelectProps> = (props) => {
       }}
       closeMenuOnSelect={!isMulti}
       components={{ ClearIndicator, DropdownIndicator, IndicatorsContainer, IndicatorSeparator: null }}
-      isClearable
+      isClearable={isClearable}
       isDisabled={disabled}
       isMulti={isMulti}
       isSearchable
@@ -47,6 +47,11 @@ const Select: React.FC<SelectProps> = (props) => {
       value={value}
     />
   )
+}
+
+Select.defaultProps = {
+  // eslint-disable-next-line react/default-props-match-prop-types
+  isClearable: true,
 }
 
 export default Select

--- a/src/client/components/Inputs/Select/types.ts
+++ b/src/client/components/Inputs/Select/types.ts
@@ -14,7 +14,7 @@ export type OptionsOrGroups = readonly (Option | OptionsGroup)[]
 
 export type ValueInput = string | Array<string> | null
 
-export type SelectProps = Pick<ReactSelectProps, 'isMulti'> & {
+export type SelectProps = Pick<ReactSelectProps, 'isClearable' | 'isMulti'> & {
   disabled?: boolean
   onChange: (value: string | Array<string> | null) => void
   options: OptionsOrGroups

--- a/src/client/components/Navigation/NavGeo/RecipeSelector/RecipeSelector.scss
+++ b/src/client/components/Navigation/NavGeo/RecipeSelector/RecipeSelector.scss
@@ -1,0 +1,14 @@
+@import 'src/client/style/partials';
+
+.geo-recipe-selector {
+  background-color: $ui-bg-hover;
+}
+
+.geo-recipe-selector__container {
+  width: 100%;
+}
+
+.geo-recipe-selector__label {
+  display: inline-block;
+  margin-bottom: $spacing-xxs;
+}

--- a/src/client/components/Navigation/NavGeo/RecipeSelector/RecipeSelector.tsx
+++ b/src/client/components/Navigation/NavGeo/RecipeSelector/RecipeSelector.tsx
@@ -1,0 +1,57 @@
+import './RecipeSelector.scss'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { LayerSectionKey } from 'meta/geo'
+import { CUSTOM_RECIPE_KEY, Recipe } from 'meta/geo/layer'
+
+import { useAppDispatch } from 'client/store'
+import { GeoActions, useGeoLayerSectionRecipeName } from 'client/store/ui/geo'
+import { useCountryIso } from 'client/hooks'
+import Select from 'client/components/Inputs/Select'
+
+import { useRecipeOptions } from './hooks/useRecipeOptions'
+
+type Props = {
+  recipes: Array<Recipe>
+  sectionKey: LayerSectionKey
+}
+
+const RecipeSelector: React.FC<Props> = (props) => {
+  const { recipes, sectionKey } = props
+
+  const dispatch = useAppDispatch()
+  const { t } = useTranslation()
+  const countryIso = useCountryIso()
+
+  const selectedRecipe = useGeoLayerSectionRecipeName(sectionKey)
+  const options = useRecipeOptions({ recipes })
+
+  const handleRecipeChange = (value: string) => {
+    const newRecipe = recipes.find(({ forestAreaDataProperty }) => forestAreaDataProperty === value)
+    dispatch(
+      GeoActions.setLayerSectionRecipe({
+        countryIso,
+        recipe: newRecipe,
+        recipeName: value,
+        sectionKey,
+      })
+    )
+  }
+
+  return (
+    <div className="geo-recipe-selector__container">
+      <span className="geo-recipe-selector__label">{t('geo.recipes.recipes')}</span>
+      <div className="geo-recipe-selector">
+        <Select
+          isClearable={false}
+          onChange={handleRecipeChange}
+          options={options}
+          value={selectedRecipe ?? CUSTOM_RECIPE_KEY}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default RecipeSelector

--- a/src/client/components/Navigation/NavGeo/RecipeSelector/hooks/useRecipeOptions.ts
+++ b/src/client/components/Navigation/NavGeo/RecipeSelector/hooks/useRecipeOptions.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { CUSTOM_RECIPE_KEY, Recipe } from 'meta/geo/layer'
+
+import { Option } from 'client/components/Inputs/Select'
+
+type Props = {
+  recipes: Array<Recipe>
+}
+
+type Returned = Array<Option>
+
+export const useRecipeOptions = (props: Props): Returned => {
+  const { recipes } = props
+  const { t } = useTranslation()
+
+  return useMemo<Returned>(() => {
+    const options = recipes.map((recipe) => ({
+      label: t(recipe.labelKey),
+      value: recipe.forestAreaDataProperty,
+    }))
+    const optionCustom: Option = {
+      label: t('common.custom'),
+      value: CUSTOM_RECIPE_KEY,
+    }
+
+    return [optionCustom, ...options]
+  }, [recipes, t])
+}

--- a/src/client/components/Navigation/NavGeo/RecipeSelector/index.ts
+++ b/src/client/components/Navigation/NavGeo/RecipeSelector/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RecipeSelector'

--- a/src/client/components/PageLayout/Toolbar/Toolbar.scss
+++ b/src/client/components/PageLayout/Toolbar/Toolbar.scss
@@ -49,6 +49,6 @@
   font-size: $font-l;
   text-align: center;
   position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
+  right: 40%;
+  transform: translateX(40%);
 }

--- a/src/client/store/ui/geo/actions/setLayerSectionRecipe.ts
+++ b/src/client/store/ui/geo/actions/setLayerSectionRecipe.ts
@@ -2,7 +2,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit'
 
 import { CountryIso } from 'meta/area'
 import { LayerSectionKey } from 'meta/geo'
-import { LayerKey, LayerSource, Recipe } from 'meta/geo/layer'
+import { CUSTOM_RECIPE_KEY, LayerKey, LayerSource, Recipe } from 'meta/geo/layer'
 
 import { RootState } from 'client/store/RootState'
 import { GeoActions } from 'client/store/ui/geo/slice'
@@ -18,7 +18,7 @@ export const setLayerSectionRecipe = createAsyncThunk<void, Params>(
   'geo/setLayerSectionRecipe',
   async ({ countryIso, recipe, recipeName, sectionKey }, { dispatch, getState }) => {
     dispatch(GeoActions.setLayerSectionRecipeName({ recipe: recipeName, sectionKey }))
-    if (recipeName === 'custom') return
+    if (recipeName === CUSTOM_RECIPE_KEY) return
     const state = getState()
     const sectionState = (state as RootState).geo.sections?.[sectionKey]
     const recipeLayersSet = new Set()

--- a/src/client/store/ui/geo/actions/toggleLayer.ts
+++ b/src/client/store/ui/geo/actions/toggleLayer.ts
@@ -2,7 +2,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit'
 
 import { CountryIso } from 'meta/area'
 import { LayerSectionKey } from 'meta/geo'
-import { LayerKey, LayerSource } from 'meta/geo/layer'
+import { CUSTOM_RECIPE_KEY, LayerKey, LayerSource } from 'meta/geo/layer'
 
 import { RootState } from 'client/store/RootState'
 import { GeoActions } from 'client/store/ui/geo/slice'
@@ -24,7 +24,7 @@ export const toggleLayer = createAsyncThunk<void, Params>(
 
     const currentLayerSelected = layerState?.selected ?? false
     dispatch(GeoActions.setLayerSelected({ sectionKey, layerKey, selected: !currentLayerSelected }))
-    dispatch(GeoActions.setLayerSectionRecipeName({ recipe: 'custom', sectionKey }))
+    dispatch(GeoActions.setLayerSectionRecipeName({ recipe: CUSTOM_RECIPE_KEY, sectionKey }))
 
     // If the layer is now selected, doesn't have a mapId cached and is visible, fetch it
     const currentMapId = layerState?.mapId

--- a/src/i18n/resources/en/common.js
+++ b/src/i18n/resources/en/common.js
@@ -9,6 +9,7 @@ module.exports = {
   copyToClipboard: 'Copy to clipboard',
   countries: 'Countries',
   country: 'Country',
+  custom: 'Custom',
   dashboard: 'Dashboard',
   dataExport: 'Data Export',
   done: 'Done',

--- a/src/i18n/resources/en/geo.js
+++ b/src/i18n/resources/en/geo.js
@@ -6,6 +6,16 @@ module.exports = {
   },
   landsat: 'Landsat',
   maxCloudCoverage: 'Max Cloud Coverage',
+  recipes: {
+    forest: {
+      allGfc10: 'All (GFC Hansen >=10%)',
+      allGfc20: 'All (GFC Hansen >=20%)',
+      allGfc30: 'All (GFC Hansen >=30%)',
+      esriEsa: 'ESRI & ESA',
+      esriEsaGlobland2020Gfc10: 'ESRI, ESA, Globland 2020 & GFC Hansen >=10%',
+    },
+    recipes: 'Recipes',
+  },
   satelliteMosaic: 'Satellite Mosaic',
   sentinel: 'Sentinel',
   showSatelliteMosaic: 'Show Satellite Mosaic',

--- a/src/meta/geo/forest.ts
+++ b/src/meta/geo/forest.ts
@@ -129,7 +129,7 @@ export const forestAgreementRecipes: Array<Recipe> = [
       },
     ],
     forestAreaDataProperty: 'faAgreementHansen10',
-    recipeLabel: 'All (GFC Hansen >=10%)',
+    labelKey: 'geo.recipes.forest.allGfc10',
   },
   {
     layers: [
@@ -148,7 +148,7 @@ export const forestAgreementRecipes: Array<Recipe> = [
       },
     ],
     forestAreaDataProperty: 'faAgreementHansen20',
-    recipeLabel: 'All (GFC Hansen >=20%)',
+    labelKey: 'geo.recipes.forest.allGfc20',
   },
   {
     layers: [
@@ -167,7 +167,7 @@ export const forestAgreementRecipes: Array<Recipe> = [
       },
     ],
     forestAreaDataProperty: 'faAgreementHansen30',
-    recipeLabel: 'All (GFC Hansen >=30%)',
+    labelKey: 'geo.recipes.forest.allGfc30',
   },
   {
     layers: [
@@ -182,12 +182,12 @@ export const forestAgreementRecipes: Array<Recipe> = [
       },
     ],
     forestAreaDataProperty: 'faAgreementEsriEsaGloHansen10',
-    recipeLabel: 'ESRI, ESA, Globland 2020 & GFC Hansen >=10%',
+    labelKey: 'geo.recipes.forest.esriEsaGlobland2020Gfc10',
   },
   {
     layers: [{ key: ForestKey.ESRI }, { key: ForestKey.ESAWorldCover }],
     forestAreaDataProperty: 'faAgreementEsriEsa',
-    recipeLabel: 'ESRI & ESA',
+    labelKey: 'geo.recipes.forest.esriEsa',
   },
 ]
 

--- a/src/meta/geo/layer.ts
+++ b/src/meta/geo/layer.ts
@@ -28,7 +28,7 @@ export interface LayerSource {
 export interface Recipe {
   layers: Array<LayerSource>
   forestAreaDataProperty: string
-  recipeLabel: string
+  labelKey: string
 }
 
 export const CUSTOM_RECIPE_KEY = 'custom'

--- a/src/meta/geo/layer.ts
+++ b/src/meta/geo/layer.ts
@@ -31,6 +31,8 @@ export interface Recipe {
   recipeLabel: string
 }
 
+export const CUSTOM_RECIPE_KEY = 'custom'
+
 export type LayerMetadata = {
   scale?: number
   palette?: Array<string>


### PR DESCRIPTION
Adding the Recipe Selector component.
The Forest Layers component is not included in this PR. It is included in the video just to show how it would look. I will be adding later a component that renders the sections dynamically with the current `sections` array we have in `meta/geo`:
`export const sections: Array<LayerSection> = [forestLayers, protectedAreaLayers, burnedAreaLayers]`


https://github.com/openforis/fra-platform/assets/41337901/ae5212d6-21a6-48c1-9553-b6516b7b8908




And, fixing the Beta message which was overlapping with the new components in the toolbar:

Before:

https://github.com/openforis/fra-platform/assets/41337901/2c010242-eafb-4932-9425-892f7aba131d


Now:


https://github.com/openforis/fra-platform/assets/41337901/4f04fc62-d0d0-439b-949e-d66e52497017

