### PR TITLE
3955 - Dashboard: Global data not updated on filter

### DIFF
--- a/src/client/components/Dashboard/hooks/useGetTableData.ts
+++ b/src/client/components/Dashboard/hooks/useGetTableData.ts
@@ -1,9 +1,10 @@
-import { useEffect } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
 import { CountryIso } from 'meta/area'
 
 import { useAppDispatch } from 'client/store'
 import { DataActions } from 'client/store/data'
+import { useHomeCountriesFilter } from 'client/store/ui/home'
 import { useCountryRouteParams } from 'client/hooks/useRouteParams'
 import { Props } from 'client/components/Dashboard/props'
 
@@ -13,11 +14,21 @@ export const useGetTableData = (props: Props): void => {
   const dispatch = useAppDispatch()
   const { assessmentName, cycleName, countryIso } = useCountryRouteParams<CountryIso>()
   const dependencies = useDependencies(props)
+  const homeCountriesFilter = useHomeCountriesFilter()
 
-  useEffect(() => {
+  const countryISOs = useMemo(
+    () => (homeCountriesFilter.length > 0 ? homeCountriesFilter : [countryIso]),
+    [homeCountriesFilter, countryIso]
+  )
+
+  const fetchTableData = useCallback(() => {
     if (dependencies.size > 0) {
       const propsFetch = { assessmentName, cycleName, countryIso, mergeOdp: true }
-      dispatch(DataActions.getTableData({ ...propsFetch, tableNames: Array.from(dependencies) }))
+      dispatch(DataActions.getTableData({ ...propsFetch, countryISOs, tableNames: Array.from(dependencies) }))
     }
-  }, [assessmentName, countryIso, cycleName, dependencies, dispatch])
+  }, [assessmentName, cycleName, countryIso, dependencies, dispatch, countryISOs])
+
+  useEffect(() => {
+    fetchTableData()
+  }, [fetchTableData])
 }

--- a/src/client/store/data/actions/getTableData.ts
+++ b/src/client/store/data/actions/getTableData.ts
@@ -3,6 +3,7 @@ import axios from 'axios'
 
 import { ApiEndPoint } from 'meta/api/endpoint'
 import { CycleParams } from 'meta/api/request'
+import { CountryIso } from 'meta/area'
 import { AssessmentName, CycleName } from 'meta/assessment'
 import { RecordAssessmentData } from 'meta/data'
 
