### PR TITLE
3645 - Dashboard: Check sections exist to avoid crash

### DIFF
--- a/src/client/pages/CountryHome/Overview/Overview.tsx
+++ b/src/client/pages/CountryHome/Overview/Overview.tsx
@@ -1,10 +1,14 @@
 import React from 'react'
 
+import { useSections } from 'client/store/metadata'
 import Dashboard from 'client/components/Dashboard'
 import { useItems } from 'client/pages/CountryHome/Overview/hooks'
 
 const Overview: React.FC = () => {
   const items = useItems()
+
+  const sections = useSections()
+  if (!sections) return null
 
   return <Dashboard items={items} />
 }

--- a/src/client/pages/CountryHome/Overview/meta/forestArea/index.ts
+++ b/src/client/pages/CountryHome/Overview/meta/forestArea/index.ts
@@ -14,7 +14,7 @@ const cols: Record<string, Array<string>> = {
 }
 
 const tableName = 'extentOfForest'
-const tableId = 2
+const tableId = 1
 
 const rowMetadata: RowsMetadata = [
   {

--- a/src/client/pages/CountryHome/Overview/meta/forestAreaPercentOfLandArea/index.ts
+++ b/src/client/pages/CountryHome/Overview/meta/forestAreaPercentOfLandArea/index.ts
@@ -12,7 +12,7 @@ const cols: Record<string, Array<string>> = {
 }
 
 const tableName = 'extentOfForest'
-const tableId = 2
+const tableId = 3
 
 const rowMetadata: RowsMetadata = [
   {

--- a/src/client/pages/CountryHome/Overview/meta/forestGrowingStockAndCarbon/index.ts
+++ b/src/client/pages/CountryHome/Overview/meta/forestGrowingStockAndCarbon/index.ts
@@ -10,7 +10,7 @@ const cols: Record<string, Array<string>> = {
 }
 
 const tableName = 'forestGrowingStockAndCarbonDashboard'
-const tableId = 1
+const tableId = 2
 
 const rowMetadata: Record<string, RowsMetadata> = {
   '2020': [

--- a/src/client/pages/CountryHome/Overview/meta/primaryDesignatedManagementObjective/index.ts
+++ b/src/client/pages/CountryHome/Overview/meta/primaryDesignatedManagementObjective/index.ts
@@ -19,7 +19,7 @@ const variables = [
 ]
 
 const tableName = 'primaryDesignatedManagementObjective'
-const tableId = 2
+const tableId = 7
 
 const rowMetadata: RowsMetadata = variables.map((variableName, i) => ({
   id: i + 1,

--- a/src/client/pages/CountryHome/Overview/meta/utils/index.ts
+++ b/src/client/pages/CountryHome/Overview/meta/utils/index.ts
@@ -39,6 +39,7 @@ const getHeaderRow = (cycle: Cycle, cols: Array<string>, tableId: number): Row =
           index: 0,
           style: getStyle(cycle),
         },
+        uuid: UUIDs.v4(),
       },
       ...cols.map((colName, index) => {
         return {
@@ -50,6 +51,7 @@ const getHeaderRow = (cycle: Cycle, cols: Array<string>, tableId: number): Row =
             colType: ColType.header,
             style: getStyle(cycle),
           },
+          uuid: UUIDs.v4(),
         }
       }),
     ],

--- a/src/client/pages/Section/DataTable/Table/TableHead/TableHead.tsx
+++ b/src/client/pages/Section/DataTable/Table/TableHead/TableHead.tsx
@@ -35,7 +35,7 @@ const TableHead: React.FC<Props> = (props) => {
   return (
     <thead>
       {rowsHeader.map((row: TypeRow, rowIndex: number) => (
-        <tr id={`${row.props.type}_${String(row.id)}`} key={row.uuid}>
+        <tr key={row.uuid} id={`${row.props.type}_${String(row.id)}`}>
           {row.cols.map((col: TypeCol, colIndex: number) => {
             const { index } = col.props
 
@@ -63,9 +63,9 @@ const TableHead: React.FC<Props> = (props) => {
                 key={col.uuid}
                 className={className}
                 colSpan={colSpan}
-                rowSpan={rowSpan}
                 odpId={odpHeader.id}
                 odpYear={odpHeader.year}
+                rowSpan={rowSpan}
                 sectionName={table.props.name}
               />
             ) : (


### PR DESCRIPTION
- Check sections exist to avoid crashing the application in Overview tab (used by table component)
- Add missing uuids to avoid react `key` error in console
- Add table ids to correspond order in dashboard