### PR TITLE
Hotfix: Fix user countries for reminder email

### DIFF
--- a/src/server/service/mail/remindReviewers.ts
+++ b/src/server/service/mail/remindReviewers.ts
@@ -120,8 +120,8 @@ const getReviewerRecipients = async (props: {
                 assessments: [],
               }
             }
-
-            assessmentsByReviewer[user.email].assessments.push({ assessment, cycle, countries: inReview })
+            const userCountries = inReview.filter((country) => Users.isReviewer(user, country.countryIso, cycle))
+            assessmentsByReviewer[user.email].assessments.push({ assessment, cycle, countries: userCountries })
           })
         })
       )


### PR DESCRIPTION
Fix issue where users were accidentally assigned all countries which were in review, even though the user wouldn't be a reviewer for this country.

Fix: Filter user countries: check that the user has reviewer role for given country