### PR TITLE
3743 - Broken Links - Add sockets events and Get verification job status

### DIFF
--- a/src/meta/api/endpoint/ApiEndPoint.ts
+++ b/src/meta/api/endpoint/ApiEndPoint.ts
@@ -59,6 +59,7 @@ export const ApiEndPoint = {
       many: () => apiPath('cycle-data', 'links'),
       one: () => apiPath('cycle-data', 'links', 'link'),
       verify: () => apiPath('cycle-data', 'links', 'verify'),
+      verifyStatus: () => apiPath('cycle-data', 'links', 'verify', 'status'),
     },
 
     OriginalDataPoint: {

--- a/src/meta/socket/sockets.ts
+++ b/src/meta/socket/sockets.ts
@@ -64,6 +64,11 @@ const getNodeValuesUpdateEvent = (props: {
   return `${countryIso}-${assessmentName}-${cycleName}-nodeUpdates`
 }
 
+const getLinksVerificationEvent = (props: { assessmentName: AssessmentName; cycleName: string }) => {
+  const { assessmentName, cycleName } = props
+  return `${assessmentName}-${cycleName}-linksVerification`
+}
+
 export const Sockets = {
   getNodeValidationsUpdateEvent,
   getNodeValuesUpdateEvent,
@@ -74,4 +79,5 @@ export const Sockets = {
   getTopicMessageAddEvent,
   getTopicMessageDeleteEvent,
   getTopicStatusEvent,
+  getLinksVerificationEvent,
 }

--- a/src/server/api/cycleData/index.ts
+++ b/src/server/api/cycleData/index.ts
@@ -20,6 +20,7 @@ import { removeDataSource } from './descriptions/removeDataSource'
 import { upsertDescription } from './descriptions/upsertDescription'
 import { getLinksCount } from './links/getLinksCount'
 import { getManyLinks } from './links/getManyLinks'
+import { isVerificationInProgress } from './links/isVerificationInProgress'
 import { updateLink } from './links/updateLink'
 import { verifyLinks } from './links/verifyLinks'
 import { copyOriginalDataPointNationalClasses } from './originalDataPoint/copyOriginalDataPointNationalClasses'
@@ -191,5 +192,6 @@ export const CycleDataApi = {
     express.get(ApiEndPoint.CycleData.Links.many(), AuthMiddleware.requireAdmin, getManyLinks)
     express.get(ApiEndPoint.CycleData.Links.count(), AuthMiddleware.requireAdmin, getLinksCount)
     express.post(ApiEndPoint.CycleData.Links.verify(), AuthMiddleware.requireAdmin, verifyLinks)
+    express.get(ApiEndPoint.CycleData.Links.verifyStatus(), AuthMiddleware.requireAdmin, isVerificationInProgress)
   },
 }

--- a/src/server/api/cycleData/links/isVerificationInProgress.ts
+++ b/src/server/api/cycleData/links/isVerificationInProgress.ts
@@ -1,0 +1,24 @@
+import { Response } from 'express'
+
+import { CycleRequest } from 'meta/api/request'
+
+import { AssessmentController } from 'server/controller/assessment'
+import { CycleDataController } from 'server/controller/cycleData'
+import Requests from 'server/utils/requests'
+
+type Request = CycleRequest
+
+export const isVerificationInProgress = async (req: Request, res: Response) => {
+  try {
+    const { assessmentName, cycleName } = req.query
+
+    const { assessment, cycle } = await AssessmentController.getOneWithCycle({ assessmentName, cycleName })
+
+    const activeJobs = await CycleDataController.Links.getActiveVerifyJobs({ assessment, cycle })
+    const isVerificationInProgress = activeJobs.length > 0
+
+    Requests.send(res, isVerificationInProgress)
+  } catch (e) {
+    Requests.sendErr(res, e)
+  }
+}

--- a/src/server/controller/cycleData/links/getActiveVerifyJobs.ts
+++ b/src/server/controller/cycleData/links/getActiveVerifyJobs.ts
@@ -1,0 +1,15 @@
+import { Job } from 'bullmq'
+
+import { Assessment, Cycle } from 'meta/assessment'
+
+import { VisitCycleLinksQueueFactory } from './visitCycleLinks/queueFactory'
+import { VisitCycleLinksProps } from './visitCycleLinks'
+
+type Props = {
+  assessment: Assessment
+  cycle: Cycle
+}
+
+export const getActiveVerifyJobs = async (props: Props): Promise<Array<Job<VisitCycleLinksProps>>> => {
+  return VisitCycleLinksQueueFactory.getActiveJobs(props)
+}

--- a/src/server/controller/cycleData/links/index.ts
+++ b/src/server/controller/cycleData/links/index.ts
@@ -2,9 +2,10 @@ import { LinkRepository } from 'server/repository/assessmentCycle/links'
 
 import { getAllLinksToVisit } from './getAllLinksToVisit'
 import { update } from './update'
-import { visitCycleLinks } from './visitCycleLinks'
+import { visitCycleLinks, VisitCycleLinksQueueFactory } from './visitCycleLinks'
 
 export const Links = {
+  getActiveVerifyJobs: VisitCycleLinksQueueFactory.getActiveJobs,
   getAllLinksToVisit,
   getCount: LinkRepository.getCount,
   getMany: LinkRepository.getMany,

--- a/src/server/controller/cycleData/links/index.ts
+++ b/src/server/controller/cycleData/links/index.ts
@@ -1,11 +1,12 @@
 import { LinkRepository } from 'server/repository/assessmentCycle/links'
 
+import { getActiveVerifyJobs } from './getActiveVerifyJobs'
 import { getAllLinksToVisit } from './getAllLinksToVisit'
 import { update } from './update'
-import { visitCycleLinks, VisitCycleLinksQueueFactory } from './visitCycleLinks'
+import { visitCycleLinks } from './visitCycleLinks'
 
 export const Links = {
-  getActiveVerifyJobs: VisitCycleLinksQueueFactory.getActiveJobs,
+  getActiveVerifyJobs,
   getAllLinksToVisit,
   getCount: LinkRepository.getCount,
   getMany: LinkRepository.getMany,

--- a/src/server/controller/cycleData/links/visitCycleLinks/index.ts
+++ b/src/server/controller/cycleData/links/visitCycleLinks/index.ts
@@ -1,3 +1,2 @@
 export type { VisitCycleLinksJob, VisitCycleLinksProps } from './props'
-export { VisitCycleLinksQueueFactory } from './queueFactory'
 export { visitCycleLinks } from './visitCycleLinks'

--- a/src/server/controller/cycleData/links/visitCycleLinks/queueFactory.ts
+++ b/src/server/controller/cycleData/links/visitCycleLinks/queueFactory.ts
@@ -1,4 +1,4 @@
-import { Queue, QueueOptions, Worker } from 'bullmq'
+import { Job, Queue, QueueOptions, Worker } from 'bullmq'
 import IORedis from 'ioredis'
 
 import { Assessment, Cycle } from 'meta/assessment'
@@ -40,6 +40,12 @@ const getInstance = (props: Props): Queue<VisitCycleLinksProps> => {
   return queue
 }
 
+const getActiveJobs = async (props: Props): Promise<Array<Job<VisitCycleLinksProps>>> => {
+  const queue = getInstance(props)
+  const activeJobs: Array<Job<VisitCycleLinksProps>> = await queue.getActive()
+  return activeJobs
+}
+
 process.on('SIGTERM', async () => {
   await Promise.all(Object.values(workers).map((worker) => worker.close()))
   Logger.debug('[visitCycleLinks] all workers closed')
@@ -47,5 +53,6 @@ process.on('SIGTERM', async () => {
 
 export const VisitCycleLinksQueueFactory = {
   connection,
+  getActiveJobs,
   getInstance,
 }


### PR DESCRIPTION
Adding sockets events and adding an endpoint to get the verification job status.
The idea is to get the verify job status when the UI page loads to potentially disable the verify button, and then listen to socket events. 