### PR TITLE
2480 - Introduce migrations schema

### DIFF
--- a/src/server/repository/public/ddl/getCreatePublicSchemaDDL.ts
+++ b/src/server/repository/public/ddl/getCreatePublicSchemaDDL.ts
@@ -91,19 +91,6 @@ export const getCreatePublicSchemaDDL = (schemaName = 'public'): string => {
     create index if not exists idx_activity_log_cycle_message on ${schemaName}.activity_log using btree (cycle_uuid, message);
     create index if not exists idx_activity_log_filtering on ${schemaName}.activity_log using btree (assessment_uuid, cycle_uuid, country_iso, message, time);
 
-    create table if not exists ${schemaName}.migration_steps (
-      id serial primary key,
-      name character varying(255) not null unique,
-      run_on timestamp without time zone not null default now()
-    );
-
-    -- This table is created separately, but left here for consistency
-    create table if not exists ${schemaName}.migrations (
-      id serial primary key,
-      name character varying(255) not null,
-      run_on timestamp without time zone not null default now()
-    );
-
     create table if not exists ${schemaName}.region (
       region_code text primary key not null,
       name text

--- a/src/test/migrations/index.ts
+++ b/src/test/migrations/index.ts
@@ -17,8 +17,27 @@ let migrationSteps: Array<string>
 let previousMigrations: Array<string> = []
 const executedMigrations: Array<string> = []
 
+const tableDDL = `
+    create schema if not exists migrations;
+
+    do $$ 
+    begin
+      if exists (select 1 from information_schema.tables where table_schema = 'public' and table_name = 'migration_steps') then
+        alter table public.migration_steps rename to steps;
+        alter table public.steps set schema migrations;
+      else
+        create table if not exists migrations.steps (
+          id serial primary key,
+          name character varying(255) unique not null,
+          run_on timestamp without time zone not null default now()
+        );
+      end if;
+    end $$;
+`
+
 const init = async () => {
-  previousMigrations = await client.map('select * from migration_steps', [], (row) => row.name)
+  await client.query(tableDDL)
+  previousMigrations = await client.map('select * from migrations.steps', [], (row) => row.name)
   migrationSteps = fs
     .readdirSync(path.join(__dirname, `steps`))
     .filter((file) => file !== 'template.ts' && file.endsWith('.ts') && !previousMigrations.includes(file))
@@ -55,7 +74,7 @@ const exec = async () => {
     // eslint-disable-next-line no-restricted-syntax
     for (const file of executedMigrations) {
       // eslint-disable-next-line no-await-in-loop
-      await client.query('insert into migration_steps (name) values ($1)', [file])
+      await client.query('insert into migrations.steps (name) values ($1)', [file])
     }
   }
 

--- a/src/test/migrations/steps/20240909101347-step-exclude-public-migrations.ts
+++ b/src/test/migrations/steps/20240909101347-step-exclude-public-migrations.ts
@@ -1,4 +1,5 @@
 import * as pgPromise from 'pg-promise'
+import { tableMigrationsPublicDDL } from 'tools/migrations/public/tableMigrationsPublicDDL'
 
 import { BaseProtocol, DB } from 'server/db'
 
@@ -15,19 +16,15 @@ export default async () => {
   const pgp = pgPromise()
   // DROP CONTENT
   await client.query(`
-    truncate table public.migrations;
+    drop table if exists public.migrations;
   `)
 
-  // UPDATE DDL
-  await client.query(`
-    alter table migrations
-    alter column run_on set default now(),
-    alter column run_on type timestamp without time zone
-  `)
+  // INIT TABLE
+  await client.query(tableMigrationsPublicDDL)
 
   // INSERT
   const cs = new pgp.helpers.ColumnSet(['name'], {
-    table: { table: 'migrations', schema: 'public' },
+    table: { table: 'public', schema: 'migrations' },
   })
 
   const query = `${pgp.helpers.insert(values, cs)}`

--- a/src/tools/migrations/public/index.ts
+++ b/src/tools/migrations/public/index.ts
@@ -3,6 +3,7 @@ import 'dotenv/config'
 
 import * as fs from 'fs'
 import * as path from 'path'
+import { tableMigrationsPublicDDL } from 'tools/migrations/public/tableMigrationsPublicDDL'
 import { Promises } from 'utils/promises'
 
 import { DB } from 'server/db'
@@ -13,18 +14,8 @@ let migrationSteps: Array<string>
 let previousMigrations: Array<string> = []
 const executedMigrations: Array<string> = []
 
-const tableDDL = `
-    create schema if not exists migrations;
-
-    create table if not exists migrations.public (
-      id serial primary key,
-      name character varying(255) unique not null,
-      run_on timestamp without time zone not null default now()
-    );
-`
-
 const init = async () => {
-  await client.query(tableDDL)
+  await client.query(tableMigrationsPublicDDL)
   previousMigrations = await client.map('select * from migrations.public', [], (row) => row.name)
   migrationSteps = fs
     .readdirSync(path.join(__dirname, `steps`))

--- a/src/tools/migrations/public/tableMigrationsPublicDDL.ts
+++ b/src/tools/migrations/public/tableMigrationsPublicDDL.ts
@@ -1,0 +1,9 @@
+export const tableMigrationsPublicDDL = `
+    create schema if not exists migrations;
+
+    create table if not exists migrations.public (
+      id serial primary key,
+      name character varying(255) unique not null,
+      run_on timestamp without time zone not null default now()
+    );
+`


### PR DESCRIPTION
Flow:

Running migration-steps:
- drop `public.migrations`
- init `migrations.public` table
- populate `migrations.public` with given rows (we dont want to run)

Running migration-public (after steps) (local instance)
- no migrations are ran as expected

Running migration-public (clean/new instance)
- public is initialized as expected

![image](https://github.com/user-attachments/assets/42eaa24a-1d13-43a8-9a15-e78b820c09eb)
