### PR TITLE
3654 History: Add Endpoint for History

### DIFF
--- a/src/client/components/Navigation/NavAssessment/History/History.tsx
+++ b/src/client/components/Navigation/NavAssessment/History/History.tsx
@@ -4,13 +4,7 @@ import { useHistory } from 'client/store/data/hooks/useHistory'
 import Items from 'client/components/Navigation/NavAssessment/History/Items'
 import Title from 'client/components/Navigation/NavAssessment/History/Title'
 
-import { useData } from './hooks/useData'
-import { useGetData } from './hooks/useGetData'
-
 const History: React.FC = () => {
-  useGetData()
-
-  const data = useData()
   const history = useHistory()
 
   return (
@@ -19,7 +13,7 @@ const History: React.FC = () => {
         return (
           <React.Fragment key={key}>
             <Title value={value} />
-            <Items values={data} />
+            <Items sectionKey={value.sectionKey} />
           </React.Fragment>
         )
       })}

--- a/src/client/components/Navigation/NavAssessment/History/Items/Items.tsx
+++ b/src/client/components/Navigation/NavAssessment/History/Items/Items.tsx
@@ -1,18 +1,22 @@
 import React from 'react'
 
-import { ActivityLog } from 'meta/assessment'
+import { HistoryItemSectionKey } from 'meta/cycleData'
 
