### PR TITLE
4000 - Dashboard metadata migration to node ext

### DIFF
--- a/src/meta/dashboard/index.ts
+++ b/src/meta/dashboard/index.ts
@@ -1,2 +1,2 @@
-export type { DashboardItem, DashboardTable } from './dashboard'
+export type { DashboardBarChart, DashboardItem, DashboardPieChart, DashboardTable } from './dashboard'
 export { DashboardItemType } from './dashboard'

--- a/src/meta/nodeExt/nodeExt.ts
+++ b/src/meta/nodeExt/nodeExt.ts
@@ -11,6 +11,7 @@ export enum NodeExtCellType {
 export enum NodeExtType {
   contact = 'contact',
   node = 'node',
+  dataQuery = 'data-query',
 }
 
 export type NodeExt<Props, Value extends NodeValue | null = NodeValue> = {

--- a/src/meta/nodeExt/nodeExt.ts
+++ b/src/meta/nodeExt/nodeExt.ts
@@ -11,7 +11,7 @@ export enum NodeExtCellType {
 export enum NodeExtType {
   contact = 'contact',
   node = 'node',
-  dataQuery = 'data-query',
+  dataQuery = 'dataQuery',
 }
 
 export type NodeExt<Props, Value extends NodeValue | null = NodeValue> = {

--- a/src/meta/nodeExt/nodeExt.ts
+++ b/src/meta/nodeExt/nodeExt.ts
@@ -11,7 +11,7 @@ export enum NodeExtCellType {
 export enum NodeExtType {
   contact = 'contact',
   node = 'node',
-  dataQuery = 'dataQuery',
+  dashboard = 'dashboard',
 }
 
 export type NodeExt<Props, Value extends NodeValue | null = NodeValue> = {

--- a/src/test/migrations/steps/20241009113849-step-dashboard-metadata-insert.ts
+++ b/src/test/migrations/steps/20241009113849-step-dashboard-metadata-insert.ts
@@ -37,7 +37,7 @@ export default async (client: BaseProtocol) => {
   await Promises.each(assessment.cycles, async (cycle) => {
     const schemaCycle = Schemas.getNameCycle(assessment, cycle)
     const dashboardItems = dashboardItemFactories.map((factory) => factory(cycle, false))
-    const nodeExtType = NodeExtType.dataQuery
+    const nodeExtType = NodeExtType.dashboard
 
     const query = `select 1 from ${schemaCycle}.node_ext where type = $1`
     const exists = (await client.manyOrNone(query, [nodeExtType])).length > 0

--- a/src/test/migrations/steps/20241009113849-step-dashboard-metadata-insert.ts
+++ b/src/test/migrations/steps/20241009113849-step-dashboard-metadata-insert.ts
@@ -1,0 +1,56 @@
+import * as pgPromise from 'pg-promise'
+import { Promises } from 'utils/promises'
+
+import { AssessmentNames, Cycle } from 'meta/assessment'
+import { DashboardItem } from 'meta/dashboard'
+import { NodeExtType } from 'meta/nodeExt'
+
+import { AssessmentController } from 'server/controller/assessment'
+import { BaseProtocol, Schemas } from 'server/db'
+import { Logger } from 'server/utils/logger'
+
+import { forestArea } from './metadata/dashboard/forestArea'
+import { forestAreaPercentOfLandArea } from './metadata/dashboard/forestAreaPercentOfLandArea'
+import { forestAreaWithinProtectedAreas } from './metadata/dashboard/forestAreaWithinProtectedAreas'
+import { forestGrowingStockAndCarbonDashboard } from './metadata/dashboard/forestGrowingStockAndCarbon'
+import { forestOwnership } from './metadata/dashboard/forestOwnership'
+import { naturallyRegeneratingForestArea } from './metadata/dashboard/naturallyRegeneratingForestArea'
+import { primaryDesignatedManagementObjectiveDashboard } from './metadata/dashboard/primaryDesignatedManagementObjective'
+import { primaryForestPercentOfForestArea } from './metadata/dashboard/primaryForestPercentOfForestArea'
+
+type DashboardItemFactory = (cycle: Cycle, region: boolean) => DashboardItem
+
+const dashboardItemFactories: Array<DashboardItemFactory> = [
+  forestArea,
+  forestGrowingStockAndCarbonDashboard,
+  forestAreaPercentOfLandArea,
+  primaryForestPercentOfForestArea,
+  forestAreaWithinProtectedAreas,
+  forestOwnership,
+  primaryDesignatedManagementObjectiveDashboard,
+  naturallyRegeneratingForestArea,
+]
+
+export default async (client: BaseProtocol) => {
+  const pgp = pgPromise()
+  const assessment = await AssessmentController.getOne({ assessmentName: AssessmentNames.fra }, client)
+  await Promises.each(assessment.cycles, async (cycle) => {
+    const schemaCycle = Schemas.getNameCycle(assessment, cycle)
+    const dashboardItems = dashboardItemFactories.map((factory) => factory(cycle, false))
+    const nodeExtType = NodeExtType.dataQuery
+
+    const query = `select 1 from ${schemaCycle}.node_ext where type = $1`
+    const exists = (await client.manyOrNone(query, [nodeExtType])).length > 0
+    if (!exists) {
+      const columns = ['type', 'value']
+      const options = { table: { table: 'node_ext', schema: schemaCycle } }
+      const cs = new pgp.helpers.ColumnSet(columns, options)
+      const values = [{ type: nodeExtType, value: JSON.stringify(dashboardItems) }]
+      const query = pgp.helpers.insert(values, cs)
+      await client.none(query)
+      Logger.info(`Inserted dashboard items for cycle ${cycle.name}`)
+    } else {
+      Logger.info(`Dashboard items for cycle ${cycle.name} already exist`)
+    }
+  })
+}

--- a/src/test/migrations/steps/metadata/dashboard/forestArea/index.ts
+++ b/src/test/migrations/steps/metadata/dashboard/forestArea/index.ts
@@ -1,0 +1,47 @@
+import { Cycle, Unit } from 'meta/assessment'
+import { ChartColor } from 'meta/chart'
+import { DashboardBarChart, DashboardItemType } from 'meta/dashboard'
+
+import { getTable, RowsMetadata } from '../utils'
+
+const commonColumns = ['1990', '2000', '2010', '2020']
+
+const cols: Record<string, Array<string>> = {
+  '2020': commonColumns,
+  '2025': [...commonColumns, '2025'],
+}
+
+const tableName = 'extentOfForest'
+const tableId = 1
+
+const rowMetadata = (region: boolean): RowsMetadata => [
+  {
+    id: 1,
+    variableName: 'forestArea',
+    label: { key: `statisticalFactsheets.rowName.area` },
+    calculateFn: `${tableName}.forestArea ${region ? '/ 1000' : ''}`,
+    calculationDependencies: [{ tableName, variableName: 'forestArea' }],
+  },
+]
+
+export const forestArea = (cycle: Cycle, region: boolean): DashboardBarChart => ({
+  type: DashboardItemType.barChart,
+  title: {
+    key: 'statisticalFactsheets.forestArea.title',
+    params: { startYear: cols[cycle.name].at(0), endYear: cols[cycle.name].at(-1), unit: `unit.${Unit.haThousand}` },
+  },
+  table: getTable({ cycle, cols: cols[cycle.name], tableId, rowMetadata: rowMetadata(region), tableName }),
+  chart: {
+    columns: cols[cycle.name],
+    cells: [
+      {
+        variableName: 'forestArea',
+        color: ChartColor.green,
+        label: { key: 'statisticalFactsheets.rowName.area' },
+        unit: `unit.${Unit.haThousand}`,
+      },
+    ],
+    xAxis: { label: { key: 'common.year' } },
+    yAxis: { label: { key: `unit.${Unit.haThousand}` } },
+  },
+})

--- a/src/test/migrations/steps/metadata/dashboard/forestAreaPercentOfLandArea/index.ts
+++ b/src/test/migrations/steps/metadata/dashboard/forestAreaPercentOfLandArea/index.ts
@@ -1,0 +1,66 @@
+import { Cycle, Unit } from 'meta/assessment'
+import { ChartColor } from 'meta/chart'
+import { DashboardItemType } from 'meta/dashboard'
+import { DashboardPieChart } from 'meta/dashboard/dashboard'
+
+import type { RowsMetadata } from '../utils'
+import { getTable } from '../utils'
+
+const cols: Record<string, Array<string>> = {
+  '2020': ['2020'],
+  '2025': ['2025'],
+}
+
+const tableName = 'extentOfForest'
+const tableId = 3
+
+const rowMetadata = (region: boolean): RowsMetadata => [
+  {
+    id: 1,
+    variableName: 'forestArea',
+    label: { key: `statisticalFactsheets.rowName.forest` },
+    calculateFn: `${tableName}.forestArea ${region ? '/ 1000' : ''}`,
+    // calculateFn: `100 * (${tableName}.forestArea / ${tableName}.totalLandArea)`,
+    calculationDependencies: [
+      { tableName, variableName: 'forestArea' },
+      { tableName, variableName: 'totalLandArea' },
+    ],
+  },
+  {
+    id: 2,
+    variableName: 'otherLand',
+    label: { key: `statisticalFactsheets.rowName.otherLand` },
+    calculateFn: `${tableName}.totalLandArea ${region ? '/ 1000' : ''} - ${tableName}.forestArea ${
+      region ? '/ 1000' : ''
+    }`,
+    // calculateFn: `100 - (100 * (${tableName}.forestArea / ${tableName}.totalLandArea))`,
+    calculationDependencies: [
+      { tableName, variableName: 'forestArea' },
+      { tableName, variableName: 'totalLandArea' },
+    ],
+  },
+]
+
+export const forestAreaPercentOfLandArea = (cycle: Cycle, region: boolean): DashboardPieChart => ({
+  type: DashboardItemType.pieChart,
+  title: { key: 'statisticalFactsheets.forestAreaPercent.title', params: { year: cols[cycle.name].at(0) } },
+  table: getTable({ cycle, cols: cols[cycle.name], tableId, rowMetadata: rowMetadata(region), tableName }),
+  chart: {
+    cells: [
+      {
+        variableName: 'forestArea',
+        color: ChartColor.green,
+        columnName: cols[cycle.name][0],
+        label: { key: 'statisticalFactsheets.rowName.forest' },
+        unit: `unit.${Unit.haThousand}`,
+      },
+      {
+        variableName: 'otherLand',
+        color: ChartColor.otherLand,
+        columnName: cols[cycle.name][0],
+        label: { key: 'statisticalFactsheets.rowName.otherLand' },
+        unit: `unit.${Unit.haThousand}`,
+      },
+    ],
+  },
+})

--- a/src/test/migrations/steps/metadata/dashboard/forestAreaWithinProtectedAreas/index.ts
+++ b/src/test/migrations/steps/metadata/dashboard/forestAreaWithinProtectedAreas/index.ts
@@ -1,0 +1,68 @@
+import { Cycle, TableNames, Unit } from 'meta/assessment'
+import { ChartColor } from 'meta/chart'
+import { DashboardItemType, DashboardPieChart } from 'meta/dashboard'
+
+import { getTable, RowsMetadata } from '../utils'
+
+const cols: Record<string, Array<string>> = {
+  '2020': ['2020'],
+  '2025': ['2025'],
+}
+
+const tableId = 5
+const tableName = 'forestAreaWithinProtectedAreas'
+const variableName = 'forest_area_within_protected_areas'
+
+export const forestAreaWithinProtectedAreas = (cycle: Cycle, region: boolean): DashboardPieChart => {
+  const columnName = cols[cycle.name][0]
+  const rowMetadata: RowsMetadata = [
+    {
+      id: 1,
+      variableName,
+      label: { key: `statisticalFactsheets.rowName.protected` },
+      calculateFn: `${tableName}.${variableName} ${region ? '/ 1000' : ''}`,
+      // calculateFn: `100 * ${tableName}.${variableName} / ${TableNames.extentOfForest}.forestArea`,
+      calculationDependencies: [
+        { tableName, variableName },
+        { tableName: TableNames.extentOfForest, variableName: 'forestArea' },
+      ],
+    },
+    {
+      id: 2,
+      variableName: 'forestArea',
+      label: { key: `statisticalFactsheets.rowName.other` },
+      calculateFn: `${TableNames.extentOfForest}.forestArea ${region ? '/ 1000' : ''} - ${tableName}.${variableName} ${
+        region ? '/ 1000' : ''
+      }`,
+      // calculateFn: `100 - 100 * ${tableName}.${variableName} / ${TableNames.extentOfForest}.forestArea`,
+      calculationDependencies: [
+        { tableName, variableName },
+        { tableName: TableNames.extentOfForest, variableName: 'forestArea' },
+      ],
+    },
+  ]
+
+  return {
+    type: DashboardItemType.pieChart,
+    title: { key: 'statisticalFactsheets.forestAreaWithinProtectedAreas.title', params: { year: columnName } },
+    table: getTable({ cycle, cols: cols[cycle.name], tableId, rowMetadata, tableName }),
+    chart: {
+      cells: [
+        {
+          variableName: 'forestArea',
+          color: ChartColor.green,
+          columnName,
+          label: { key: 'statisticalFactsheets.rowName.other' },
+          unit: `unit.${Unit.haThousand}`,
+        },
+        {
+          variableName,
+          color: ChartColor.forestLight,
+          columnName,
+          label: { key: 'statisticalFactsheets.rowName.protected' },
+          unit: `unit.${Unit.haThousand}`,
+        },
+      ],
+    },
+  }
+}

--- a/src/test/migrations/steps/metadata/dashboard/forestGrowingStockAndCarbon/index.ts
+++ b/src/test/migrations/steps/metadata/dashboard/forestGrowingStockAndCarbon/index.ts
@@ -1,0 +1,116 @@
+import { Cycle, TableNames } from 'meta/assessment'
+import { DashboardItemType, DashboardTable } from 'meta/dashboard'
+
+import { getTable, RowsMetadata } from '../utils'
+
+const cols: Record<string, Array<string>> = {
+  '2020': ['1990', '2000', '2010', '2020'],
+  '2025': ['1990', '2000', '2010', '2020', '2025'],
+}
+
+const tableName = 'forestGrowingStockAndCarbonDashboard'
+const tableId = 2
+
+const rowMetadata: Record<string, (region: boolean) => RowsMetadata> = {
+  '2020': (region) => [
+    {
+      id: 1,
+      variableName: 'forest',
+      label: {
+        key: 'statisticalFactsheets.carbonAndGrowingStock.growing_stock_total',
+        params: { unit: region ? 'unit.billionCubicMeter' : 'unit.millionsCubicMeterOverBark' },
+      },
+      calculateFn: `growingStockTotal.forest ${region ? '/ 1000' : ''}`,
+      calculationDependencies: [{ tableName: 'growingStockTotal', variableName: 'forest' }],
+    },
+    {
+      id: 2,
+      variableName: 'carbonStockBiomassTotal',
+      label: {
+        key: 'statisticalFactsheets.carbonAndGrowingStock.carbon_stock_biomass_total',
+        params: { unit: region ? 'unit.gt' : 'unit.tonnesPerHa' },
+      },
+      calculateFn: region
+        ? `${TableNames.carbonStock}.carbon_stock_biomass_total / 1000000`
+        : `${TableNames.carbonStock}.carbon_forest_below_ground + ${TableNames.carbonStock}.carbon_forest_above_ground`,
+      calculationDependencies: [
+        { tableName: TableNames.carbonStock, variableName: 'carbon_forest_above_ground' },
+        { tableName: TableNames.carbonStock, variableName: 'carbon_forest_below_ground' },
+      ],
+    },
+    {
+      id: 3,
+      variableName: 'carbonStockTotal',
+      label: {
+        key: 'statisticalFactsheets.carbonAndGrowingStock.carbon_stock_total',
+        params: { unit: region ? 'unit.gt' : 'unit.tonnesPerHa' },
+      },
+      calculateFn: region
+        ? `${TableNames.carbonStock}.carbon_stock_total / 1000000`
+        : `
+${TableNames.carbonStock}.carbon_forest_above_ground + 
+${TableNames.carbonStock}.carbon_forest_below_ground + 
+${TableNames.carbonStock}.carbon_forest_deadwood + 
+${TableNames.carbonStock}.carbon_forest_litter + 
+${TableNames.carbonStock}.carbon_forest_soil
+      `,
+      calculationDependencies: [
+        { tableName: TableNames.carbonStock, variableName: 'carbon_forest_above_ground' },
+        { tableName: TableNames.carbonStock, variableName: 'carbon_forest_below_ground' },
+        { tableName: TableNames.carbonStock, variableName: 'carbon_forest_deadwood' },
+        { tableName: TableNames.carbonStock, variableName: 'carbon_forest_litter' },
+        { tableName: TableNames.carbonStock, variableName: 'carbon_forest_soil' },
+      ],
+    },
+  ],
+  '2025': (region: boolean) => [
+    {
+      id: 1,
+      variableName: 'forest',
+      label: {
+        key: 'statisticalFactsheets.carbonAndGrowingStock.growing_stock_total',
+        params: { unit: region ? 'unit.billionCubicMeter' : 'unit.millionsCubicMeterOverBark' },
+      },
+      calculateFn: 'growingStockTotal.forest',
+      calculationDependencies: [{ tableName: 'growingStockTotal', variableName: 'forest' }],
+    },
+    {
+      id: 2,
+      variableName: 'carbonStockBiomassTotal',
+      label: {
+        key: 'statisticalFactsheets.carbonAndGrowingStock.carbon_stock_biomass_total',
+        params: { unit: region ? 'unit.gt' : 'unit.tonnesPerHa' },
+      },
+      calculateFn: `${TableNames.carbonStockAvg}.carbon_forest_above_ground + ${TableNames.carbonStockAvg}.carbon_forest_below_ground `,
+      calculationDependencies: [
+        { tableName: TableNames.carbonStockAvg, variableName: 'carbon_forest_above_ground' },
+        { tableName: TableNames.carbonStockAvg, variableName: 'carbon_forest_below_ground' },
+      ],
+    },
+    {
+      id: 3,
+      variableName: 'carbonStockTotal',
+      label: {
+        key: 'statisticalFactsheets.carbonAndGrowingStock.carbon_stock_total',
+        params: { unit: region ? 'unit.gt' : 'unit.tonnesPerHa' },
+      },
+      calculateFn: `${TableNames.carbonStockAvg}.carbon_forest_above_ground + ${TableNames.carbonStockAvg}.carbon_forest_below_ground + ${TableNames.carbonStockAvg}.carbon_forest_deadwood + ${TableNames.carbonStockAvg}.carbon_forest_litter + ${TableNames.carbonStockAvg}.carbon_forest_soil`,
+      calculationDependencies: [
+        { tableName: TableNames.carbonStockAvg, variableName: 'carbon_forest_above_ground' },
+        { tableName: TableNames.carbonStockAvg, variableName: 'carbon_forest_below_ground' },
+        { tableName: TableNames.carbonStockAvg, variableName: 'carbon_forest_deadwood' },
+        { tableName: TableNames.carbonStockAvg, variableName: 'carbon_forest_litter' },
+        { tableName: TableNames.carbonStockAvg, variableName: 'carbon_forest_soil' },
+      ],
+    },
+  ],
+}
+
+export const forestGrowingStockAndCarbonDashboard = (cycle: Cycle, region: boolean): DashboardTable => ({
+  type: DashboardItemType.table,
+  title: {
+    key: 'statisticalFactsheets.carbonAndGrowingStock.title',
+    params: { startYear: cols[cycle.name].at(0), endYear: cols[cycle.name].at(-1) },
+  },
+  table: getTable({ cycle, cols: cols[cycle.name], tableId, rowMetadata: rowMetadata[cycle.name](region), tableName }),
+})

--- a/src/test/migrations/steps/metadata/dashboard/forestOwnership/index.ts
+++ b/src/test/migrations/steps/metadata/dashboard/forestOwnership/index.ts
@@ -1,0 +1,49 @@
+import { Cycle, CycleName, Unit } from 'meta/assessment'
+import { ChartColor } from 'meta/chart'
+import { DashboardItemType, DashboardPieChart } from 'meta/dashboard'
+
+import { getTable, RowsMetadata } from '../utils'
+
+const tableId = 6
+const tableName = 'forestOwnership'
+
+const variableNames: Array<{ variableName: string; color: ChartColor; cycleName?: CycleName }> = [
+  { variableName: 'private_ownership', color: ChartColor.private },
+  { variableName: 'public_ownership', color: ChartColor.public },
+  { variableName: 'other', color: ChartColor.otherLand, cycleName: '2025' },
+  { variableName: 'unknown', color: ChartColor.unknown, cycleName: '2025' },
+  { variableName: 'other_or_unknown', color: ChartColor.otherLand, cycleName: '2020' },
+]
+
+const cols: Record<CycleName, Array<string>> = {
+  '2020': ['2015'],
+  '2025': ['2020'],
+}
+
+export const forestOwnership = (cycle: Cycle, region: boolean): DashboardPieChart => {
+  const columnName = cols[cycle.name][0]
+  const variables = variableNames.filter(({ cycleName }) => !cycleName || cycleName === cycle.name)
+
+  const rowMetadata: RowsMetadata = variables.map(({ variableName }) => ({
+    id: 1,
+    variableName,
+    label: { key: `statisticalFactsheets.rowName.${variableName}` },
+    calculateFn: `${tableName}.${variableName} ${region ? '/ 1000' : ''}`,
+    calculationDependencies: [{ tableName, variableName }],
+  }))
+
+  return {
+    type: DashboardItemType.pieChart,
+    title: { key: 'statisticalFactsheets.forestOwnership.title', params: { year: columnName } },
+    table: getTable({ cycle, cols: cols[cycle.name], tableId, rowMetadata, tableName }),
+    chart: {
+      cells: variables.map(({ variableName, color }) => ({
+        variableName,
+        color,
+        columnName,
+        label: { key: `statisticalFactsheets.rowName.${variableName}` },
+        unit: `unit.${Unit.haThousand}`,
+      })),
+    },
+  }
+}

--- a/src/test/migrations/steps/metadata/dashboard/naturallyRegeneratingForestArea/index.ts
+++ b/src/test/migrations/steps/metadata/dashboard/naturallyRegeneratingForestArea/index.ts
@@ -1,0 +1,58 @@
+import { Cycle, TableNames, Unit } from 'meta/assessment'
+import { ChartColor } from 'meta/chart'
+import { DashboardBarChart, DashboardItemType } from 'meta/dashboard'
+
+import type { RowsMetadata } from '../utils'
+import { getTable } from '../utils'
+
+const commonColumns = ['1990', '2000', '2010', '2020']
+
+const cols: Record<string, Array<string>> = {
+  '2020': commonColumns,
+  '2025': [...commonColumns, '2025'],
+}
+
+const tableName = TableNames.forestCharacteristics
+const tableId = 8
+export const naturallyRegeneratingForestArea = (cycle: Cycle, region: boolean): DashboardBarChart => {
+  const cells = [
+    {
+      variableName: 'naturalForestArea',
+      color: ChartColor.green,
+      unit: `unit.${Unit.haThousand}`,
+      label: { key: 'statisticalFactsheets.rowName.naturalForestArea' },
+    },
+    {
+      variableName: 'plantedForest',
+      color: ChartColor.forestPlanted,
+      unit: `unit.${Unit.haThousand}`,
+      label: { key: 'statisticalFactsheets.rowName.plantedForest' },
+    },
+  ]
+  const rowMetadata = (region: boolean): RowsMetadata => {
+    return [
+      ...cells.map(({ variableName }, i) => ({
+        id: i + 1,
+        variableName,
+        label: { key: `statisticalFactsheets.rowName.${variableName}` },
+        calculateFn: `${tableName}.${variableName} ${region ? '/ 1000' : ''}`,
+        calculationDependencies: [{ tableName, variableName }],
+      })),
+    ]
+  }
+
+  return {
+    type: DashboardItemType.barChart,
+    title: {
+      key: 'statisticalFactsheets.naturallyRegeneratingForest.title',
+      params: { startYear: cols[cycle.name].at(0), endYear: cols[cycle.name].at(-1), unit: `unit.${Unit.haThousand}` },
+    },
+    table: getTable({ cycle, cols: cols[cycle.name], tableId, rowMetadata: rowMetadata(region), tableName }),
+    chart: {
+      columns: cols[cycle.name],
+      cells,
+      xAxis: { label: { key: 'common.year' } },
+      yAxis: { label: { key: `unit.${Unit.haThousand}` } },
+    },
+  }
+}

--- a/src/test/migrations/steps/metadata/dashboard/primaryDesignatedManagementObjective/index.ts
+++ b/src/test/migrations/steps/metadata/dashboard/primaryDesignatedManagementObjective/index.ts
@@ -1,0 +1,53 @@
+import { Cycle } from 'meta/assessment'
+import { DashboardItemType, DashboardTable } from 'meta/dashboard'
+
+import { getTable, RowsMetadata } from '../utils'
+
+const cols: Record<string, Array<string>> = {
+  '2020': ['1990', '2000', '2010', '2020'],
+  '2025': ['1990', '2000', '2010', '2020', '2025'],
+}
+
+const baseVariables = [
+  'production',
+  'multiple_use',
+  'conservation_of_biodiversity',
+  'protection_of_soil_and_water',
+  'social_services',
+  'other',
+]
+
+const variables: Record<string, Array<string>> = {
+  '2020': baseVariables,
+  '2025': [...baseVariables, 'no_designation', 'unknown'],
+}
+
+const tableName = 'primaryDesignatedManagementObjective'
+const tableId = 7
+
+const rowMetadata = (cycle: Cycle, region: boolean): RowsMetadata =>
+  variables[cycle.name].map((variableName, i) => ({
+    id: i + 1,
+    variableName,
+    label: {
+      key: `statisticalFactsheets.primaryDesignatedManagementObjective.${variableName}`,
+      params: {
+        unit: 'unit.haThousand',
+      },
+    },
+    calculateFn: `${tableName}.${variableName} ${region ? '/ 1000' : ''}`,
+    calculationDependencies: [{ tableName, variableName }],
+  }))
+
+export const primaryDesignatedManagementObjectiveDashboard = (cycle: Cycle, region: boolean): DashboardTable => ({
+  type: DashboardItemType.table,
+  title: {
+    key: 'statisticalFactsheets.primaryDesignatedManagementObjective.title',
+    params: {
+      startYear: cols[cycle.name].at(0),
+      endYear: cols[cycle.name].at(-1),
+      unit: 'unit.haThousand',
+    },
+  },
+  table: getTable({ cycle, cols: cols[cycle.name], tableId, rowMetadata: rowMetadata(cycle, region), tableName }),
+})

--- a/src/test/migrations/steps/metadata/dashboard/primaryForestPercentOfForestArea/index.ts
+++ b/src/test/migrations/steps/metadata/dashboard/primaryForestPercentOfForestArea/index.ts
@@ -1,0 +1,105 @@
+import { Cycle, TableNames, Unit } from 'meta/assessment'
+import { ChartColor } from 'meta/chart'
+import { DashboardItemType, DashboardPieChart } from 'meta/dashboard'
+
+import { getTable, RowsMetadata } from '../utils'
+
+const cols: Record<string, Array<string>> = {
+  '2020': ['2020'],
+  '2025': ['2025'],
+}
+
+const tableId = 4
+const tableNames: Record<string, TableNames> = {
+  '2020': TableNames.specificForestCategories,
+  '2025': TableNames.forestCharacteristics,
+}
+
+const variableNames: Record<string, string> = {
+  '2020': 'primary_forest',
+  '2025': 'primaryForest',
+}
+
+export const primaryForestPercentOfForestArea = (cycle: Cycle, region: boolean): DashboardPieChart => {
+  const columnName = cols[cycle.name][0]
+  const tableName = tableNames[cycle.name]
+  const variableName = variableNames[cycle.name]
+
+  // const calculateFnPrimaryForest = `100 * (${tableName}.${variableName} / ${TableNames.extentOfForest}.forestArea)`
+  // const calculateFnOtherLand = `100 - (100 * (${tableName}.${variableName} / ${TableNames.extentOfForest}.forestArea))`
+
+  const rowMetadata: Record<string, RowsMetadata> = {
+    '2020': [
+      {
+        id: 1,
+        variableName,
+        label: { key: `statisticalFactsheets.rowName.primaryForest` },
+        calculateFn: `${tableName}.${variableName} ${region ? '/ 1000' : ''}`,
+        calculationDependencies: [
+          { tableName, variableName },
+          { tableName: TableNames.extentOfForest, variableName: 'forestArea' },
+        ],
+      },
+      {
+        id: 2,
+        variableName: 'otherLand',
+        label: { key: `statisticalFactsheets.rowName.otherArea` },
+        calculateFn: `${TableNames.extentOfForest}.forestArea ${
+          region ? '/ 1000' : ''
+        } - ${tableName}.${variableName} ${region ? '/ 1000' : ''}`,
+        calculationDependencies: [
+          { tableName, variableName },
+          { tableName: TableNames.extentOfForest, variableName: 'forestArea' },
+        ],
+      },
+    ],
+    '2025': [
+      {
+        id: 1,
+        variableName: 'primaryForest',
+        label: { key: `statisticalFactsheets.rowName.primaryForest` },
+        calculateFn: `${tableName}.${variableName} ${region ? '/ 1000' : ''}`,
+        calculationDependencies: [
+          { tableName, variableName },
+          { tableName: TableNames.extentOfForest, variableName: 'forestArea' },
+        ],
+      },
+      {
+        id: 2,
+        variableName: 'otherLand',
+        label: { key: `statisticalFactsheets.rowName.otherArea` },
+        calculateFn: `${TableNames.extentOfForest}.forestArea ${
+          region ? '/ 1000' : ''
+        } - ${tableName}.${variableName} ${region ? '/ 1000' : ''}`,
+        calculationDependencies: [
+          { tableName, variableName },
+          { tableName: TableNames.extentOfForest, variableName: 'forestArea' },
+        ],
+      },
+    ],
+  }
+
+  return {
+    type: DashboardItemType.pieChart,
+    title: { key: 'statisticalFactsheets.primaryForest.title', params: { year: cols[cycle.name].at(0) } },
+    table: getTable({ cycle, cols: cols[cycle.name], tableId, rowMetadata: rowMetadata[cycle.name], tableName }),
+    chart: {
+      cells: [
+        {
+          variableName,
+          color: ChartColor.forestLight,
+          columnName,
+          label: { key: 'statisticalFactsheets.rowName.primaryForest' },
+          unit: `unit.${Unit.haThousand}`,
+        },
+        {
+          variableName: 'otherLand',
+          color: ChartColor.otherLand,
+          columnName,
+          label: { key: 'statisticalFactsheets.rowName.otherForest' },
+          unit: `unit.${Unit.haThousand}`,
+        },
+      ],
+    },
+  }
+}

--- a/src/test/migrations/steps/metadata/dashboard/utils/index.ts
+++ b/src/test/migrations/steps/metadata/dashboard/utils/index.ts
@@ -1,0 +1,155 @@
+import { UUIDs } from 'utils/uuids'
+
+import { Col, ColStyle, ColType, Cycle, CycleUuid, Label, Row, RowType, Table, VariableCache } from 'meta/assessment'
+
+export type RowMetadata = {
+  id: number
+  label: Label
+  variableName: string
+  calculateFn: string
+  calculationDependencies: Array<VariableCache>
+}
+
+export type RowsMetadata = Array<RowMetadata>
+
+const getStyle = (cycle: Cycle): Record<CycleUuid, ColStyle> => {
+  return {
+    [cycle.uuid]: {
+      colSpan: 1,
+      rowSpan: 1,
+    },
+  }
+}
+
+const getCols = (cycle: Cycle, cols: Array<string>, rowId: number): Array<Col> => {
+  return cols.map((col) => {
+    return {
+      rowId,
+      props: {
+        cycles: [cycle.uuid],
+        colName: col,
+        colType: ColType.decimal,
+        style: getStyle(cycle),
+      },
+      uuid: UUIDs.v4(),
+    }
+  })
+}
+
+const getHeaderRow = (cycle: Cycle, cols: Array<string>, tableId: number): Row => {
+  return {
+    cols: [
+      {
+        rowId: 1,
+        props: {
+          colType: ColType.header,
+          cycles: [cycle.uuid],
+          index: 0,
+          style: getStyle(cycle),
+        },
+        uuid: UUIDs.v4(),
+      },
+      ...cols.map((colName, index) => {
+        return {
+          rowId: 1,
+          props: {
+            index: index + 1,
+            cycles: [cycle.uuid],
+            colName,
+            colType: ColType.header,
+            style: getStyle(cycle),
+          },
+          uuid: UUIDs.v4(),
+        }
+      }),
+    ],
+    id: 1,
+    props: {
+      type: RowType.header,
+      index: 'header_1',
+      cycles: [cycle.uuid],
+    },
+    tableId,
+    uuid: UUIDs.v4(),
+  }
+}
+
+type GetRowsProps = { cycle: Cycle; cols: Array<string>; tableId: number; rowMetadata: RowsMetadata }
+export const getRows = (props: GetRowsProps): Array<Row> => {
+  const { cycle, cols, tableId, rowMetadata } = props
+  const headerRow: Row = getHeaderRow(cycle, cols, tableId)
+
+  const _getRow = (row: RowMetadata): Row => {
+    return {
+      cols: [
+        {
+          rowId: row.id,
+          props: {
+            colType: ColType.header,
+            cycles: [cycle.uuid],
+            index: 'header_0',
+            labels: {
+              [cycle.uuid]: row.label,
+            },
+            style: getStyle(cycle),
+          },
+          uuid: UUIDs.v4(),
+        },
+        ...getCols(cycle, cols, row.id),
+      ],
+      id: row.id,
+      props: {
+        type: RowType.data,
+        index: row.id,
+        cycles: [cycle.uuid],
+        readonly: false,
+        variableName: row.variableName,
+        calculateFn: {
+          [cycle.uuid]: row.calculateFn,
+        },
+      },
+      tableId,
+      uuid: UUIDs.v4(),
+    }
+  }
+
+  return [headerRow, ...rowMetadata.map(_getRow)]
+}
+
+export const getCalculationDependencies = (rowMetadata: RowsMetadata): Record<string, VariableCache[]> => {
+  const r: Record<string, VariableCache[]> = {}
+  rowMetadata.forEach((row) => {
+    r[row.variableName] = row.calculationDependencies
+  })
+  return r
+}
+
+type GetTableProps = {
+  cycle: Cycle
+  cols: Array<string>
+  tableId: number
+  rowMetadata: RowsMetadata
+  tableName: string
+}
+export const getTable = (props: GetTableProps): Table => {
+  const { cycle, cols, tableId, rowMetadata, tableName } = props
+  const table: Table = {
+    id: tableId,
+    tableSectionId: -1,
+    calculationDependencies: getCalculationDependencies(rowMetadata),
+    props: {
+      odp: false,
+      readonly: true,
+      name: tableName + cycle.name,
+      cycles: [cycle.uuid],
+      dataExport: true,
+      columnNames: {
+        [cycle.uuid]: cols,
+      },
+    },
+    rows: getRows({ cycle, cols, tableId, rowMetadata }),
+    uuid: UUIDs.v4(),
+  }
+
+  return table
+}


### PR DESCRIPTION
- Metadata copied from `Overview/`
- Next pr will remove old metadata from `Overview/`
- migration metadata only change is updated imports and removed function call(s) (eg. util `unit()`)

![kuva](https://github.com/user-attachments/assets/53d2db88-f7fd-4e08-82b9-17b8f7d394eb)
