### PR TITLE
3713 - (Urgent) Fix editor not saving when pasting from Word/Excel

### DIFF
--- a/src/client/components/EditorWYSIWYG/hooks/useOnBlur.ts
+++ b/src/client/components/EditorWYSIWYG/hooks/useOnBlur.ts
@@ -42,13 +42,13 @@ export const useOnBlur = (props: Props): OnChange => {
   useEffect(() => {
     if (Objects.isEmpty(jodit)) return () => undefined
 
-    const onProcessHTML = () => {
+    const onBeforeOpenPasteDialog = () => {
       pastedHtmlRef.current = true
     }
-    jodit.events?.on('processHTML', onProcessHTML)
+    jodit.events?.on('beforeOpenPasteDialog', onBeforeOpenPasteDialog)
 
     return () => {
-      jodit.events?.off('processHTML', onProcessHTML)
+      jodit.events?.off('beforeOpenPasteDialog', onBeforeOpenPasteDialog)
     }
   }, [jodit])
 


### PR DESCRIPTION
Root cause:
Normally, when pasting HTML,  the `onProcessHTML` event is fired ***before*** `onBlur` by the library. That correctly manages the `pastedHtmlRef` flag we use to decide whether or not we save. However, when the pasted text is detected to be from Word or Excel, the `onProcessHTML` event is fired ***after*** `onBlur`. That causes the `pastedHtmlRef` to be set to true, preventing the value from being saved. 

Fix: Managing the `pastedHtmlRef` flag with the event `beforeOpenPasteDialog` that I just found in the editor source code. This event is triggered the same by the library regardless if the text is normal HTML or from Word/Excel. 

https://github.com/openforis/fra-platform/assets/41337901/186a8826-709f-492a-b93c-854331e018d9

