### PR TITLE
3464 - ODP: custom 2020 logic

### DIFF
--- a/src/client/pages/OriginalDataPoint/components/ExtentOfForest/ExtentOfForest.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ExtentOfForest/ExtentOfForest.tsx
@@ -36,7 +36,7 @@ const ExtentOfForest: React.FC<Props> = (props) => {
 
   const tableRef = useRef(null)
 
-  const fileName = `odp-${t(`nationalDataPoint.forestCategoriesLabel${cycleName === '2025' ? '2025' : ''}`)} ${
+  const fileName = `odp-${t(`nationalDataPoint.forestCategoriesLabel${cycleName !== '2020' ? '2025' : ''}`)} ${
     year ?? ''
   }`
   return (
@@ -45,7 +45,7 @@ const ExtentOfForest: React.FC<Props> = (props) => {
         <div className="odp__section-header">
           <ButtonTableExport disabled={year === -1 || year === undefined} filename={fileName} tableRef={tableRef} />
           <h3 className="subhead">
-            {t(`nationalDataPoint.forestCategoriesLabel${cycleName === '2025' ? '2025' : ''}`)}
+            {t(`nationalDataPoint.forestCategoriesLabel${cycleName !== '2020' ? '2025' : ''}`)}
           </h3>
           <DefinitionLink
             anchor="1a"
@@ -68,7 +68,7 @@ const ExtentOfForest: React.FC<Props> = (props) => {
                   </th>
                 )}
                 <th className="fra-table__header-cell fra-table__divider" colSpan={2}>
-                  {t(`nationalDataPoint.${cycleName === '2025' ? 'nationalClassifications' : 'nationalClasses'}`)}
+                  {t(`nationalDataPoint.${cycleName !== '2020' ? 'nationalClassifications' : 'nationalClasses'}`)}
                 </th>
                 <th className="fra-table__header-cell" colSpan={3}>
                   {t(`nationalDataPoint.fraClasses`)}
@@ -78,11 +78,9 @@ const ExtentOfForest: React.FC<Props> = (props) => {
                 <th className="fra-table__header-cell-left">{t('nationalDataPoint.class')}</th>
                 <th className="fra-table__header-cell fra-table__divider">{t('nationalDataPoint.area')}</th>
                 <th className="fra-table__header-cell">{t('fraClass.forest')}</th>
+                <th className="fra-table__header-cell">{t(`fra.extentOfForest.otherWoodedLand`)}</th>
                 <th className="fra-table__header-cell">
-                  {t(`${cycleName === '2025' ? 'fra.extentOfForest.otherWoodedLand' : 'fraClass.otherWoodedLand'}`)}
-                </th>
-                <th className="fra-table__header-cell">
-                  {t(`${cycleName === '2025' ? 'fra.extentOfForest.remainingLandArea' : 'fraClass.otherLand'}`)}
+                  {t(`${cycleName !== '2020' ? 'fra.extentOfForest.remainingLandArea' : 'fraClass.otherLand'}`)}
                 </th>
               </tr>
 

--- a/src/client/pages/OriginalDataPoint/components/ExtentOfForest/ExtentOfForestRow.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ExtentOfForest/ExtentOfForestRow.tsx
@@ -140,7 +140,7 @@ const ExtentOfForestRow: React.FC<Props> = (props) => {
       {showReviewIndicator && (
         <td className="fra-table__review-cell no-print">
           <ReviewIndicator
-            subtitle={t(`nationalDataPoint.forestCategoriesLabel${cycle.name === '2025' ? '2025' : ''}`)}
+            subtitle={t(`nationalDataPoint.forestCategoriesLabel${cycle.name !== '2020' ? '2025' : ''}`)}
             title={name}
             topicKey={Topics.getOdpClassReviewTopicKey(originalDataPoint.id, uuid, 'extentOfForest')}
           />

--- a/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristics.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristics.tsx
@@ -43,9 +43,9 @@ const ForestCharacteristics: React.FC<Props> = (props) => {
   })
 
   const hasPlantation = plantationTotal && Numbers.greaterThanOrEqualTo(plantationTotal, 0)
-  // Display primary_forest only for ODP/Cycle2025
+  //  naturally regenerating forest is not available in Cycle 2020
   const hasNaturallyRegeneratingForest =
-    cycleName === '2025' &&
+    cycleName !== '2020' &&
     naturallyRegeneratingForestTotal &&
     Numbers.greaterThanOrEqualTo(naturallyRegeneratingForestTotal, 0)
 
@@ -82,7 +82,7 @@ const ForestCharacteristics: React.FC<Props> = (props) => {
                   </th>
                 )}
                 <th className="fra-table__header-cell fra-table__divider" colSpan={2}>
-                  {t(`nationalDataPoint.${cycleName === '2025' ? 'nationalClassifications' : 'nationalClasses'}`)}
+                  {t(`nationalDataPoint.${cycleName !== '2020' ? 'nationalClassifications' : 'nationalClasses'}`)}
                 </th>
                 <th className="fra-table__header-cell" colSpan={3}>
                   {t(`nationalDataPoint.fraClasses`)}

--- a/src/client/pages/OriginalDataPoint/components/NationalClasses/components/NationalClassesTable.tsx
+++ b/src/client/pages/OriginalDataPoint/components/NationalClasses/components/NationalClassesTable.tsx
@@ -38,7 +38,7 @@ export const NationalClassesTable = (props: Props) => {
       )}
 
       <DataCell header>
-        {t(`nationalDataPoint.${cycleName === '2025' ? 'nationalClassifications' : 'nationalClass'}`)}
+        {t(`nationalDataPoint.${cycleName !== '2020' ? 'nationalClassifications' : 'nationalClass'}`)}
       </DataCell>
       <DataCell header lastCol>
         {t('nationalDataPoint.definition')}

--- a/src/client/pages/OriginalDataPoint/components/NationalClasses/components/Title.tsx
+++ b/src/client/pages/OriginalDataPoint/components/NationalClasses/components/Title.tsx
@@ -24,7 +24,7 @@ export const Title = (props: Props) => {
     <div className="odp__section-header">
       <ButtonGridExport disabled={year === -1} filename={`FRA${cycleName}-NDP${year}.csv`} gridRef={gridRef} />
       <h3 className="subhead">
-        {t(`nationalDataPoint.${cycleName === '2025' ? 'nationalClassifications' : 'nationalClasses'}`)}
+        {t(`nationalDataPoint.${cycleName !== '2020' ? 'nationalClassifications' : 'nationalClasses'}`)}
       </h3>
     </div>
   )

--- a/src/client/pages/OriginalDataPoint/components/OriginalData/OriginalData.tsx
+++ b/src/client/pages/OriginalDataPoint/components/OriginalData/OriginalData.tsx
@@ -60,7 +60,7 @@ const OriginalData: React.FC<Props> = (props) => {
           })}
         >
           {`${extentOfForest.anchor} ${i18n.t(
-            `nationalDataPoint.forestCategoriesLabel${cycle.name === '2025' ? '2025' : ''}`
+            `nationalDataPoint.forestCategoriesLabel${cycle.name !== '2020' ? '2025' : ''}`
           )}`}
         </NavLink>
         <NavLink
@@ -83,10 +83,10 @@ const OriginalData: React.FC<Props> = (props) => {
       </div>
 
       {sectionName === extentOfForest.name && (
-        <ExtentOfForest originalDataPoint={originalDataPoint} canEditData={canEditData} />
+        <ExtentOfForest canEditData={canEditData} originalDataPoint={originalDataPoint} />
       )}
       {sectionName !== extentOfForest.name && (
-        <ForestCharacteristics originalDataPoint={originalDataPoint} canEditData={canEditData} />
+        <ForestCharacteristics canEditData={canEditData} originalDataPoint={originalDataPoint} />
       )}
     </div>
   )

--- a/src/meta/assessment/cycle.ts
+++ b/src/meta/assessment/cycle.ts
@@ -6,9 +6,8 @@ export interface CycledPropsObject<Props = void> {
   id?: number
 }
 
-export type CycleUuid = string
-
 export type CycleName = string
+export type CycleUuid = string
 
 export enum CycleStatus {
   draft = 'draft',


### PR DESCRIPTION
### 2020
<img width="1437" alt="Screenshot 2024-10-09 at 12 30 19" src="https://github.com/user-attachments/assets/137f40a4-fe15-4314-8375-e44282419ccc">
<img width="1442" alt="Screenshot 2024-10-09 at 12 30 10" src="https://github.com/user-attachments/assets/a1545d67-1c21-4b11-81b7-ba831c865864">

### 2029
<img width="1436" alt="Screenshot 2024-10-09 at 12 29 36" src="https://github.com/user-attachments/assets/77c7ea6e-4266-4360-ae13-36bd87d51693">
<img width="1440" alt="Screenshot 2024-10-09 at 12 29 23" src="https://github.com/user-attachments/assets/93d3ef0a-f00f-4eaf-b452-c61b8a8ceac4">


### 2025
<img width="1442" alt="Screenshot 2024-10-09 at 12 29 03" src="https://github.com/user-attachments/assets/31a81401-a795-4a19-bae5-199a4c3f270b">
<img width="1445" alt="Screenshot 2024-10-09 at 12 28 52" src="https://github.com/user-attachments/assets/e2e6094c-c97e-49b6-b871-8d9c1c123a6f">
