### PR TITLE
3654 - History: On closing history browser - reset to original state

### DIFF
--- a/src/client/components/Navigation/NavAssessment/History/Items/Item/hooks/useOnClick.ts
+++ b/src/client/components/Navigation/NavAssessment/History/Items/Item/hooks/useOnClick.ts
@@ -1,27 +1,14 @@
 import { useCallback } from 'react'
 
-import { ActivityLogDescription, CommentableDescriptionName, CommentableDescriptionValue } from 'meta/assessment'
 import { Histories } from 'meta/cycleData'
 
 import { useAppDispatch } from 'client/store'
 import { DataActions } from 'client/store/data'
 import { useSectionRouteParams } from 'client/hooks/useRouteParams'
+import { getStatePath } from 'client/components/Navigation/NavAssessment/History/Items/utils/getStatePath'
+import { getTargetValue } from 'client/components/Navigation/NavAssessment/History/Items/utils/getTargetValue'
 
 import { Props } from '../props'
-
-const getTargetValue: {
-  [key in CommentableDescriptionName]?: (activityLog: ActivityLogDescription) => CommentableDescriptionValue
-} = {
-  dataSources: (activityLog: ActivityLogDescription) => {
-    return activityLog.target.description.value
-  },
-}
-
-const statePath: { [key in CommentableDescriptionName]?: (pathParts: Array<string>) => Array<string> } = {
-  dataSources: (pathParts: Array<string>) => {
-    return ['descriptions', ...pathParts, 'dataSources']
-  },
-}
 
 export const useOnClick = (props: Props): (() => void) => {
   const { sectionKey } = props
@@ -29,7 +16,7 @@ export const useOnClick = (props: Props): (() => void) => {
   const { assessmentName, cycleName, countryIso, sectionName } = useSectionRouteParams()
   return useCallback(() => {
     const { name } = Histories.getHistoryItemKeyParts(sectionKey)
-    const path = statePath[name]([assessmentName, cycleName, countryIso, sectionName])
+    const path = getStatePath[name]([assessmentName, cycleName, countryIso, sectionName])
     const value = getTargetValue[name](props.datum)
     dispatch(DataActions.setValue({ path, value }))
   }, [assessmentName, countryIso, cycleName, dispatch, props.datum, sectionKey, sectionName])

--- a/src/client/components/Navigation/NavAssessment/History/Items/Items.tsx
+++ b/src/client/components/Navigation/NavAssessment/History/Items/Items.tsx
@@ -4,6 +4,7 @@ import { HistoryItemSectionKey } from 'meta/cycleData'
 
 import { useData } from '../hooks/useData'
 import { useGetData } from '../hooks/useGetData'
+import { useResetState } from './hooks/useResetState'
 import Item from './Item'
 
 type Props = {
@@ -13,6 +14,8 @@ const Items: React.FC<Props> = (props: Props) => {
   const { sectionKey } = props
   useGetData(sectionKey)
   const data = useData(sectionKey)
+
+  useResetState(sectionKey)
 
   return (
     <div className="nav-section__items-visible">

--- a/src/client/components/Navigation/NavAssessment/History/Items/hooks/useResetState.ts
+++ b/src/client/components/Navigation/NavAssessment/History/Items/hooks/useResetState.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+
+import { Histories, HistoryItemSectionKey } from 'meta/cycleData'
+
+import { useAppDispatch } from 'client/store'
+import { DataActions } from 'client/store/data'
+import { useSectionRouteParams } from 'client/hooks/useRouteParams'
+import { useData } from 'client/components/Navigation/NavAssessment/History/hooks/useData'
+import { getStatePath } from 'client/components/Navigation/NavAssessment/History/Items/utils/getStatePath'
+import { getTargetValue } from 'client/components/Navigation/NavAssessment/History/Items/utils/getTargetValue'
+
+// Reset the state to its original state
+
+export const useResetState = (sectionKey: HistoryItemSectionKey): void => {
+  const { assessmentName, cycleName, countryIso, sectionName } = useSectionRouteParams()
+  const dispatch = useAppDispatch()
+  const data = useData(sectionKey)
+
+  useEffect(() => {
+    return () => {
+      if (data) {
+        const { name } = Histories.getHistoryItemKeyParts(sectionKey)
+        const value = getTargetValue[name](data?.at(0))
+        const path = getStatePath[name]([assessmentName, cycleName, countryIso, sectionName])
+        dispatch(DataActions.setValue({ value, path }))
+      }
+    }
+  }, [assessmentName, countryIso, cycleName, data, dispatch, sectionKey, sectionName])
+}

--- a/src/client/components/Navigation/NavAssessment/History/Items/utils/getStatePath.ts
+++ b/src/client/components/Navigation/NavAssessment/History/Items/utils/getStatePath.ts
@@ -1,0 +1,9 @@
+import { CommentableDescriptionName } from 'meta/assessment'
+
+// Utility functions to get the path to the state that needs to be updated
+
+export const getStatePath: { [key in CommentableDescriptionName]?: (pathParts: Array<string>) => Array<string> } = {
+  dataSources: (pathParts: Array<string>) => {
+    return ['descriptions', ...pathParts, 'dataSources']
+  },
+}

--- a/src/client/components/Navigation/NavAssessment/History/Items/utils/getTargetValue.ts
+++ b/src/client/components/Navigation/NavAssessment/History/Items/utils/getTargetValue.ts
@@ -1,0 +1,9 @@
+import { ActivityLogDescription, CommentableDescriptionName, CommentableDescriptionValue } from 'meta/assessment'
+
+export const getTargetValue: {
+  [key in CommentableDescriptionName]?: (activityLog: ActivityLogDescription) => CommentableDescriptionValue
+} = {
+  dataSources: (activityLog: ActivityLogDescription) => {
+    return activityLog?.target.description.value
+  },
+}


### PR DESCRIPTION
Todo:
- Investigate a better way to implement this.
- Investigate if we can always expect the data head to be the latest state? Probably not in case we have manipulated data with eg. migrations? @minotogna 

https://github.com/openforis/fra-platform/assets/5508251/ff695b33-b21e-4075-be7a-1ae645c2a6a9



