### PR TITLE
3807 - Fix invalid links tooltip not showing

### DIFF
--- a/src/client/components/DataGrid/DataCell/DataCell.tsx
+++ b/src/client/components/DataGrid/DataCell/DataCell.tsx
@@ -33,7 +33,7 @@ const DataCell: React.FC<Props> = (props) => {
         className
       )}
       data-tooltip-content={dataTooltipContent}
-      data-tooltip-id={dataTooltipId}
+      data-tooltip-id={dataTooltipContent ? dataTooltipId : null}
       style={{ gridColumn, gridRow }}
     >
       {React.Children.toArray(children)}


### PR DESCRIPTION
The root cause is that the DataCell component has its own tooltip data. Since it is higher in the DOM tree, its tooltip takes precedent over the editor tooltip.

![image](https://github.com/openforis/fra-platform/assets/41337901/3492c6f9-dba5-4af1-bc32-931e0458b123)

And since the DataCell tooltip content is empty, nothing is shown. 

Current Fix:
Setting the tooltip id in the DataCell only if it has content, that way it won't take precedent over the children tooltips if it is empty. 

Other possible fix: 
From the DataCell caller, passing data-tooltip-id only when the content is not empty. In DataSourceRow it would be something like:

```
    <DataRow actions={actions}>
      {componentsOrder.map((componentKey) => {
        const Component = Components[componentKey]
        return (
          <DataCell
            key={`${componentKey}-${dataSource.uuid}`}
            className={classNames({ 'validation-error': errors[componentKey] })}
            data-tooltip-content={errors[componentKey]}
        ->  data-tooltip-id={errors[componentKey] ? TooltipId.error : null}
            ...
```


https://github.com/openforis/fra-platform/assets/41337901/fb712927-428e-4553-bb6f-4f1f17a41079


