### PR TITLE
3654 - History: Minimal History layout

### DIFF
--- a/src/client/components/Navigation/NavAssessment/History/History.tsx
+++ b/src/client/components/Navigation/NavAssessment/History/History.tsx
@@ -1,29 +1,29 @@
 import React from 'react'
-import { useTranslation } from 'react-i18next'
 
 import { useHistory } from 'client/store/data/hooks/useHistory'
 import Items from 'client/components/Navigation/NavAssessment/History/Items'
+import Title from 'client/components/Navigation/NavAssessment/History/Title'
 
 import { useData } from './hooks/useData'
 import { useGetData } from './hooks/useGetData'
 
 const History: React.FC = () => {
-  const { t } = useTranslation()
+  useGetData()
 
+  const data = useData()
   const history = useHistory()
 
-  useGetData()
-  const data = useData()
-
   return (
-    <>
-      <div className="nav-section__header" role="button" tabIndex={0}>
-        {Object.values(history?.items).map((h) => {
-          return <div key={h.sectionKey}> {t(h.sectionLabelKey)} </div>
-        })}
-      </div>
-      <Items values={data} />
-    </>
+    <div className="nav-section">
+      {Object.entries(history.items).map(([key, value]) => {
+        return (
+          <React.Fragment key={key}>
+            <Title value={value} />
+            <Items values={data} />
+          </React.Fragment>
+        )
+      })}
+    </div>
   )
 }
 

--- a/src/client/components/Navigation/NavAssessment/History/Items/Item/Item.scss
+++ b/src/client/components/Navigation/NavAssessment/History/Items/Item/Item.scss
@@ -1,0 +1,27 @@
+@import 'src/client/style/partials';
+
+.history-item {
+  align-items: center;
+  background: none;
+  border: none;
+  color: $text-body;
+  cursor: pointer;
+  display: flex;
+  padding: 0;
+  transition: color 0.2s;
+  width: 100%;
+}
+
+.history-item {
+  span,
+  strong {
+    margin-right: $spacing-xxs;
+  }
+}
+
+.history-item__avatar {
+  border-radius: 100%;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+  height: 28px;
+  width: 28px;
+}

--- a/src/client/components/Navigation/NavAssessment/History/Items/Item/Item.tsx
+++ b/src/client/components/Navigation/NavAssessment/History/Items/Item/Item.tsx
@@ -1,0 +1,43 @@
+import './Item.scss'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Dates } from 'utils/dates'
+
+import { ApiEndPoint } from 'meta/api/endpoint'
+import { ActivityLog, ActivityLogs } from 'meta/assessment'
+import { Users } from 'meta/user'
+
+type Props = {
+  datum: ActivityLog<never>
+}
+
+const formatDate = (date?: string): string => (date ? Dates.format(Dates.parseISO(date), 'dd MMMM yyyy HH:mm') : '')
+
+const Item: React.FC<Props> = (props) => {
+  const { t } = useTranslation()
+  const { datum: activity } = props
+  const { user } = activity
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  const onClick = () => {}
+
+  return (
+    <button className="nav-section__item history-item" onClick={onClick} type="button">
+      <div className="nav-section__order">
+        <img
+          alt={Users.getFullName(user)}
+          className="history-item__avatar"
+          src={ApiEndPoint.User.profilePicture(String(user.id))}
+        />
+      </div>
+      <div className="nav-section__label">
+        <strong>{Users.getFullName(user)}</strong>
+        <span>{ActivityLogs.getLabelAction({ activity, t })}</span>
+        <span>{formatDate(activity.time)}</span>
+      </div>
+    </button>
+  )
+}
+
+export default Item

--- a/src/client/components/Navigation/NavAssessment/History/Items/Item/index.ts
+++ b/src/client/components/Navigation/NavAssessment/History/Items/Item/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Item'

