### PR TITLE
4032 - Fix assessment UUID comparison

### DIFF
--- a/src/meta/user/userRoles.ts
+++ b/src/meta/user/userRoles.ts
@@ -37,9 +37,7 @@ const getLastRole = (params: { assessment?: Assessment; user: User }) => {
 
   if (!user || !user.roles) return undefined
 
-  const roles = assessment
-    ? user.roles.filter((role) => Number(role.assessmentUuid) === Number(assessment?.uuid))
-    : user.roles
+  const roles = assessment ? user.roles.filter((role) => role.assessmentUuid === assessment?.uuid) : user.roles
 
   if (roles.length === 1) return roles[0]
 

--- a/src/meta/user/users.ts
+++ b/src/meta/user/users.ts
@@ -63,7 +63,7 @@ const hasEditorRole = (props: { user: User; countryIso: AreaCode; cycle: Cycle }
 const hasRoleInAssessment = (props: { user: User; assessment: Assessment }): boolean => {
   const { assessment, user } = props
   if (isAdministrator(user)) return true
-  return user?.roles?.some((role) => Number(role.assessmentUuid) === Number(assessment.uuid))
+  return user?.roles?.some((role) => role.assessmentUuid === assessment.uuid)
 }
 
 const hasRoleInCycle = (props: { user: User; cycle: Cycle }): boolean => {


### PR DESCRIPTION
Noticed a typo in comparing assessment uuid

We used to have `id` comparison, but now we are comparing using `uuid`.