### PR TITLE
4032 - UserInvitations and subcomponents

### DIFF
--- a/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/Buttons.tsx
+++ b/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/Buttons.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+import { UserInvitationSummary } from 'meta/user'
+
+import Resend from './Resend/Resend'
+// import Information from './Information'
+import Remove from './Remove'
+
+type Props = {
+  invitationSummary: UserInvitationSummary
+}
+
+const Buttons: React.FC<Props> = (props: Props) => {
+  const { invitationSummary } = props
+  return (
+    <div className="button-container">
+      {/* <Information invitationSummary={invitationSummary} /> */}
+      <Resend invitationSummary={invitationSummary} />
+      <Remove invitationSummary={invitationSummary} />
+    </div>
+  )
+}
+
+export default Buttons

--- a/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/Remove/Remove.tsx
+++ b/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/Remove/Remove.tsx
@@ -1,0 +1,43 @@
+import React, { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { TooltipId } from 'meta/tooltip'
+import { UserInvitationSummary } from 'meta/user'
+
+import { useUser } from 'client/store/user'
+import { useToaster } from 'client/hooks/useToaster'
+import Icon from 'client/components/Icon'
+
+import { useRemoveInvitation } from './hooks/useRemoveInvitation'
+
+interface Props {
+  invitationSummary: UserInvitationSummary
+}
+
+const Remove: React.FC<Props> = (props: Props) => {
+  const { invitationSummary } = props
+  const { t } = useTranslation()
+  const { toaster } = useToaster()
+  const currentUser = useUser()
+
+  const callback = useCallback(() => {
+    toaster.success(t('userManagement.invitationDeleted'))
+  }, [toaster, t])
+
+  const removeInvitation = useRemoveInvitation({ invitationSummary, callback })
+
+  return (
+    <button
+      className="btn-s btn-link-destructive"
+      data-tooltip-content={t('userManagement.remove')}
+      data-tooltip-id={TooltipId.error}
+      disabled={currentUser.uuid === invitationSummary.userUuid}
+      onClick={removeInvitation}
+      type="button"
+    >
+      <Icon name="trash-simple" />
+    </button>
+  )
+}
+
+export default Remove

--- a/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/Remove/hooks/useRemoveInvitation.ts
+++ b/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/Remove/hooks/useRemoveInvitation.ts
@@ -1,0 +1,31 @@
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { CountryIso } from 'meta/area'
+import { UserInvitationSummary } from 'meta/user'
+
+import { useAppDispatch } from 'client/store'
+import { UserManagementActions } from 'client/store/ui/userManagement'
+import { useCountryRouteParams } from 'client/hooks/useRouteParams'
+
+type Props = {
+  invitationSummary: UserInvitationSummary
+  callback: () => void
+}
+
+export const useRemoveInvitation = (props: Props) => {
+  const { invitationSummary, callback } = props
+  const { uuid: invitationUuid, name: user } = invitationSummary
+  const { assessmentName, cycleName, countryIso } = useCountryRouteParams<CountryIso>()
+
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+
+  return useCallback(() => {
+    // eslint-disable-next-line no-alert
+    if (window.confirm(t('userManagement.confirmDelete', { user }))) {
+      const params = { assessmentName, cycleName, countryIso, invitationUuid }
+      dispatch(UserManagementActions.removeInvitation(params)).then(callback)
+    }
+  }, [t, invitationUuid, user, dispatch, assessmentName, cycleName, countryIso, callback])
+}

--- a/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/Remove/index.ts
+++ b/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/Remove/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Remove'

--- a/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/Resend/Resend.tsx
+++ b/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/Resend/Resend.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { TooltipId } from 'meta/tooltip'
+import { UserInvitations, UserInvitationSummary } from 'meta/user'
+
+import Icon from 'client/components/Icon'
+
+import { useResendInvitation } from '../hooks/useResendInvitation'
+
+interface Props {
+  invitationSummary: UserInvitationSummary
+}
+
+const Information: React.FC<Props> = (props: Props) => {
+  const { invitationSummary } = props
+  const { resendInvitation, isLoading } = useResendInvitation({ invitationSummary })
+
+  const { t } = useTranslation()
+
+  if (!UserInvitations.isExpired(invitationSummary)) {
+    return null
+  }
+
+  return (
+    <button
+      className="btn-s btn-link"
+      data-tooltip-content={t('userManagement.inviteAgain')}
+      data-tooltip-id={TooltipId.info}
+      disabled={isLoading}
+      onClick={resendInvitation}
+      type="button"
+    >
+      <Icon name="icon-paper-plane" />
+    </button>
+  )
+}
+
+export default Information

--- a/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/Resend/index.ts
+++ b/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/Resend/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Resend'

--- a/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/hooks/useResendInvitation.ts
+++ b/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/hooks/useResendInvitation.ts
@@ -1,0 +1,45 @@
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { CountryIso } from 'meta/area'
+import { UserInvitationSummary } from 'meta/user'
+
+import { useAppDispatch } from 'client/store'
+import { UserManagementActions } from 'client/store/ui/userManagement'
+import { useCountryRouteParams } from 'client/hooks/useRouteParams'
+import { useToaster } from 'client/hooks/useToaster'
+
+type Props = {
+  invitationSummary: UserInvitationSummary
+  callback?: () => void
+}
+
+type Returned = {
+  resendInvitation: () => void
+  isLoading: boolean
+}
+
+export const useResendInvitation = (props: Props): Returned => {
+  const { invitationSummary, callback } = props
+  const { uuid: invitationUuid } = invitationSummary
+  const { assessmentName, cycleName, countryIso } = useCountryRouteParams<CountryIso>()
+
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+
+  const { t } = useTranslation()
+  const { toaster } = useToaster()
+
+  const dispatch = useAppDispatch()
+
+  const resendInvitation = useCallback(() => {
+    setIsLoading(true)
+    const params = { assessmentName, countryIso, cycleName, invitationUuid }
+    dispatch(UserManagementActions.sendInvitationEmail(params)).then(() => {
+      toaster.success(t('userManagement.invitationEmailSent'))
+      setIsLoading(false)
+      callback?.()
+    })
+  }, [dispatch, assessmentName, countryIso, cycleName, invitationUuid, toaster, t, callback])
+
+  return { resendInvitation, isLoading }
+}

--- a/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/index.ts
+++ b/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Buttons/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Buttons'

--- a/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Info/Info.tsx
+++ b/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Info/Info.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import classNames from 'classnames'
+
+import { TooltipId } from 'meta/tooltip'
+import { UserInvitations as UserInvitationMeta, UserInvitationSummary } from 'meta/user'
+
+import Icon from 'client/components/Icon'
+
+type Props = {
+  userInvitation: UserInvitationSummary
+}
+
+const Info: React.FC<Props> = (props: Props) => {
+  const { userInvitation } = props
+
+  const { t } = useTranslation()
+
+  const expired = UserInvitationMeta.isExpired(userInvitation)
+  if (!expired) return null
+
+  return (
+    <div data-tooltip-content={t('login.invitationExpired')} data-tooltip-id={TooltipId.error}>
+      <Icon className={classNames({ expired })} name="round-e-info" />
+    </div>
+  )
+}
+
+export default Info

--- a/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Info/index.ts
+++ b/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/Info/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Info'

--- a/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/UserInvitations.scss
+++ b/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/UserInvitations.scss
@@ -7,4 +7,22 @@
   .btn-invite {
     margin: $spacing-xs $spacing-xs $spacing-xs auto;
   }
+
+  .data-grid-column {
+    display: flex;
+    align-items: center;
+  }
+
+  .invitation {
+    color: $text-disabled;
+  }
+
+  .expired {
+    color: lighten($ui-destructive, 40%);
+  }
+
+  .button-container {
+    position: relative;
+    margin-left: auto;
+  }
 }

