### PR TITLE
3915 - Cycle Switch: Public access ->Last Published only

### DIFF
--- a/src/client/components/PageLayout/Header/CycleSwitcher/CycleSwitcher.tsx
+++ b/src/client/components/PageLayout/Header/CycleSwitcher/CycleSwitcher.tsx
@@ -1,6 +1,9 @@
 import './CycleSwitcher.scss'
 import React from 'react'
 
+import { Assessments } from 'meta/assessment'
+
+import { useAssessment } from 'client/store/assessment'
 import { useCycleRouteParams } from 'client/hooks/useRouteParams'
 import Icon from 'client/components/Icon'
 import PopoverControl from 'client/components/PopoverControl'
@@ -8,16 +11,20 @@ import PopoverControl from 'client/components/PopoverControl'
 import { usePopoverItems } from './hooks/usePopoverItems'
 
 const CycleSwitcher = () => {
+  const assessment = useAssessment()
   const { cycleName } = useCycleRouteParams()
   const popoverItems = usePopoverItems()
 
-  if (popoverItems.length < 1) return <span className="cycle-switcher-locked">{cycleName}</span>
+  if (popoverItems.length < 1) return null
+
+  const latestCycle = Assessments.getLastCreatedCycle(assessment)
+  const displayName = latestCycle.name === cycleName ? '' : cycleName
 
   return (
     <div className="cycle-switcher">
       <PopoverControl items={popoverItems}>
         <div className="app-header__menu-item">
-          <span>{cycleName}</span>
+          <span>{displayName}</span>
           <Icon name="small-down" />
         </div>
       </PopoverControl>

--- a/src/client/components/PageLayout/Header/CycleSwitcher/hooks/usePopoverItems.tsx
+++ b/src/client/components/PageLayout/Header/CycleSwitcher/hooks/usePopoverItems.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { Cycles } from 'meta/assessment'
+import { Assessments, Cycles } from 'meta/assessment'
 import { Users } from 'meta/user'
 
 import { useAssessments } from 'client/store/assessment'
@@ -33,11 +33,14 @@ export const usePopoverItems = (): Array<PopoverItem> => {
 
           const assessmentName = assessment.props.name
           const cycleName = cycle.name
+          const isLatestCycle = Assessments.getLastCreatedCycle(assessment)?.name === cycleName
           const isCurrentRoute = assessmentName === routeParams.assessmentName && cycleName === routeParams.cycleName
+          const label = t(`${assessmentName}.labels.short`)
+          const content = `${label} ${isLatestCycle ? t('common.latest') : cycleName}`
 
           if (canViewCycle && !isCurrentRoute) {
             const item: PopoverItem = {
-              content: `${t(`${assessmentName}.labels.short`)} ${cycleName}`,
+              content,
               onClick: () => navigateTo({ assessment, cycle, user }),
             }
             items.push(item)

--- a/src/client/pages/Landing/hooks/useRedirectAssessmentAndCycle.tsx
+++ b/src/client/pages/Landing/hooks/useRedirectAssessmentAndCycle.tsx
@@ -1,3 +1,4 @@
+import { Assessments } from 'meta/assessment'
 import { Users } from 'meta/user'
 import { UserRoles } from 'meta/user/userRoles'
 
@@ -16,10 +17,7 @@ export const useRedirectAssessmentAndCycle = () => {
   )
 
   const isAdmin = Users.isAdministrator(user)
-
-  const cycle = isAdmin
-    ? [...assessment.cycles].sort((a, b) => (a.name > b.name ? -1 : 1)).at(0)
-    : assessment.cycles.find((cycle) => cycle.uuid === (userLastRole?.cycleUuid ?? assessment.props.defaultCycle))
+  const cycle = isAdmin ? Assessments.getLastCreatedCycle(assessment) : Assessments.getLastPublishedCycle(assessment)
 
   return { assessment, cycle }
 }

--- a/src/client/store/user/hooks/index.ts
+++ b/src/client/store/user/hooks/index.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 
 import { CountryIso } from 'meta/area'
-import { CommentableDescriptionName, Cycle, Cycles, SectionName } from 'meta/assessment'
+import { Assessments, CommentableDescriptionName, Cycle, Cycles, SectionName } from 'meta/assessment'
 import { Authorizer, CollaboratorEditPropertyType, User, Users } from 'meta/user'
 
 import { useAppSelector } from 'client/store'
@@ -30,6 +30,10 @@ export const useUserCycles = (): Array<Cycle> => {
   const user = useUser()
   const isAdministrator = Users.isAdministrator(user)
   if (isAdministrator) return assessment.cycles
+
+  // Users who are not logged in can only access the most recently published cycle
+  if (!user) return [Assessments.getLastPublishedCycle(assessment)]
+
   // Return only current assessment cycles for user
   return assessment.cycles.filter(
     (cycle) => Cycles.isPublished(cycle) || user?.roles.some((role) => cycle.uuid === role.cycleUuid)

--- a/src/i18n/resources/ar/common.js
+++ b/src/i18n/resources/ar/common.js
@@ -31,6 +31,7 @@ module.exports = {
   label: 'التسمية',
   language: 'اللغة',
   lastEdit: 'آخر تعديل',
+  latest: 'الأحدث',
   link: 'الرابط',
   load: 'تحميل',
   loading: 'جاري التحميل...',

--- a/src/i18n/resources/en/common.js
+++ b/src/i18n/resources/en/common.js
@@ -35,6 +35,7 @@ module.exports = {
   label: 'Label',
   language: 'Language',
   lastEdit: 'Last edit',
+  latest: 'Latest',
   link: 'Link',
   load: 'Load',
   loading: 'Loading...',

--- a/src/i18n/resources/es/common.js
+++ b/src/i18n/resources/es/common.js
@@ -25,6 +25,7 @@ module.exports = {
   label: 'Etiqueta',
   language: 'Idioma',
   lastEdit: 'Última edición',
+  latest: 'Último',
   link: 'Enlace',
   login: 'Área reservada',
   name: 'Nombre',

--- a/src/i18n/resources/fr/common.js
+++ b/src/i18n/resources/fr/common.js
@@ -28,6 +28,7 @@ module.exports = {
   label: 'Nom',
   language: 'Langue',
   lastEdit: 'Dernière modification',
+  latest: 'Dernier',
   link: 'Lien',
   login: 'Espace réservé',
   name: 'Nom',

--- a/src/i18n/resources/ru/common.js
+++ b/src/i18n/resources/ru/common.js
@@ -29,6 +29,7 @@ module.exports = {
   label: 'Ярлык',
   language: 'Язык',
   lastEdit: 'Последнее реадактирование',
+  latest: 'Последний',
   link: 'Ссылка',
   load: 'Загрузить',
   loading: 'Загрузка...',

--- a/src/i18n/resources/zh/common.js
+++ b/src/i18n/resources/zh/common.js
@@ -31,6 +31,7 @@ module.exports = {
   label: '标签',
   language: '语言',
   lastEdit: '最后编辑',
+  latest: '最新',
   link: '链接',
   load: '加载',
   loading: '加载中...',

--- a/src/meta/assessment/assessments.ts
+++ b/src/meta/assessment/assessments.ts
@@ -1,8 +1,9 @@
 import { Areas, AssessmentStatus, Country, CountryIso } from 'meta/area'
 
 import { User, Users } from '../user'
+import { Assessment } from './assessment'
 import { AssessmentName } from './assessmentName'
-import { Cycle } from './cycle'
+import { Cycle, CycleStatus } from './cycle'
 
 export interface AssessmentStatusTransition {
   next?: AssessmentStatus
@@ -55,6 +56,49 @@ export const AssessmentStatusTransitions = {
 
 const getShortLabel = (assessmentName: AssessmentName) => `${assessmentName}.labels.short`
 
+/**
+ * Retrieves the most recently published cycle from an assessment.
+ *
+ * @param {Assessment} assessment - Assessment
+ * @returns {Cycle | undefined} The most recently published cycle, or undefined if no published cycles exist.
+ */
+const getLastPublishedCycle = (assessment: Assessment): Cycle | undefined => {
+  const publishedCycles = assessment.cycles.filter((cycle) => cycle.props.status === CycleStatus.published)
+
+  if (publishedCycles.length === 0) {
+    return undefined
+  }
+
+  return publishedCycles.reduce((last, current) => {
+    const lastDate = new Date(last.props.datePublished)
+    const currentDate = new Date(current.props.datePublished)
+    return lastDate > currentDate ? last : current
+  })
+}
+
+/**
+ * Retrieves the most recently created cycle from an assessment.
+ * Note: cycle.props.status can be draft, even when dateCreated is present.
+ *
+ * @param {Assessment} assessment - Assessment
+ * @returns {Cycle | undefined} The most recently created cycle, or undefined if no cycles exist.
+ */
+const getLastCreatedCycle = (assessment: Assessment): Cycle | undefined => {
+  const createdCycles = assessment.cycles.filter((cycle) => cycle.props.dateCreated)
+
+  if (createdCycles.length === 0) {
+    return undefined
+  }
+
+  return createdCycles.reduce((last, current) => {
+    const lastDate = new Date(last.props.dateCreated)
+    const currentDate = new Date(current.props.dateCreated)
+    return lastDate > currentDate ? last : current
+  })
+}
+
 export const Assessments = {
   getShortLabel,
+  getLastPublishedCycle,
+  getLastCreatedCycle,
 }

--- a/src/meta/assessment/assessments.ts
+++ b/src/meta/assessment/assessments.ts
@@ -1,9 +1,12 @@
+import { Dates } from 'utils/dates'
+
 import { Areas, AssessmentStatus, Country, CountryIso } from 'meta/area'
+import { Cycles } from 'meta/assessment/cycles'
 
 import { User, Users } from '../user'
 import { Assessment } from './assessment'
 import { AssessmentName } from './assessmentName'
-import { Cycle, CycleStatus } from './cycle'
+import { Cycle } from './cycle'
 
 export interface AssessmentStatusTransition {
   next?: AssessmentStatus
@@ -63,7 +66,7 @@ const getShortLabel = (assessmentName: AssessmentName) => `${assessmentName}.lab
  * @returns {Cycle | undefined} The most recently published cycle, or undefined if no published cycles exist.
  */
 const getLastPublishedCycle = (assessment: Assessment): Cycle | undefined => {
-  const publishedCycles = assessment.cycles.filter((cycle) => cycle.props.status === CycleStatus.published)
+  const publishedCycles = assessment.cycles.filter((cycle) => Cycles.isPublished(cycle))
 
   if (publishedCycles.length === 0) {
     return undefined
@@ -72,28 +75,21 @@ const getLastPublishedCycle = (assessment: Assessment): Cycle | undefined => {
   return publishedCycles.reduce((last, current) => {
     const lastDate = new Date(last.props.datePublished)
     const currentDate = new Date(current.props.datePublished)
-    return lastDate > currentDate ? last : current
+    return Dates.isAfter(currentDate, lastDate) ? current : last
   })
 }
 
 /**
  * Retrieves the most recently created cycle from an assessment.
- * Note: cycle.props.status can be draft, even when dateCreated is present.
  *
  * @param {Assessment} assessment - Assessment
  * @returns {Cycle | undefined} The most recently created cycle, or undefined if no cycles exist.
  */
 const getLastCreatedCycle = (assessment: Assessment): Cycle | undefined => {
-  const createdCycles = assessment.cycles.filter((cycle) => cycle.props.dateCreated)
-
-  if (createdCycles.length === 0) {
-    return undefined
-  }
-
-  return createdCycles.reduce((last, current) => {
+  return assessment.cycles.reduce((last, current) => {
     const lastDate = new Date(last.props.dateCreated)
     const currentDate = new Date(current.props.dateCreated)
-    return lastDate > currentDate ? last : current
+    return Dates.isAfter(currentDate, lastDate) ? current : last
   })
 }
 


### PR DESCRIPTION
# 3915 - Cycle Switch: Public access ->Last Published only
---
This pull request will change non logged user logic:
Non logged in users will have access only to a single cycle, the latest published cycle

## Flows:

### Non logged user
https://github.com/user-attachments/assets/6f9b5d92-378a-4362-bb97-8bc4101e8079

### Logged admin user
https://github.com/user-attachments/assets/d42e5d45-baa8-486f-823c-e172e4d093fc

### Logged non admin user
https://github.com/user-attachments/assets/d94a31dc-45b3-408e-b9a3-4d1c4ebfa989


Developers note:
Translations added with DeepL