### PR TITLE
Fix public files access rights

### DIFF
--- a/src/test/migrations/steps/20240418115156-step-fix-public-props-repository-items.ts
+++ b/src/test/migrations/steps/20240418115156-step-fix-public-props-repository-items.ts
@@ -1,0 +1,22 @@
+import { Promises } from 'utils/promises'
+
+import { AssessmentController } from 'server/controller/assessment'
+import { BaseProtocol, Schemas } from 'server/db'
+
+export default async (client: BaseProtocol) => {
+  const assessments = await AssessmentController.getAll({}, client)
+  await Promises.each(assessments, async (assessment) => {
+    await Promises.each(assessment.cycles, async (cycle) => {
+      const schemaName = Schemas.getNameCycle(assessment, cycle)
+      const q = `
+          update ${schemaName}.repository
+          set props = props || '{"public": true}'::jsonb
+          where uuid in
+              (select regexp_replace(value ->> 'text', '.*file/(.*?)\\?.*', '\\1')::uuid
+              from ${schemaName}.descriptions where value ->> 'text' ilike '%cycle-data/repository/file%')
+      `
+
+      await client.query(q)
+    })
+  })
+}


### PR DESCRIPTION
Issue was not in authorizer as suspected, but in the migrations:
The old repository items did not have prop `public.true`

![image](https://github.com/openforis/fra-platform/assets/5508251/6d3ad038-93fb-417f-82a2-c3eccbbff296)