--- a/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/UserInvitations.tsx
+++ b/src/client/pages/CountryHome/Collaborators/UserList/UserInvitations/UserInvitations.tsx
@@ -1,12 +1,81 @@
 import './UserInvitations.scss'
-import React from 'react'
+import React, { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 
+import classNames from 'classnames'
+
+import { ApiEndPoint } from 'meta/api/endpoint'
+import { UserInvitations as UserInvitationMeta, UserInvitationSummary, Users } from 'meta/user'
+
+import TablePaginated, { Column } from 'client/components/TablePaginated'
+
+import Buttons from './Buttons'
+import Info from './Info'
 import Invite from './Invite'
 
+const useColumns = (): Array<Column<UserInvitationSummary>> => {
+  const { t } = useTranslation()
+
+  const className = 'invitation'
+
+  return useMemo<Array<Column<UserInvitationSummary>>>(
+    () => [
+      {
+        header: '',
+        key: 'info',
+        component: ({ datum }) => <Info userInvitation={datum} />,
+      },
+      {
+        component: ({ datum }) => (
+          <span className={classNames(className, { expired: UserInvitationMeta.isExpired(datum) })}>{datum.name}</span>
+        ),
+        header: t('common.name'),
+        key: 'name',
+        orderByProperty: 'u.name',
+      },
+      {
+        component: ({ datum }) => (
+          <span className={classNames(className, { expired: UserInvitationMeta.isExpired(datum) })}>
+            {t(Users.getI18nRoleLabelKey(datum.role))}
+          </span>
+        ),
+        header: t('common.role'),
+        key: 'role',
+        orderByProperty: 'role',
+      },
+      {
+        component: ({ datum }) => (
+          <span className={classNames(className, { expired: UserInvitationMeta.isExpired(datum) })}>{datum.email}</span>
+        ),
+        header: t('common.email'),
+        key: 'email',
+        orderByProperty: 'u.email',
+      },
+      {
+        header: '',
+        key: 'actions',
+        component: ({ datum }) => <Buttons invitationSummary={datum} />,
+      },
+    ],
+    [t]
+  )
+}
+
 const UserInvitations: React.FC = () => {
+  const columns = useColumns()
+
+  const len = columns.length - 1
+  const gridTemplateColumns = `32px repeat(${len}, auto)`
+
   return (
     <div className="user-invitations">
       <Invite />
+      <TablePaginated
+        columns={columns}
+        counter={{ show: false }}
+        gridTemplateColumns={gridTemplateColumns}
+        path={ApiEndPoint.User.invitations()}
+      />
     </div>
   )
 }


### PR DESCRIPTION
Note: Next PR: Invitation Popup and update store with invitation actions (e.g. update information -> refetch, delete -> update store)

![image](https://github.com/user-attachments/assets/20ec8cfc-5fc9-4f7b-a5cf-680ed3c18683)
