### PR TITLE
3964 - BulkDownload: Metadata

### DIFF
--- a/src/i18n/resources/en.js
+++ b/src/i18n/resources/en.js
@@ -16,10 +16,12 @@ const panEuropean = require('./en/panEuropean/panEuropean')
 const statisticalFactsheets = require('./en/statisticalFactsheets')
 const uc = require('./en/uc')
 const validation = require('./en/validation')
+const bulkDownload = require('./en/bulkDownload')
 
 module.exports.translation = {
   admin,
   area,
+  bulkDownload,
   common,
   contentCheck,
   dataDownload,

--- a/src/i18n/resources/en/bulkDownload.js
+++ b/src/i18n/resources/en/bulkDownload.js
@@ -1,0 +1,3 @@
+module.exports = {
+  dateOfExport: 'Date of export',
+}

--- a/src/server/controller/cycleData/getBulkDownload/utils/getMetadata.ts
+++ b/src/server/controller/cycleData/getBulkDownload/utils/getMetadata.ts
@@ -1,0 +1,88 @@
+import { createI18nPromise } from 'i18n/i18nFactory'
+import { i18n as i18nType } from 'i18next'
+import { Objects } from 'utils/objects'
+
+import { Assessment, Cycle, Labels, RowType } from 'meta/assessment'
+
+import { MetadataController } from 'server/controller/metadata'
+
+type Props = {
+  assessment: Assessment
+  cycle: Cycle
+  tableName: string
+  csvColumn: string
+}
+
+/**
+ * Retrieves the unit label path for a given table name and cycle.
+ *
+ * @param {string} tableName - The name of the table.
+ * @param {Cycle} cycle - The cycle.
+ * @returns {string[]} An array representing the path to the unit in the metadata.
+ */
+const getUnitLabelPath = (tableName: string, cycle: Cycle): string[] => {
+  const pathMap: Record<string, string[]> = {
+    growingStockTotal: ['0', 'cols', '0', 'props', 'labels', cycle.uuid],
+    growingStockComposition2025: ['1', 'cols', '0', 'props', 'labels', cycle.uuid],
+    carbonStockSoilDepth: ['0', 'cols', '0', 'props', 'labels', cycle.uuid],
+  }
+
+  // The unit label is found from the second column of the header row by default
+  const defaultPath = ['0', 'cols', '1', 'props', 'labels', cycle.uuid]
+  return pathMap[tableName] || defaultPath
+}
+
+/**
+ * Retrieves the row type for a given table name.
+ *
+ * @param {string} tableName - The name of the table.
+ * @returns {RowType} The row type for the given table.
+ */
+const getRowType = (tableName: string): RowType => {
+  const rowTypeMap: Record<string, RowType> = {
+    carbonStockSoilDepth: RowType.data,
+  }
+
+  return rowTypeMap[tableName] || RowType.header
+}
+
+/**
+ * Retrieves the metadata for a given table name and cycle.
+ *
+ * @param {Object} props - The properties object.
+ * @param {Assessment} props.assessment - Assessment.
+ * @param {Cycle} props.cycle - Cycle
+ * @param {string} props.tableName - The name of the table.
+ *
+ * @returns {Promise<{ dateExported: string, unit: string }>} Metadata.
+ */
+export const getMetadata = async (
+  props: Props
+): Promise<{
+  dateExported: string
+  unit: string
+}> => {
+  const { assessment, cycle, tableName } = props
+
+  const table = await MetadataController.getTable({ assessment, cycle, tableName })
+  const rows = await MetadataController.getRows({
+    assessment,
+    tableName,
+    cycle,
+    includeCols: true,
+    rowType: getRowType(tableName), // Use the new getRowType function here
+  })
+
+  const i18n = (await createI18nPromise('en')) as i18nType
+  const dateOfExport = `(${i18n.t('bulkDownload.dateOfExport')})`
+  const dateExported = `${new Date().toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  })} ${dateOfExport}`
+
+  const label = Objects.getInPath(rows, getUnitLabelPath(tableName, cycle))
+  const unit = label ? i18n.t(Labels.getLabel({ label, t: i18n.t })) : i18n.t(`unit.${table.props.unit}`)
+
+  return { dateExported, unit }
+}

--- a/src/server/controller/metadata/index.ts
+++ b/src/server/controller/metadata/index.ts
@@ -46,6 +46,7 @@ export const MetadataController = {
 
   // row
   createRow: RowRepository.create,
+  getRows: RowRepository.getMany,
 
   // col
   addColumn,

--- a/src/server/repository/assessment/row/getMany.ts
+++ b/src/server/repository/assessment/row/getMany.ts
@@ -1,0 +1,56 @@
+import * as pgPromise from 'pg-promise'
+
+import { Assessment, Cycle, Row, RowType } from 'meta/assessment'
+
+import { BaseProtocol, DB, Schemas } from 'server/db'
+import { RowAdapter } from 'server/repository/adapter'
+
+type Props = {
+  assessment: Assessment
+  cycle: Cycle
+  tableName: string
+  variableName?: string
+  includeCols?: boolean
+  rowType?: RowType
+}
+
+export const getMany = (props: Props, client: BaseProtocol = DB): Promise<Array<Row>> => {
+  const { assessment, cycle, tableName, variableName, includeCols, rowType } = props
+  const schema = Schemas.getName(assessment)
+
+  const pgp = pgPromise()
+  const queryParams: Record<string, string | boolean> = { tableName, cycleUuid: cycle.uuid }
+  const where: Array<string> = []
+
+  if (variableName) {
+    queryParams.variableName = variableName
+    // eslint-disable-next-line no-template-curly-in-string
+    where.push("r.props ->> 'variableName' = ${variableName}")
+  }
+
+  // eslint-disable-next-line no-template-curly-in-string
+  where.push("t.props ->> 'name' = ${tableName}")
+  // eslint-disable-next-line no-template-curly-in-string
+  where.push("(r.props -> 'cycles' ? ${cycleUuid} or r.props ->> 'type' = 'header')")
+
+  if (rowType) {
+    queryParams.rowType = rowType
+    // eslint-disable-next-line no-template-curly-in-string
+    where.push("r.props ->> 'type' = ${rowType}")
+  }
+
+  const query = pgp.as.format(
+    `
+    select r.*
+           ${includeCols ? `, coalesce(jsonb_agg(c.*) filter (where c.uuid is not null), '[]') as cols` : ''}
+    from ${schema}.row r
+    left join ${schema}."table" t on r.table_id = t.id
+    ${includeCols ? `left join ${schema}.col c on r.id = c.row_id` : ''}
+    where ${where.join(' and ')}
+    ${includeCols ? `group by r.id, r.uuid, r.props` : ''}
+  `,
+    queryParams
+  )
+
+  return client.map<Row>(query, [], RowAdapter)
+}

--- a/src/server/repository/assessment/row/index.ts
+++ b/src/server/repository/assessment/row/index.ts
@@ -1,4 +1,5 @@
 import { create } from 'server/repository/assessment/row/create'
+import { getMany } from 'server/repository/assessment/row/getMany'
 import { getManyCache } from 'server/repository/assessment/row/getManyCache'
 import { getOne } from 'server/repository/assessment/row/getOne'
 import { getVariablesCache } from 'server/repository/assessment/row/getVariablesCache'
@@ -7,5 +8,6 @@ export const RowRepository = {
   create,
   getManyCache,
   getOne,
+  getMany,
   getVariablesCache,
 }

--- a/src/utils/objects/getInPath.ts
+++ b/src/utils/objects/getInPath.ts
@@ -1,0 +1,3 @@
+export const getInPath = (obj: any, path: string[]) => {
+  return path.reduce((acc, pathPart) => acc?.[pathPart], obj)
+}

--- a/src/utils/objects/index.ts
+++ b/src/utils/objects/index.ts
@@ -10,6 +10,7 @@ import * as isNil from 'lodash.isnil'
 import * as pick from 'lodash.pick'
 // @ts-ignore
 import * as unset from 'lodash.unset'
+import { getInPath } from 'utils/objects/getInPath'
 
 import { camelize } from './camelize'
 import { isEmpty } from './isEmpty'
@@ -19,6 +20,7 @@ import { setInPath } from './setInPath'
 export const Objects = {
   camelize,
   cloneDeep,
+  getInPath,
   isEmpty,
   isEqual,
   isFunction,


### PR DESCRIPTION
For csv files divided by variable, we introduce some metadata:
- table anchor followed by variable name
- date of export
- unit as shown in the table


We introduce also:
- `Objects.getInPath`
- `RowController.getRows` with optional arguments (variableName, includeCols and rowType)