### PR TITLE
3507 - Fix mojibake - Unescape country in EN and FR email translations

### DIFF
--- a/src/i18n/resources/en.js
+++ b/src/i18n/resources/en.js
@@ -220,10 +220,10 @@ The FRA team fra@fao.org
     send: 'Send',
     cancel: 'Cancel',
     notificationEmail: {
-      subject: '{{sender}} sent you a message on {{country}}',
+      subject: '{{sender}} sent you a message on {{- country}}',
       textMessage: `Dear {{recipient}},
 
-{{sender}} sent you a message on {{country}}.
+{{sender}} sent you a message on {{- country}}.
 
 Access the platform at the following URL to see and respond:
 {{- link}}
@@ -450,7 +450,7 @@ The FRA team
       subject: 'FRA platform invitation',
       textMessage: `Dear {{invitedUser}},
 
-You have been invited to access {{assessmentName}} {{cycleName}} as {{role}} for {{country}}.
+You have been invited to access {{assessmentName}} {{cycleName}} as {{role}} for {{- country}}.
 
 Accept this invitation and access the platform at the following URL:
 {{- link}}
@@ -886,7 +886,7 @@ The FRA team
 {{- serverUrl}}`,
       htmlMessage: `Dear {{recipientName}},
 <br/><br/>
-{{changer}} changed the status of {{assessment}} to "{{status}}" for {{- country}} on FRA Platform.
+{{changer}} changed the status of {{assessment}} to "{{status}}" for {{country}} on FRA Platform.
 <br/><br/>
 {{message}}
 <br/><br/>

--- a/src/i18n/resources/en/email.js
+++ b/src/i18n/resources/en/email.js
@@ -3,7 +3,7 @@ module.exports = {
     subject: 'User {{invitedUserName}} {{invitedUserSurname}} has accepted your invitation',
     textMessage: `Dear {{recipientName}} {{recipientSurname}},
 
-User {{invitedUserName}} {{invitedUserSurname}} has accepted your invitation to {{assessmentName}} {{cycleName}} as {{role}} for {{country}}:
+User {{invitedUserName}} {{invitedUserSurname}} has accepted your invitation to {{assessmentName}} {{cycleName}} as {{role}} for {{- country}}:
 {{- manageCollaboratorsUrl}}
 
 The FRA team`,
@@ -15,9 +15,9 @@ The FRA team`,
   },
 
   remindReviewer: {
-    subject: 'Reminder: Pending review for {{assessmentName}} {{cycleName}} {{country}}',
+    subject: 'Reminder: Pending review for {{assessmentName}} {{cycleName}} {{- country}}',
     textMessage: `Dear {{recipientName}},
-    The {{assessmentName}} country report of {{country}} has been “In review” since {{lastInReview}}.
+    The {{assessmentName}} country report of {{- country}} has been “In review” since {{lastInReview}}.
     Please provide your comments and send the report back to “Editing”, or proceed with approval if there are no further issues.
 
     {{- countryUrl}}

--- a/src/i18n/resources/fr.js
+++ b/src/i18n/resources/fr.js
@@ -390,7 +390,7 @@ L'équipe de FRA
       subject: 'Invitation à la plateforme de FRA',
       textMessage: `Cher {{invitedUser}},
 
-Vous avez été invité à accéder {{assessmentName}} {{cycleName}} comme {{role}} pour le/la {{country}}.
+Vous avez été invité à accéder {{assessmentName}} {{cycleName}} comme {{role}} pour le/la {{- country}}.
 
 Acceptez cette invitation et accédez à cette plateforme à l'adresse suivante:
 {{- link}}
@@ -824,10 +824,10 @@ L'équipe de FRA fra@fao.org
     fra: 'FRA',
     deskStudy: 'Étude de bureau',
     statusChangeNotification: {
-      subject: 'Le statut de {{country}} a été changé à {{status}} dans la plateforme de FRA',
+      subject: 'Le statut de {{- country}} a été changé à {{status}} dans la plateforme de FRA',
       textMessage: `Cher {{recipientName}},
 
-{{changer}} a changé le statut de {{assessment}} à "{{status}}" pour {{country}} dans la plateforme de FRA.
+{{changer}} a changé le statut de {{assessment}} à "{{status}}" pour {{- country}} dans la plateforme de FRA.
 
 {{message}}
 

--- a/src/i18n/resources/fr/email.js
+++ b/src/i18n/resources/fr/email.js
@@ -3,7 +3,7 @@ module.exports = {
     subject: 'L’utilisateur {{invitedUserName}} {{invitedUserSurname}} a accepté votre invitation',
     textMessage: `Cher/Chère {{recipientName}} {{recipientSurname}},
 
-L’utilisateur {{invitedUserName}} {{invitedUserSurname}} a accepté votre invitation à participer à {{assessmentName}} {{cycleName}} en tant que {{role}} pour le/la {{country}}
+L’utilisateur {{invitedUserName}} {{invitedUserSurname}} a accepté votre invitation à participer à {{assessmentName}} {{cycleName}} en tant que {{role}} pour le/la {{- country}}
 {{- manageCollaboratorsUrl}}
 
 L’équipe FRA`,


### PR DESCRIPTION
Since the single quote is also used in some country names in French, I added the fix for it as well:

<img width="567" alt="image" src="https://github.com/openforis/fra-platform/assets/41337901/325ab596-8bbf-4d30-904d-4205c12c883b">

Fixed:
<img width="567" alt="image" src="https://github.com/openforis/fra-platform/assets/41337901/c428b6a0-f8b9-4242-9fa2-ce1a51a1f463">

Related to #3507 