### PR TITLE
3648 - Fix cursor changing position when pasting HTML

### DIFF
--- a/src/client/components/EditorWYSIWYG/EditorWYSIWYG.tsx
+++ b/src/client/components/EditorWYSIWYG/EditorWYSIWYG.tsx
@@ -19,13 +19,14 @@ type Props = {
 const EditorWYSIWYG: React.FC<Props> = (props: Props) => {
   const { disabled, onChange, options, value } = props
 
-  const { config, configReadOnly } = useConfigs({ options })
-  const onBlur = useOnBlur({ onChange })
+  const { configs, jodit } = useConfigs({ options })
+
+  const onBlur = useOnBlur({ jodit, onChange, value })
 
   return (
     <div className={classNames('editorWYSIWYG', { disabled })}>
-      {disabled && <JoditEditor config={configReadOnly} value={value} />}
-      {!disabled && <JoditEditor config={config} onBlur={onBlur} value={value} />}
+      {disabled && <JoditEditor config={configs.configReadOnly} value={value} />}
+      {!disabled && <JoditEditor config={configs.config} onBlur={onBlur} value={value} />}
     </div>
   )
 }

--- a/src/client/components/EditorWYSIWYG/hooks/useConfigs.ts
+++ b/src/client/components/EditorWYSIWYG/hooks/useConfigs.ts
@@ -1,12 +1,17 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
+
+import { Jodit } from 'jodit-react'
 
 import { EditorConfig } from 'client/components/EditorWYSIWYG/types'
 
 type Props = { options?: EditorConfig }
 
 type Returned = {
-  config: EditorConfig
-  configReadOnly: EditorConfig
+  configs: {
+    config: EditorConfig
+    configReadOnly: EditorConfig
+  }
+  jodit: Jodit
 }
 
 const buttons = [
@@ -40,12 +45,19 @@ const buttons = [
 export const useConfigs = (props: Props): Returned => {
   const { options } = props
 
-  return useMemo<Returned>(() => {
+  const [jodit, setJodit] = useState<Jodit>()
+
+  const configs = useMemo<Returned['configs']>(() => {
     const config: EditorConfig = {
       // @ts-ignore
       addNewLine: false,
       buttons,
       enter: 'div',
+      events: {
+        afterInit: (args: Jodit) => {
+          setJodit(args)
+        },
+      },
       inline: true,
       placeholder: '',
       readonly: false,
@@ -65,4 +77,6 @@ export const useConfigs = (props: Props): Returned => {
 
     return { config, configReadOnly }
   }, [options])
+
+  return { configs, jodit }
 }


### PR DESCRIPTION
Preventing the `onChange` callback to run when `onBlur` is triggered by the Jodit Editor HTML processor popup. That fixes the cursor changing position, and keeps the logic that sanitizes the content before sending it to the BE.


https://github.com/openforis/fra-platform/assets/41337901/eb8f8f6a-69ee-4f20-81ab-35f95c541084

