### PR TITLE
3910 - Fix memory issues in broken links worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
     "express-validator": "^6.14.2",
     "extract-zip": "^2.0.1",
     "fast-csv": "^4.3.6",
+    "htmlparser2": "^9.1.0",
     "http-proxy-middleware": "^2.0.4",
     "i18next": "^21.6.14",
     "ioredis": "^5.2.4",

--- a/src/client/pages/Admin/Admin.tsx
+++ b/src/client/pages/Admin/Admin.tsx
@@ -30,10 +30,10 @@ const sections: Array<Section> = [
     name: SectionNames.Admin.userManagement,
     labelKey: 'landing.sections.userManagement',
   },
-  // {
-  //   name: SectionNames.Admin.links,
-  //   labelKey: 'landing.links.links',
-  // },
+  {
+    name: SectionNames.Admin.links,
+    labelKey: 'landing.links.links',
+  },
   // { name: 'dataExport', labelKey: 'common.dataExport' },
 ]
 

--- a/src/server/controller/cycleData/links/utils/getLinksFromHtml.ts
+++ b/src/server/controller/cycleData/links/utils/getLinksFromHtml.ts
@@ -1,4 +1,4 @@
-import { JSDOM } from 'jsdom'
+import { Parser } from 'htmlparser2'
 import { Objects } from 'utils/objects'
 
 type LinkInfo = {
@@ -11,20 +11,36 @@ type Returned = Array<LinkInfo>
 export const getLinksFromHtml = (html: string): Returned => {
   if (Objects.isEmpty(html)) return []
 
-  const dom = new JSDOM(html)
-  const doc = dom.window.document
-  const anchorTags = doc.querySelectorAll('a')
-
   const links: Returned = []
-  for (let i = 0; i < anchorTags.length; i += 1) {
-    const anchor = anchorTags[i]
-    const link = anchor.getAttribute('href')
-    const name = anchor.textContent
-    links.push({
-      link,
-      name,
-    })
-  }
+
+  let currentLink: LinkInfo | null = null
+  const parser = new Parser(
+    {
+      onopentag(name, attributes) {
+        if (name === 'a') {
+          currentLink = {
+            link: attributes.href ?? null,
+            name: '',
+          }
+        }
+      },
+      ontext(text) {
+        if (currentLink) {
+          currentLink.name += text
+        }
+      },
+      onclosetag(tagname) {
+        if (tagname === 'a' && currentLink) {
+          links.push(currentLink)
+          currentLink = null
+        }
+      },
+    },
+    { decodeEntities: true }
+  )
+
+  parser.write(html)
+  parser.end()
 
   return links
 }

--- a/src/server/repository/assessmentCycle/links/getMany.ts
+++ b/src/server/repository/assessmentCycle/links/getMany.ts
@@ -25,7 +25,7 @@ const _getOrderClause = (
 
   const direction = orderByDirection ?? TablePaginatedOrderByDirection.asc
   if (orderBy === 'code') {
-    return `order by (visits -> jsonb_array_length(visits) - 1 ->> 'code') ${direction}`
+    return `order by (visits -> jsonb_array_length(visits) - 1 ->> 'code') ${direction}, id asc`
   }
   return `order by ${orderBy} ${direction}`
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5575,7 +5575,16 @@ dom-serializer@^1.0.1:
     domhandler "^4.2.0"
     entities "^2.0.0"
 
-domelementtype@^2.0.1, domelementtype@^2.2.0:
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.0.1, domelementtype@^2.2.0, domelementtype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
@@ -5593,6 +5602,13 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
   dependencies:
     domelementtype "^2.2.0"
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
 
 domino@^2.1.6:
   version "2.1.6"
@@ -5612,6 +5628,15 @@ domutils@^2.5.2, domutils@^2.8.0:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
+
+domutils@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -5800,7 +5825,7 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
-entities@^4.4.0:
+entities@^4.2.0, entities@^4.4.0, entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
@@ -7520,6 +7545,16 @@ htmlparser2@^6.1.0:
     domhandler "^4.0.0"
     domutils "^2.5.2"
     entities "^2.0.0"
+
+htmlparser2@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-9.1.0.tgz#cdb498d8a75a51f739b61d3f718136c369bc8c23"
+  integrity sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.1.0"
+    entities "^4.5.0"
 
 http-deceiver@^1.2.7:
   version "1.2.7"


### PR DESCRIPTION
I tracked down the spikes in memory usage in the Visit Cycle Links Job, and it turned out to be in the function `links/getAllLinksToVisit -> _processLinks -> getLinksFromHtml`

`getLinksFromHtml` uses the JSDOM library to parse the html text and get the links from the `a` tags: 
`const dom = new JSDOM(html) ....`.
It seems the memory is not freed after that function is done running due to how the internals of JSDOM work, causing the heap to grow until after all links in all locations are processed. 

I tried manually deleting the references to the JSDOM instance, but it didn't help:
```
dom.window.close();
document = null;
dom = null;
```
More on the issue: https://github.com/jsdom/jsdom/issues/1682

Solution: using `htmlparser2` instead, which is a module we already have (it is a dependency of a library we are using).

Memory usage before (peak: 1856 MB): 
![Pasted Graphic 7](https://github.com/user-attachments/assets/c8bd4bd9-dabf-47e8-babc-7ee9ed60d114)
 
 Memory usage after (peak: 140 MB): 
 
![Pasted Graphic 6](https://github.com/user-attachments/assets/059ddcc9-ab3a-4d6d-ad5c-5127cfbafe1a)
