### PR TITLE
3507 - Fix mojibake in status notification

### DIFF
--- a/src/i18n/resources/en.js
+++ b/src/i18n/resources/en.js
@@ -871,10 +871,10 @@ The FRA team fra@fao.org
     panEuropean: 'pan-European',
     deskStudy: 'Desk study',
     statusChangeNotification: {
-      subject: '{{country}} status changed to {{status}} on FRA Platform',
+      subject: '{{- country}} status changed to {{status}} on FRA Platform',
       textMessage: `Dear {{recipientName}},
 
-{{changer}} changed the status of {{assessment}} to "{{status}}" for {{country}} on FRA Platform.
+{{changer}} changed the status of {{assessment}} to "{{status}}" for {{- country}} on FRA Platform.
 
 {{message}}
 
@@ -884,7 +884,7 @@ The FRA team
 {{- serverUrl}}`,
       htmlMessage: `Dear {{recipientName}},
 <br/><br/>
-{{changer}} changed the status of {{assessment}} to "{{status}}" for {{country}} on FRA Platform.
+{{changer}} changed the status of {{assessment}} to "{{status}}" for {{- country}} on FRA Platform.
 <br/><br/>
 {{message}}
 <br/><br/>


### PR DESCRIPTION
Fixing a mojibake in the status notification email.

The root reason is that during i18next interpolation, the single quotes are escaped by default prevent mitigate XSS attacks. This can be toggled off by adding a dash : `{{- country}}`.  
https://www.i18next.com/translation-function/interpolation#unescape

An alternative to fix all instances would be to toggle off escape globally during the i18next initialization.

Fixed text:
<img width="933" alt="image" src="https://github.com/openforis/fra-platform/assets/41337901/b4890042-0102-47f4-8a4c-6c321fe2e2f0">