@@ -10,13 +11,22 @@ type Props = CycleParams & {
   auth?: { assessmentName: AssessmentName; cycleName: CycleName }
   mergeOdp?: boolean
   tableNames: Array<string>
+  countryISOs?: Array<CountryIso>
 }
 
 export const getTableData = createAsyncThunk<RecordAssessmentData, Props>('data/tableData/get', async (props) => {
-  const { auth, countryIso, assessmentName, cycleName, tableNames, mergeOdp = false } = props
+  const { assessmentName, auth, countryIso, countryISOs, cycleName, mergeOdp = false, tableNames } = props
 
   const authContext = auth ? encodeURIComponent(JSON.stringify(auth)) : undefined
-  const params = { assessmentName, countryIso, cycleName, tableNames, countryISOs: [countryIso], mergeOdp, authContext }
+  const params = {
+    assessmentName,
+    countryIso,
+    cycleName,
+    tableNames,
+    countryISOs: countryISOs ?? [countryIso],
+    mergeOdp,
+    authContext,
+  }
   const { data } = await axios.get(ApiEndPoint.CycleData.Table.tableData(), { params })
 
   return data

--- a/src/client/store/ui/home/hooks.ts
+++ b/src/client/store/ui/home/hooks.ts
@@ -1,4 +1,0 @@
-import { RootState, useAppSelector } from 'client/store'
-
-export const useHomeCountriesFilter = (): Array<string> =>
-  useAppSelector((state: RootState) => state?.ui?.home?.countriesFilter ?? [])

--- a/src/client/store/ui/home/hooks/index.ts
+++ b/src/client/store/ui/home/hooks/index.ts
@@ -1,0 +1,5 @@
+import { useAppSelector } from 'client/store'
+
+import { selectHomeCountriesFilter } from '../selectors'
+
+export const useHomeCountriesFilter = () => useAppSelector(selectHomeCountriesFilter)

--- a/src/client/store/ui/home/hooks/index.ts
+++ b/src/client/store/ui/home/hooks/index.ts
@@ -1,5 +1,5 @@
 import { useAppSelector } from 'client/store'
 
-import { selectHomeCountriesFilter } from '../selectors'
+import { HomeSelector } from '../selectors'
 
-export const useHomeCountriesFilter = () => useAppSelector(selectHomeCountriesFilter)
+export const useHomeCountriesFilter = () => useAppSelector(HomeSelector.getCountriesFilter)

--- a/src/client/store/ui/home/selectors/index.ts
+++ b/src/client/store/ui/home/selectors/index.ts
@@ -6,7 +6,11 @@ import { RootState } from 'client/store'
 
 const _getState = (state: RootState) => state.ui.home
 
-export const selectHomeCountriesFilter = createSelector(
+export const getCountriesFilter = createSelector(
   [_getState],
   (homeState): Array<CountryIso> => homeState?.countriesFilter ?? []
 )
+
+export const HomeSelector = {
+  getCountriesFilter,
+}

--- a/src/client/store/ui/home/selectors/index.ts
+++ b/src/client/store/ui/home/selectors/index.ts
@@ -1,0 +1,12 @@
+import { createSelector } from '@reduxjs/toolkit'
+
+import { CountryIso } from 'meta/area'
+
+import { RootState } from 'client/store'
+
+const _getState = (state: RootState) => state.ui.home
+
+export const selectHomeCountriesFilter = createSelector(
+  [_getState],
+  (homeState): Array<CountryIso> => homeState?.countriesFilter ?? []
+)

--- a/src/client/store/ui/home/stateType.ts
+++ b/src/client/store/ui/home/stateType.ts
@@ -1,3 +1,5 @@
+import { CountryIso } from 'meta/area'
+
 export interface HomeState {
-  countriesFilter?: Array<string>
+  countriesFilter?: Array<CountryIso>
 }

--- a/src/server/api/cycleData/table/getTableData.ts
+++ b/src/server/api/cycleData/table/getTableData.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express'
 
 import { CycleDataRequest } from 'meta/api/request'
-import { AreaCode, Areas, CountryIso } from 'meta/area'
+import { Areas, CountryIso } from 'meta/area'
 
 import { AssessmentController } from 'server/controller/assessment'
 import { CycleDataController } from 'server/controller/cycleData'
@@ -9,7 +9,6 @@ import Requests from 'server/utils/requests'
 
 type GetTableDataRequest = CycleDataRequest<{
   tableNames: Array<string>
-  countryIso: AreaCode
   countryISOs: Array<CountryIso>
   variables: Array<string>
   columns: Array<string>

--- a/src/server/api/cycleData/table/getTableData.ts
+++ b/src/server/api/cycleData/table/getTableData.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express'
 
 import { CycleDataRequest } from 'meta/api/request'
-import { Areas, CountryIso } from 'meta/area'
+import { AreaCode, Areas, CountryIso } from 'meta/area'
 
 import { AssessmentController } from 'server/controller/assessment'
 import { CycleDataController } from 'server/controller/cycleData'
@@ -9,6 +9,7 @@ import Requests from 'server/utils/requests'
 
 type GetTableDataRequest = CycleDataRequest<{
   tableNames: Array<string>
+  countryIso: AreaCode
   countryISOs: Array<CountryIso>
   variables: Array<string>
   columns: Array<string>
@@ -21,6 +22,7 @@ export const getTableData = async (req: GetTableDataRequest, res: Response) => {
       assessmentName,
       cycleName,
       tableNames = [],
+      countryIso,
       countryISOs,
       variables,
       columns,
@@ -31,12 +33,12 @@ export const getTableData = async (req: GetTableDataRequest, res: Response) => {
 
     const { assessment, cycle } = await AssessmentController.getOneWithCycle({ assessmentName, cycleName })
 
-    const isRegion = !Areas.isISOCountry(countryISOs[0])
+    const isRegion = !Areas.isISOCountry(countryIso)
 
     // When fetching data for regions, use getAggregatedTableData
     const getData = isRegion ? CycleDataController.TableData.getAggregatedTableData : CycleDataController.getTableData
 
-    const props = { assessment, cycle, countryISOs, tableNames, variables, columns, mergeOdp }
+    const props = { assessment, cycle, countryIso, countryISOs, tableNames, variables, columns, mergeOdp }
     const table = await getData(props)
 
     Requests.send(res, table)

--- a/src/server/controller/cycleData/tableData/getAggregatedTableData.ts
+++ b/src/server/controller/cycleData/tableData/getAggregatedTableData.ts
@@ -12,11 +12,24 @@ export const getAggregatedTableData = async (
   props: Props,
   client: BaseProtocol = DB
 ): Promise<RecordAssessmentData> => {
-  const { assessment, cycle, countryISOs: countryISOsProp, tableNames, columns, variables, mergeOdp } = props
+  const {
+    assessment,
+    cycle,
+    countryIso,
+    countryISOs: countryISOsProp,
+    tableNames,
+    columns,
+    variables,
+    mergeOdp,
+  } = props
   const tables = getTablesCondition({ tableNames, columns, variables, mergeOdp })
 
-  const regionCode = countryISOsProp[0] as RegionCode
-  const countryISOs = await CountryRepository.getCountryIsos({ assessment, cycle, regionCode }, client)
+  const regionCode = countryIso as RegionCode
+  // If we have more than one countryIso, then we are given a subset of countries
+  const countryISOs =
+    countryISOsProp.length > 1
+      ? countryISOsProp
+      : await CountryRepository.getCountryIsos({ assessment, cycle, regionCode }, client)
 
   const faoEstimates = await DataRepository.getFaoEstimateData(
     { assessment, cycle, countryISOs, regionCode, tables },

--- a/src/server/controller/cycleData/tableData/getAggregatedTableData.ts
+++ b/src/server/controller/cycleData/tableData/getAggregatedTableData.ts
@@ -1,4 +1,4 @@
-import { RegionCode } from 'meta/area'
+import { AreaCode, RegionCode } from 'meta/area'
 import { RecordAssessmentData } from 'meta/data'
 
 import { getTablesCondition } from 'server/controller/cycleData/tableData/getTablesCondition'
@@ -9,7 +9,7 @@ import { DataRepository } from 'server/repository/assessmentCycle/data'
 import { Props } from './props'
 
 export const getAggregatedTableData = async (
-  props: Props,
+  props: Props & { countryIso: AreaCode },
   client: BaseProtocol = DB
 ): Promise<RecordAssessmentData> => {
   const {

--- a/src/server/controller/cycleData/tableData/props.ts
+++ b/src/server/controller/cycleData/tableData/props.ts
@@ -1,9 +1,10 @@
-import { CountryIso } from 'meta/area'
+import { AreaCode, CountryIso } from 'meta/area'
 import { Assessment, Cycle, VariableCache } from 'meta/assessment'
 
 export type Props = {
   assessment: Assessment
   cycle: Cycle
+  countryIso: AreaCode
   countryISOs: Array<CountryIso>
   tableNames: Array<string> // TODO: refactor use TablesCondition instead
   variables?: Array<string>

--- a/src/server/controller/cycleData/tableData/props.ts
+++ b/src/server/controller/cycleData/tableData/props.ts
@@ -1,10 +1,9 @@
-import { AreaCode, CountryIso } from 'meta/area'
+import { CountryIso } from 'meta/area'
 import { Assessment, Cycle, VariableCache } from 'meta/assessment'
 
 export type Props = {
   assessment: Assessment
   cycle: Cycle
-  countryIso: AreaCode
   countryISOs: Array<CountryIso>
   tableNames: Array<string> // TODO: refactor use TablesCondition instead
   variables?: Array<string>


### PR DESCRIPTION
Support filtering countries for global area code in Dashboard

## Non logged in user

https://github.com/user-attachments/assets/99b54c52-3edc-4a05-b33b-2da6995163eb

## Logged in user



https://github.com/user-attachments/assets/4c7ec30d-3b3d-4e7f-9372-a4736b00ceb4



- Refactor useGetTableData hook to handle multiple country ISOs
- Use useHomeCountriesFilter hook for country selection
- Update getTableData action and API to support multiple country ISOs

