### PR TITLE
3496 - Geo UI Refactor - Layer control

### DIFF
--- a/src/client/components/Navigation/NavGeo/Layer/Layer.scss
+++ b/src/client/components/Navigation/NavGeo/Layer/Layer.scss
@@ -1,0 +1,31 @@
+@import 'src/client/style/partials';
+
+.geo-layer-control__container {
+  align-items: center;
+  display: grid;
+  grid-template-columns: 150px 120px;
+  justify-content: space-between;
+
+  .geo-layer-toggle__checkbox {
+    > span {
+      font-size: $font-s;
+      font-weight: normal;
+    }
+  }
+
+  .input-range {
+    > input {
+      width: 70px;
+    }
+  }
+}
+
+.geo-layer-control__options-container {
+  grid-column: 1 / -1;
+}
+
+.geo-layer-control__row-border {
+  border-bottom: 1px solid $ui-border;
+  grid-column: 1 / -1;
+  margin: $spacing-xxxs 0 $spacing-xxxs 0;
+}

--- a/src/client/components/Navigation/NavGeo/Layer/Layer.tsx
+++ b/src/client/components/Navigation/NavGeo/Layer/Layer.tsx
@@ -7,8 +7,8 @@ import { useAppDispatch } from 'client/store'
 import { GeoActions } from 'client/store/ui/geo'
 import { useCountryIso } from 'client/hooks'
 import InputRange from 'client/components/Inputs/InputRange'
+import LayerToggleControl from 'client/components/Navigation/NavGeo/LayerToggleControl'
 
-import LayerToggleControl from '../LayerToggleControl'
 import { useLayerControl } from './hooks/useLayerControl'
 
 type Props = {

--- a/src/client/components/Navigation/NavGeo/Layer/Layer.tsx
+++ b/src/client/components/Navigation/NavGeo/Layer/Layer.tsx
@@ -1,0 +1,62 @@
+import './Layer.scss'
+import React from 'react'
+
+import { Layer as LayerType, LayerSectionKey } from 'meta/geo'
+
+import { useAppDispatch } from 'client/store'
+import { GeoActions } from 'client/store/ui/geo'
+import { useCountryIso } from 'client/hooks'
+import InputRange from 'client/components/Inputs/InputRange'
+
+import LayerToggleControl from '../LayerToggleControl'
+import { useLayerControl } from './hooks/useLayerControl'
+
+type Props = {
+  layer: LayerType
+  sectionKey: LayerSectionKey
+}
+
+const Layer: React.FC<Props> = (props) => {
+  const { layer, sectionKey } = props
+  const dispatch = useAppDispatch()
+  const countryIso = useCountryIso()
+
+  const { fetchOnSelect, layerControlType, opacity, selected, status, title } = useLayerControl({
+    layer,
+    sectionKey,
+  })
+  const layerKey = layer.key
+
+  const handleOpacityChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const newOpacity = Math.round(Number(event.currentTarget.value) / 10) / 10
+    dispatch(GeoActions.setLayerOpacity({ countryIso, layerKey, opacity: newOpacity, sectionKey }))
+  }
+
+  const handleToggleLayer = () => {
+    if (fetchOnSelect) {
+      dispatch(GeoActions.toggleLayer({ fetchLayerParams: { countryIso }, layerKey, sectionKey }))
+    } else {
+      dispatch(GeoActions.toggleLayer({ layerKey, sectionKey }))
+    }
+  }
+
+  return (
+    <div className="geo-layer-control__container">
+      <LayerToggleControl
+        backgroundColor={layer.metadata?.palette?.[0]}
+        checked={selected}
+        label={title}
+        onCheckboxClick={handleToggleLayer}
+        status={status}
+      />
+      <InputRange disabled={!selected} onChange={handleOpacityChange} unit="%" value={opacity * 100} />
+      {/* To add: Year and Tree cover percent components */}
+      {layerControlType !== null && selected && (
+        <div className="geo-layer-control__options-container">{layerControlType}</div>
+      )}
+      <div className="geo-layer-control__row-border" />
+    </div>
+  )
+}
+
+export default Layer

