### PR TITLE
3654 - History: User interface, part 2 [RFC]

### DIFF
--- a/src/client/components/Navigation/NavAssessment/NavAssessment.tsx
+++ b/src/client/components/Navigation/NavAssessment/NavAssessment.tsx
@@ -9,13 +9,11 @@ import { Objects } from 'utils/objects'
 import { Areas, CountryIso } from 'meta/area'
 import { Routes } from 'meta/routes'
 
-import { useHistoryActive } from 'client/store/data'
 import { useSections } from 'client/store/metadata'
 import { useCountryRouteParams } from 'client/hooks/useRouteParams'
 import Hr from 'client/components/Hr'
 import Icon from 'client/components/Icon'
 import Header from 'client/components/Navigation/NavAssessment/Header'
-import Placeholder from 'client/components/Navigation/NavAssessment/Placeholder'
 import NavigationSection from 'client/components/Navigation/NavAssessment/Section'
 import { Breakpoints } from 'client/utils'
 
@@ -28,14 +26,7 @@ const NavAssessment: React.FC = () => {
 
   const maxHeight = useMaxHeight()
   const [showSections, setShowSections] = useState<boolean>(false)
-  const historyActive = useHistoryActive()
   if (Objects.isEmpty(sections)) return null
-
-  // TODO: Switch between navigation and history
-  // Placeholder
-  if (historyActive) {
-    return <Placeholder />
-  }
 
   return (
     <div className="nav-assessment" style={{ maxHeight }}>

--- a/src/client/components/Navigation/Navigation.tsx
+++ b/src/client/components/Navigation/Navigation.tsx
@@ -3,9 +3,11 @@ import React, { useEffect } from 'react'
 import MediaQuery from 'react-responsive'
 
 import { useAppDispatch } from 'client/store'
+import { useHistoryActive } from 'client/store/data'
 import { NavigationActions } from 'client/store/ui/navigation'
 import { useCountryIso } from 'client/hooks'
 import { useIsPrintRoute } from 'client/hooks/useIsRoute'
+import NavigationHistory from 'client/components/Navigation/NavigationHistory'
 import { Breakpoints } from 'client/utils'
 
 import NavigationDesktop from './NavigationDesktop'
@@ -15,12 +17,14 @@ const Navigation: React.FC = () => {
   const countryIso = useCountryIso()
   const dispatch = useAppDispatch()
   const { print } = useIsPrintRoute()
+  const historyActive = useHistoryActive()
 
   useEffect(() => {
     if (print) dispatch(NavigationActions.updateNavigationVisible(false))
   }, [print, dispatch])
 
   if (!countryIso || print) return <div />
+  if (historyActive) return <NavigationHistory />
 
   return (
     <>

--- a/src/client/components/Navigation/NavigationHistory/NavigationHistory.tsx
+++ b/src/client/components/Navigation/NavigationHistory/NavigationHistory.tsx
@@ -41,18 +41,20 @@ const NavigationHistory: React.FC = () => {
   const data = useData()
 
   return (
-    <div className="nav-assessment" style={{ maxHeight }}>
-      <div className="nav-section__header" role="button" tabIndex={0}>
-        {Object.values(history?.items).map((h) => {
-          return <div key={h.sectionKey}> {t(h.sectionLabelKey)} </div>
-        })}
-      </div>
-      <div>
-        {data?.map((d, i) => (
-          <div key={d.time} className="nav-section__item">
-            <RecentActivityItem datum={d} rowIndex={i} />
-          </div>
-        ))}
+    <div className="nav no-print">
+      <div className="nav-assessment" style={{ maxHeight }}>
+        <div className="nav-section__header" role="button" tabIndex={0}>
+          {Object.values(history?.items).map((h) => {
+            return <div key={h.sectionKey}> {t(h.sectionLabelKey)} </div>
+          })}
+        </div>
+        <div>
+          {data?.map((d, i) => (
+            <div key={d.time} className="nav-section__item">
+              <RecentActivityItem datum={d} rowIndex={i} />
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/src/client/components/Navigation/NavigationHistory/NavigationHistory.tsx
+++ b/src/client/components/Navigation/NavigationHistory/NavigationHistory.tsx
@@ -1,5 +1,5 @@
-// NOTE: This file is a placeholder and will be removed in next PR.
-// Purpose of this file is to show some content in UI for discussion.
+// Placeholder component moved to NavigationHistory.tsx
+// This is still a placeholder component.
 
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -31,7 +31,7 @@ const useData = () => {
   return data?.filter((d) => d.message === ActivityLogMessage.descriptionUpdate && d.section === sectionName)
 }
 
-const Placeholder: React.FC = () => {
+const NavigationHistory: React.FC = () => {
   const { t } = useTranslation()
   const maxHeight = useMaxHeight()
 
@@ -58,4 +58,4 @@ const Placeholder: React.FC = () => {
   )
 }
 
-export default Placeholder
+export default NavigationHistory

--- a/src/client/components/Navigation/NavigationHistory/index.ts
+++ b/src/client/components/Navigation/NavigationHistory/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NavigationHistory'


### PR DESCRIPTION
Purpose:

Find a good place for NavigationHistory and the logic to toggle it

The Placeholder component has been moved to `NavigationHistory` (the content is still a placeholder)

(The pull request output in UI looks 1:1 to previous PR video, only the location and logic to trigger the component updated)