--- a/src/client/components/Navigation/NavAssessment/History/Items/Items.tsx
+++ b/src/client/components/Navigation/NavAssessment/History/Items/Items.tsx
@@ -11,7 +11,7 @@ const Items: React.FC<Props> = (props: Props) => {
   const { values } = props
 
   return (
-    <div>
+    <div className="nav-section__items-visible">
       {values?.map((d, i) => (
         <div key={d.time} className="nav-section__item">
           <RecentActivityItem datum={d} rowIndex={i} />

--- a/src/client/components/Navigation/NavAssessment/History/Items/Items.tsx
+++ b/src/client/components/Navigation/NavAssessment/History/Items/Items.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { ActivityLog } from 'meta/assessment'
 
-import RecentActivityItem from 'client/pages/CountryHome/FraHome/RecentActivity/RecentActivityItem'
+import Item from './Item'
 
 type Props = {
   values: Array<ActivityLog<never>>
@@ -12,10 +12,10 @@ const Items: React.FC<Props> = (props: Props) => {
 
   return (
     <div className="nav-section__items-visible">
-      {values?.map((d, i) => (
-        <div key={d.time} className="nav-section__item">
-          <RecentActivityItem datum={d} rowIndex={i} />
-        </div>
+      {values?.map((d) => (
+        <React.Fragment key={d.time}>
+          <Item datum={d} />
+        </React.Fragment>
       ))}
     </div>
   )

--- a/src/client/components/Navigation/NavAssessment/History/Title/Title.tsx
+++ b/src/client/components/Navigation/NavAssessment/History/Title/Title.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { HistoryItemState } from 'client/store/data'
+
+type Props = {
+  value: HistoryItemState
+}
+
+const Title: React.FC<Props> = (props: Props) => {
+  const { value } = props
+  const { t } = useTranslation()
+
+  return (
+    <div className="nav-section__header" role="button" tabIndex={0}>
+      <div key={value.sectionKey}> {t(value.sectionLabelKey)} </div>
+    </div>
+  )
+}
+
+export default Title

--- a/src/client/components/Navigation/NavAssessment/History/Title/index.ts
+++ b/src/client/components/Navigation/NavAssessment/History/Title/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Title'

--- a/src/client/components/Navigation/NavAssessment/History/hooks/useData.ts
+++ b/src/client/components/Navigation/NavAssessment/History/hooks/useData.ts
@@ -5,7 +5,6 @@ import { useTablePaginatedData } from 'client/store/ui/tablePaginated'
 
 const path = ApiEndPoint.CycleData.activities()
 
-export const useData = () => {
-  const data = useTablePaginatedData<ActivityLog<never>>(path)
-  return data
+export const useData = (): Array<ActivityLog<never>> => {
+  return useTablePaginatedData<ActivityLog<never>>(path)
 }

--- a/src/client/components/Navigation/NavAssessment/History/hooks/useGetData.ts
+++ b/src/client/components/Navigation/NavAssessment/History/hooks/useGetData.ts
@@ -7,7 +7,7 @@ import { TablePaginatedActions } from 'client/store/ui/tablePaginated'
 import { useCountryRouteParams } from 'client/hooks/useRouteParams'
 
 const path = ApiEndPoint.CycleData.activities()
-export const useGetData = () => {
+export const useGetData = (): void => {
   const dispatch = useAppDispatch()
   const { assessmentName, cycleName, countryIso } = useCountryRouteParams()
 

--- a/src/client/store/data/index.ts
+++ b/src/client/store/data/index.ts
@@ -13,6 +13,7 @@ export { useRecordAssessmentData, useRecordAssessmentDataWithOdp } from './hooks
 export { DataActions } from './slice'
 export type {
   DataState,
+  HistoryItemState,
   RecordAssessmentValidationsState,
   RecordCountryValidationsState,
   RecordCycleValidationsState,

--- a/src/client/store/data/stateType.ts
+++ b/src/client/store/data/stateType.ts
@@ -47,7 +47,7 @@ export type RecordContacts = Record<AssessmentName, Record<CycleName, Record<Cou
 // History state types
 // ==============================
 
-type HistoryItemState = {
+export type HistoryItemState = {
   sectionLabelKey: string
   sectionKey: HistoryItemSectionKey
 }


### PR DESCRIPTION
Purpose:
Add layout for history Item
Update classes and DOM tree to match current navigation

Note: This is subject to change, so only minimal layout is added and not refined.


https://github.com/openforis/fra-platform/assets/5508251/332f9290-43dc-4538-8c45-03a24cc5dda2