--- a/src/client/components/Navigation/NavGeo/Layer/hooks/useLayerControl.ts
+++ b/src/client/components/Navigation/NavGeo/Layer/hooks/useLayerControl.ts
@@ -1,0 +1,56 @@
+import { useMemo } from 'react'
+
+import { Layer, LayerControlType, LayerSectionKey } from 'meta/geo/layer'
+
+import { useGeoLayer } from 'client/store/ui/geo'
+import { LayerFetchStatus } from 'client/store/ui/geo/stateType'
+
+type Props = {
+  layer: Layer
+  sectionKey: LayerSectionKey
+}
+
+type Returned = {
+  fetchOnSelect: boolean
+  layerControlType: LayerControlType | null
+  opacity: number
+  selected: boolean
+  status: LayerFetchStatus
+  title: string
+}
+
+export const useLayerControl = (props: Props): Returned => {
+  const { layer, sectionKey } = props
+  const layerState = useGeoLayer(sectionKey, layer.key)
+
+  return useMemo<Returned>(() => {
+    const { options } = layer
+
+    let layerControlType: LayerControlType | null = null
+
+    if (layer.isCustomAsset) {
+      layerControlType = LayerControlType.CustomAsset
+    } else if (options?.gteTreeCoverPercent !== undefined) {
+      layerControlType = LayerControlType.TreeCoverPercent
+    } else if (options?.years !== undefined) {
+      layerControlType = LayerControlType.Year
+    } else if (options?.agreementLayer !== undefined) {
+      layerControlType = LayerControlType.Agreement
+    }
+
+    const fetchOnSelect = layerControlType === null
+    const opacity = layerState?.opacity ?? 1
+    const selected = layerState?.selected ?? false
+    const status = layerState?.status ?? LayerFetchStatus.Unfetched
+    const title = layer.metadata?.title ?? layer.key
+
+    return {
+      fetchOnSelect,
+      layerControlType,
+      opacity,
+      selected,
+      status,
+      title,
+    }
+  }, [layer, layerState])
+}

--- a/src/client/components/Navigation/NavGeo/Layer/index.ts
+++ b/src/client/components/Navigation/NavGeo/Layer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Layer'

--- a/src/client/components/Navigation/NavGeo/LayerToggleControl/LayerToggleControl.scss
+++ b/src/client/components/Navigation/NavGeo/LayerToggleControl/LayerToggleControl.scss
@@ -5,7 +5,6 @@
   align-items: center;
   display: flex;
   flex-direction: row;
-  padding-top: $spacing-xxs;
 
   > .failed {
     border-color: $ui-destructive;

--- a/src/client/components/Navigation/NavGeo/LayerToggleControl/LayerToggleControl.tsx
+++ b/src/client/components/Navigation/NavGeo/LayerToggleControl/LayerToggleControl.tsx
@@ -16,7 +16,10 @@ type Props = {
 const LayerToggleControl: React.FC<Props> = (props) => {
   const { backgroundColor, checked, label, onCheckboxClick, status } = props
 
-  const style = checked && status === LayerFetchStatus.Ready ? { backgroundColor } : {}
+  let style: React.CSSProperties = { backgroundColor }
+  if (!checked || status === LayerFetchStatus.Failed || status === LayerFetchStatus.Loading) {
+    style = {}
+  }
 
   return (
     <div className="geo-layer-toggle__container">

--- a/src/client/components/Navigation/NavGeo/SatelliteMosaic/MosaicControl/MosaicControl.scss
+++ b/src/client/components/Navigation/NavGeo/SatelliteMosaic/MosaicControl/MosaicControl.scss
@@ -37,5 +37,6 @@
 }
 
 .geo-mosaic-control__year-selector-container {
+  background-color: $ui-bg-hover;
   min-width: $spacing-xxxl;
 }

--- a/src/client/components/Navigation/NavGeo/SatelliteMosaic/MosaicControl/MosaicControl.tsx
+++ b/src/client/components/Navigation/NavGeo/SatelliteMosaic/MosaicControl/MosaicControl.tsx
@@ -38,6 +38,7 @@ const MosaicControl: React.FC = () => {
       <p>{t('common.year')}</p>
       <div className="geo-mosaic-control__year-selector-container">
         <Select
+          isClearable={false}
           onChange={(value) => dispatch(GeoActions.setMosaicYear(Number(value)))}
           options={yearOptions}
           value={uiMosaicOptions.year.toString()}

--- a/src/client/components/Navigation/NavGeo/SatelliteMosaic/SatelliteMosaic.tsx
+++ b/src/client/components/Navigation/NavGeo/SatelliteMosaic/SatelliteMosaic.tsx
@@ -16,8 +16,8 @@ const SatelliteMosaic: React.FC = () => {
   return (
     <div>
       <LayerToggleControl
-        label={t('geo.showSatelliteMosaic')}
         checked={selected ?? false}
+        label={t('geo.showSatelliteMosaic')}
         onCheckboxClick={() => dispatch(GeoActions.toggleMosaicLayer())}
         status={status ?? LayerFetchStatus.Unfetched}
       />

--- a/src/meta/geo/layer.ts
+++ b/src/meta/geo/layer.ts
@@ -54,6 +54,13 @@ export type Layer = {
   metadata?: LayerMetadata
 }
 
+export enum LayerControlType {
+  TreeCoverPercent = 'TreeCoverPercent',
+  Year = 'Year',
+  CustomAsset = 'CustomAsset',
+  Agreement = 'Agreement',
+}
+
 export enum LayerSectionKey {
   Forest = 'Forest',
   ProtectedArea = 'ProtectedArea',


### PR DESCRIPTION
Adding a Layer control component that will later also handle the special layers (with year selector, tree cover percent, and so on).  


https://github.com/openforis/fra-platform/assets/41337901/a170440e-ee92-44c6-9781-d75d0bbd0bab

The translations for the titles will be included in the PR of the component that renders all the layers (including Protected Area and Burned Area), given that the type change of the layer metadata will affect them all. 

Also, the year selector from the Mosaic layer now matches the style of the recipe selector. 