+import { useData } from '../hooks/useData'
+import { useGetData } from '../hooks/useGetData'
 import Item from './Item'
 
 type Props = {
-  values: Array<ActivityLog<never>>
+  sectionKey: HistoryItemSectionKey
 }
 const Items: React.FC<Props> = (props: Props) => {
-  const { values } = props
+  const { sectionKey } = props
+  useGetData(sectionKey)
+  const data = useData(sectionKey)
 
   return (
     <div className="nav-section__items-visible">
-      {values?.map((d) => (
+      {data?.map((d) => (
         <React.Fragment key={d.time}>
           <Item datum={d} />
         </React.Fragment>

--- a/src/client/components/Navigation/NavAssessment/History/hooks/useData.ts
+++ b/src/client/components/Navigation/NavAssessment/History/hooks/useData.ts
@@ -1,10 +1,9 @@
-import { ApiEndPoint } from 'meta/api/endpoint'
 import { ActivityLog } from 'meta/assessment'
 
 import { useTablePaginatedData } from 'client/store/ui/tablePaginated'
+import { usePath } from 'client/components/Navigation/NavAssessment/History/hooks/usePath'
 
-const path = ApiEndPoint.CycleData.activities()
-
-export const useData = (): Array<ActivityLog<never>> => {
+export const useData = (sectionKey: string): Array<ActivityLog<never>> => {
+  const path = usePath(sectionKey)
   return useTablePaginatedData<ActivityLog<never>>(path)
 }

--- a/src/client/components/Navigation/NavAssessment/History/hooks/useGetData.ts
+++ b/src/client/components/Navigation/NavAssessment/History/hooks/useGetData.ts
@@ -1,18 +1,19 @@
 import { useEffect } from 'react'
 
-import { ApiEndPoint } from 'meta/api/endpoint'
+import { HistoryItemSectionKey } from 'meta/cycleData'
 
 import { useAppDispatch } from 'client/store'
 import { TablePaginatedActions } from 'client/store/ui/tablePaginated'
 import { useCountryRouteParams } from 'client/hooks/useRouteParams'
+import { usePath } from 'client/components/Navigation/NavAssessment/History/hooks/usePath'
 
-const path = ApiEndPoint.CycleData.activities()
-export const useGetData = (): void => {
+export const useGetData = (sectionKey: HistoryItemSectionKey): void => {
+  const path = usePath(sectionKey)
   const dispatch = useAppDispatch()
   const { assessmentName, cycleName, countryIso } = useCountryRouteParams()
 
   useEffect(() => {
     const params = { assessmentName, cycleName, countryIso, path, page: 0, limit: 20 }
     dispatch(TablePaginatedActions.getData(params))
-  }, [assessmentName, countryIso, cycleName, dispatch])
+  }, [assessmentName, countryIso, cycleName, dispatch, path])
 }

--- a/src/client/components/Navigation/NavAssessment/History/hooks/usePath.ts
+++ b/src/client/components/Navigation/NavAssessment/History/hooks/usePath.ts
@@ -1,0 +1,9 @@
+import { useMemo } from 'react'
+
+import { ApiEndPoint } from 'meta/api/endpoint'
+import { Histories, HistoryItemSectionKey } from 'meta/cycleData'
+
+export const usePath = (sectionKey: HistoryItemSectionKey): string => {
+  const { sectionName, name } = Histories.getHistoryItemKeyParts(sectionKey)
+  return useMemo<string>(() => ApiEndPoint.CycleData.history(sectionName, name), [name, sectionName])
+}

--- a/src/meta/api/endpoint/ApiEndPoint.ts
+++ b/src/meta/api/endpoint/ApiEndPoint.ts
@@ -33,6 +33,7 @@ export const ApiEndPoint = {
   CycleData: {
     activities: () => apiPath('cycle-data', 'activities'),
     activitiesCount: () => apiPath('cycle-data', 'activities', 'count'),
+    history: () => apiPath('cycle-data', 'history'),
 
     Descriptions: {
       many: () => apiPath('cycle-data', 'descriptions'),

--- a/src/meta/api/endpoint/ApiEndPoint.ts
+++ b/src/meta/api/endpoint/ApiEndPoint.ts
@@ -33,7 +33,8 @@ export const ApiEndPoint = {
   CycleData: {
     activities: () => apiPath('cycle-data', 'activities'),
     activitiesCount: () => apiPath('cycle-data', 'activities', 'count'),
-    history: () => apiPath('cycle-data', 'history'),
+    history: (sectionName = ':sectionName', target = ':target') =>
+      apiPath('cycle-data', 'history', sectionName, target),
 
     Descriptions: {
       many: () => apiPath('cycle-data', 'descriptions'),

--- a/src/meta/api/request/tablePaginated.ts
+++ b/src/meta/api/request/tablePaginated.ts
@@ -17,6 +17,11 @@ export type TablePaginatedDataRequestParams = BaseParams & {
   orderByDirection?: TablePaginatedOrderByDirection
 }
 
-export type TablePaginatedDataRequest = Request<never, never, never, TablePaginatedDataRequestParams>
+export type TablePaginatedDataRequest<OptionalParams extends Record<string, unknown> = never> = Request<
+  never,
+  never,
+  never,
+  TablePaginatedDataRequestParams & OptionalParams
+>
 
 export type TablePaginatedCountRequest = Request<never, never, never, BaseParams>

--- a/src/meta/cycleData/history/histories.ts
+++ b/src/meta/cycleData/history/histories.ts
@@ -5,6 +5,14 @@ const getHistoryItemSectionKey = (sectionName: string, name: CommentableDescript
   return `${sectionName}-${name}` as HistoryItemSectionKey
 }
 
+const getHistoryItemKeyParts = (
+  sectionKey: HistoryItemSectionKey
+): { sectionName: string; name: CommentableDescriptionName } => {
+  const [sectionName, name] = sectionKey.split('-')
+  return { sectionName, name: name as CommentableDescriptionName }
+}
+
 export const Histories = {
   getHistoryItemSectionKey,
+  getHistoryItemKeyParts,
 }

--- a/src/server/api/cycleData/history/getHistory.ts
+++ b/src/server/api/cycleData/history/getHistory.ts
@@ -1,0 +1,28 @@
+import { Response } from 'express'
+
+import { TablePaginatedDataRequest } from 'meta/api/request/tablePaginated'
+import { ActivityLogMessage } from 'meta/assessment'
+
+import { AssessmentController } from 'server/controller/assessment'
+import { CycleDataController } from 'server/controller/cycleData'
+import Requests from 'server/utils/requests'
+
+type HistoryRequest = TablePaginatedDataRequest<{
+  sectionName?: string
+  targetName: string
+  message: ActivityLogMessage
+}>
+
+export const getHistory = async (req: HistoryRequest, res: Response) => {
+  try {
+    const { assessmentName, cycleName, countryIso, sectionName, targetName, message } = req.query
+    const { assessment, cycle } = await AssessmentController.getOneWithCycle({ assessmentName, cycleName })
+
+    const props = { assessment, cycle, countryIso, sectionName, targetName, message }
+    const history = await CycleDataController.History.getHistory(props)
+
+    Requests.send(res, history)
+  } catch (e) {
+    Requests.sendErr(res, e)
+  }
+}

--- a/src/server/api/cycleData/history/getHistory.ts
+++ b/src/server/api/cycleData/history/getHistory.ts
@@ -1,24 +1,18 @@
 import { Response } from 'express'
 
 import { TablePaginatedDataRequest } from 'meta/api/request/tablePaginated'
-import { ActivityLogMessage } from 'meta/assessment'
 
 import { AssessmentController } from 'server/controller/assessment'
 import { CycleDataController } from 'server/controller/cycleData'
 import Requests from 'server/utils/requests'
 
-type HistoryRequest = TablePaginatedDataRequest<{
-  sectionName?: string
-  targetName: string
-  message: ActivityLogMessage
-}>
-
-export const getHistory = async (req: HistoryRequest, res: Response) => {
+export const getHistory = async (req: TablePaginatedDataRequest, res: Response) => {
   try {
-    const { assessmentName, cycleName, countryIso, sectionName, targetName, message } = req.query
+    const { assessmentName, cycleName, countryIso } = req.query
+    const { sectionName, target } = req.params
     const { assessment, cycle } = await AssessmentController.getOneWithCycle({ assessmentName, cycleName })
 
-    const props = { assessment, cycle, countryIso, sectionName, targetName, message }
+    const props = { assessment, cycle, countryIso, sectionName, target }
     const history = await CycleDataController.History.getHistory(props)
 
     Requests.send(res, history)

--- a/src/server/api/cycleData/index.ts
+++ b/src/server/api/cycleData/index.ts
@@ -4,6 +4,7 @@ import * as queue from 'express-queue'
 
 import { ApiEndPoint } from 'meta/api/endpoint'
 
+import { getHistory } from 'server/api/cycleData/history/getHistory'
 import { AuthMiddleware } from 'server/middleware/auth'
 
 import { getActivities } from './activities/getActivities'
@@ -140,6 +141,9 @@ export const CycleDataApi = {
     // Activities
     express.get(ApiEndPoint.CycleData.activities(), AuthMiddleware.requireView, getActivities)
     express.get(ApiEndPoint.CycleData.activitiesCount(), AuthMiddleware.requireView, getActivitiesCount)
+
+    // History
+    express.get(ApiEndPoint.CycleData.history(), AuthMiddleware.requireEditTableData, getHistory)
 
     // ext node
     // -- Contacts

--- a/src/server/controller/cycleData/history/getHistory.ts
+++ b/src/server/controller/cycleData/history/getHistory.ts
@@ -8,15 +8,20 @@ type Props = {
   cycle: Cycle
   countryIso: AreaCode
   sectionName: SectionName
-  message: ActivityLogMessage
-  targetName: string
+  target: string
 }
 
 type Returned = Array<ActivityLog<never>>
 
-export const getHistory = async (props: Props): Promise<Returned> => {
-  const { assessment, cycle, countryIso, sectionName, message, targetName } = props
+const messages: Record<string, ActivityLogMessage> = {
+  dataSources: ActivityLogMessage.descriptionUpdate,
+}
 
-  const getHistoryProps = { assessment, cycle, countryIso, sectionName, message, targetName }
+export const getHistory = async (props: Props): Promise<Returned> => {
+  const { assessment, cycle, countryIso, sectionName, target } = props
+
+  const message = messages[target]
+
+  const getHistoryProps = { assessment, cycle, countryIso, sectionName, message, target }
   return ActivityLogRepository.getMany(getHistoryProps)
 }

--- a/src/server/controller/cycleData/history/getHistory.ts
+++ b/src/server/controller/cycleData/history/getHistory.ts
@@ -1,0 +1,22 @@
+import { AreaCode } from 'meta/area'
+import { ActivityLog, ActivityLogMessage, Assessment, Cycle, SectionName } from 'meta/assessment'
+
+import { ActivityLogRepository } from 'server/repository/public/activityLog'
+
+type Props = {
+  assessment: Assessment
+  cycle: Cycle
+  countryIso: AreaCode
+  sectionName: SectionName
+  message: ActivityLogMessage
+  targetName: string
+}
+
+type Returned = Array<ActivityLog<never>>
+
+export const getHistory = async (props: Props): Promise<Returned> => {
+  const { assessment, cycle, countryIso, sectionName, message, targetName } = props
+
+  const getHistoryProps = { assessment, cycle, countryIso, sectionName, message, targetName }
+  return ActivityLogRepository.getMany(getHistoryProps)
+}

--- a/src/server/controller/cycleData/history/index.ts
+++ b/src/server/controller/cycleData/history/index.ts
@@ -1,0 +1,5 @@
+import { getHistory } from './getHistory'
+
+export const History = {
+  getHistory,
+}

--- a/src/server/controller/cycleData/index.ts
+++ b/src/server/controller/cycleData/index.ts
@@ -1,3 +1,4 @@
+import { History } from 'server/controller/cycleData/history'
 import { deleteOriginalDataPointNationalClass } from 'server/controller/cycleData/originalDataPoint/deleteOriginalDataPointNationalClass'
 import { Repository } from 'server/controller/cycleData/repository'
 import { CountryActivityLogRepository } from 'server/repository/assessmentCycle/countryActivityLog'
@@ -69,6 +70,9 @@ export const CycleDataController = {
   // ==== activities
   getActivities: CountryActivityLogRepository.getMany,
   getActivitiesCount: CountryActivityLogRepository.getCount,
+
+  // ====== history
+  History,
 
   // bulk download
   getBulkDownload,

--- a/src/server/repository/public/activityLog/getMany.ts
+++ b/src/server/repository/public/activityLog/getMany.ts
@@ -1,0 +1,24 @@
+import { Objects } from 'utils/objects'
+
+import { AreaCode } from 'meta/area'
+import { ActivityLog, ActivityLogMessage, Assessment, Cycle } from 'meta/assessment'
+
+import { BaseProtocol, DB } from 'server/db'
+
+type Props = {
+  assessment: Assessment
+  cycle: Cycle
+  countryIso: AreaCode
+  sectionName: string
+  message: ActivityLogMessage
+  targetName: string
+}
+
+export const getMany = async (props: Props, client: BaseProtocol = DB): Promise<Array<ActivityLog<never>>> => {
+  const { assessment, cycle, countryIso, sectionName, message, targetName } = props
+  return client.map<ActivityLog<never>>(
+    `select * from public.activity_log where assessment_uuid = $1 and cycle_uuid = $2 and country_iso = $3 and section = $4 and message = $5 and target ->> 'name' = $6;`,
+    [assessment.uuid, cycle.uuid, countryIso, sectionName, message, targetName],
+    (row) => Objects.camelize(row)
+  )
+}

--- a/src/server/repository/public/activityLog/getMany.ts
+++ b/src/server/repository/public/activityLog/getMany.ts
@@ -17,7 +17,11 @@ type Props = {
 export const getMany = async (props: Props, client: BaseProtocol = DB): Promise<Array<ActivityLog<never>>> => {
   const { assessment, cycle, countryIso, sectionName, message, target } = props
   return client.map<ActivityLog<never>>(
-    `select * from public.activity_log where assessment_uuid = $1 and cycle_uuid = $2 and country_iso = $3 and section = $4 and message = $5 and target ->> 'name' = $6;`,
+    `select al.*,
+                  jsonb_build_object('id', u.id, 'props', u.props) as user
+          from public.activity_log al
+          join public.users u on al.user_id = u.id
+          where assessment_uuid = $1 and cycle_uuid = $2 and country_iso = $3 and section = $4 and message = $5 and target ->> 'name' = $6;`,
     [assessment.uuid, cycle.uuid, countryIso, sectionName, message, target],
     (row) => Objects.camelize(row)
   )

--- a/src/server/repository/public/activityLog/getMany.ts
+++ b/src/server/repository/public/activityLog/getMany.ts
@@ -11,14 +11,14 @@ type Props = {
   countryIso: AreaCode
   sectionName: string
   message: ActivityLogMessage
-  targetName: string
+  target: string
 }
 
 export const getMany = async (props: Props, client: BaseProtocol = DB): Promise<Array<ActivityLog<never>>> => {
-  const { assessment, cycle, countryIso, sectionName, message, targetName } = props
+  const { assessment, cycle, countryIso, sectionName, message, target } = props
   return client.map<ActivityLog<never>>(
     `select * from public.activity_log where assessment_uuid = $1 and cycle_uuid = $2 and country_iso = $3 and section = $4 and message = $5 and target ->> 'name' = $6;`,
-    [assessment.uuid, cycle.uuid, countryIso, sectionName, message, targetName],
+    [assessment.uuid, cycle.uuid, countryIso, sectionName, message, target],
     (row) => Objects.camelize(row)
   )
 }

--- a/src/server/repository/public/activityLog/index.ts
+++ b/src/server/repository/public/activityLog/index.ts
@@ -1,7 +1,9 @@
+import { getMany } from './getMany'
 import { insertActivityLog } from './insertActivityLog'
 import { massiveInsert } from './massiveInsert'
 
 export const ActivityLogRepository = {
+  getMany,
   insertActivityLog,
   massiveInsert,
 }


### PR DESCRIPTION


https://github.com/openforis/fra-platform/assets/5508251/6b2ff144-43ed-4b06-88bc-b95a0c5bc9dd


Introduce very general purpose history end point that queries `public.activity_log`

Example:

```
request: http://localhost:9000/api/cycle-data/history/nonWoodForestProductsRemovals/dataSources?assessmentName=fra&cycleName=2025&countryIso=FIN


[
  {
    "time": "2024-03-08T09:55:01.357Z",
    "message": "descriptionUpdate",
    "countryIso": "FIN",
    "section": "nonWoodForestProductsRemovals",
    "target": {
      "name": "dataSources",
      "description": {
        "value": {
          "text": "<p>truncated</p>\n",
          "dataSources": [
            {
              "type": "",
              "uuid": "494ffeec-3e05-4d75-9ea7-860d9bdf9e61",
              "year": "",
              "comments": "",
              "reference": "<div>Please fill table<br></div>",
              "variables": []
            }
          ]
        }
      }
    },
    "id": 5590672,
    "userId": 1109,
    "assessmentUuid": "5ac53f13-de43-4726-8bdb-dbeff69054c8",
    "cycleUuid": "66da2217-da42-492f-9ff4-c99a59e6675c"
  }
]

```