### PR TITLE
4032 - Fix Messageboard and country status change recipients

### DIFF
--- a/src/client/components/PageLayout/Toolbar/Status/StatusConfirm/UserList/UserList.tsx
+++ b/src/client/components/PageLayout/Toolbar/Status/StatusConfirm/UserList/UserList.tsx
@@ -2,32 +2,32 @@ import './UserList.scss'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { User, Users } from 'meta/user'
+import { CountryUserSummary, Users } from 'meta/user'
 
 import { useCycle } from 'client/store/assessment'
 import { useCountryRouteParams } from 'client/hooks/useRouteParams'
 import { DataCell, DataGrid } from 'client/components/DataGrid'
 
 interface Props {
-  users: Array<User>
+  users: Array<CountryUserSummary>
 }
 
 interface CellProps {
-  user: User
+  countryUserSummary: CountryUserSummary
 }
 
-const NameCell: React.FC<CellProps> = ({ user }) => <span>{Users.getFullName(user)}</span>
+const NameCell: React.FC<CellProps> = ({ countryUserSummary }) => <span>{countryUserSummary.fullName}</span>
 
-const RoleCell: React.FC<CellProps> = ({ user }) => {
+const RoleCell: React.FC<CellProps> = ({ countryUserSummary }) => {
   const { t } = useTranslation()
   const { countryIso } = useCountryRouteParams()
   const cycle = useCycle()
-  const role = Users.getRole(user, countryIso, cycle)
+  const role = Users.getRole(countryUserSummary, countryIso, cycle)
   const key = Users.getI18nRoleLabelKey(role.role)
   return <span>{t(key)}</span>
 }
 
-const EmailCell: React.FC<CellProps> = ({ user }) => <span>{user.email}</span>
+const EmailCell: React.FC<CellProps> = ({ countryUserSummary }) => <span>{countryUserSummary.email}</span>
 
 const Components: Record<string, React.FC<CellProps>> = {
   name: NameCell,
@@ -51,12 +51,12 @@ const UserList: React.FC<Props> = (props: Props) => {
           </DataCell>
         )
       })}
-      {users.map((user, j) => {
+      {users.map((countryUserSummary, j) => {
         const lastRow = users.length - 1 === j
         return headers.map((header) => {
           return (
-            <DataCell key={`${user.email}-${header}`} lastRow={lastRow}>
-              {React.createElement(Components[header], { user })}
+            <DataCell key={`${countryUserSummary.email}-${header}`} lastRow={lastRow}>
+              {React.createElement(Components[header], { countryUserSummary })}
             </DataCell>
           )
         })

--- a/src/client/pages/CountryHome/FraHome/CountryMessageBoard/MessageBoard.tsx
+++ b/src/client/pages/CountryHome/FraHome/CountryMessageBoard/MessageBoard.tsx
@@ -8,6 +8,9 @@ import { useCountryIso } from 'client/hooks'
 
 import MessageButton from './MessageButton'
 
+/**
+ * @deprecated
+ */
 const MessageBoard: React.FC = () => {
   const countryIso = useCountryIso()
 

--- a/src/client/pages/CountryHome/FraHome/CountryMessageBoard/MessageBoardUsers.tsx
+++ b/src/client/pages/CountryHome/FraHome/CountryMessageBoard/MessageBoardUsers.tsx
@@ -38,7 +38,7 @@ const MessageBoardUsers: React.FC = () => {
               <img alt="" className="landing__user-avatar" src={ApiEndPoint.User.profilePicture(String(_user.id))} />
               <div className="landing__user-info">
                 <div className={classNames('landing__user-name', { 'session-user': user.id === _user.id })}>
-                  {Users.getFullName(_user)}
+                  {_user.fullName}
                 </div>
                 <div className="landing__user-role">
                   {t(Users.getI18nRoleLabelKey(Users.getRole(_user, countryIso, cycle)?.role))}
@@ -47,7 +47,7 @@ const MessageBoardUsers: React.FC = () => {
                   <MessageButton
                     topicKey={Topics.getMessageBoardChatKey(user, _user)}
                     topicSubtitle={t('landing.users.message')}
-                    topicTitle={Users.getFullName(_user)}
+                    topicTitle={_user.fullName}
                     topicType={MessageTopicType.chat}
                   />
                 )}

--- a/src/client/pages/CountryHome/FraHome/CountryMessageBoard/hooks/useMessageBoardUsers.tsx
+++ b/src/client/pages/CountryHome/FraHome/CountryMessageBoard/hooks/useMessageBoardUsers.tsx
@@ -1,23 +1,22 @@
 import { useMemo } from 'react'
 
-import { User, Users } from 'meta/user'
-import { UserRoles } from 'meta/user/userRoles'
+import { CountryUserSummary, Users } from 'meta/user'
 
 import { useCycle } from 'client/store/assessment'
 import { useUsers } from 'client/store/ui/userManagement'
 import { useCountryRouteParams } from 'client/hooks/useRouteParams'
 
-export const useMessageBoardUsers = (): Array<User> => {
+export const useMessageBoardUsers = (): Array<CountryUserSummary> => {
   const { countryIso } = useCountryRouteParams()
   const cycle = useCycle()
   const users = useUsers()
 
-  return useMemo<Array<User>>(
+  return useMemo<Array<CountryUserSummary>>(
     () =>
       users.filter((user) => {
         const role = Users.getRole(user, countryIso, cycle)
         if (!role) return false
-        return !(Users.isAdministrator(user) || UserRoles.isInvitationPending(role))
+        return !Users.isAdministrator(user)
       }),
     [countryIso, cycle, users]
   )

--- a/src/client/store/ui/userManagement/hooks/index.ts
+++ b/src/client/store/ui/userManagement/hooks/index.ts
@@ -1,7 +1,10 @@
-import { User } from 'meta/user'
+import { CountryUserSummary, User } from 'meta/user'
 
 import { useAppSelector } from 'client/store/store'
 
 export const useUserToEdit = (): User => useAppSelector((state) => state.ui.userManagement.user)
 
-export const useUsers = (): Array<User> => useAppSelector((state) => state.ui.userManagement.users)
+/**
+ * @deprecated
+ */
+export const useUsers = (): Array<CountryUserSummary> => useAppSelector((state) => state.ui.userManagement.users)

--- a/src/client/store/ui/userManagement/slice.ts
+++ b/src/client/store/ui/userManagement/slice.ts
@@ -34,7 +34,7 @@ export const userManagementSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder.addCase(removeInvitation.fulfilled, (state, { payload }) => {
-      const i = state.users.findIndex((u) => u.id === payload.userId)
+      const i = state.users.findIndex((u) => u.uuid === payload.userUuid)
       if (i !== -1) state.users.splice(i, 1)
     })
 
@@ -47,7 +47,7 @@ export const userManagementSlice = createSlice({
     })
 
     builder.addCase(sendInvitationEmail.fulfilled, (state, { payload }) => {
-      const i = state.users.findIndex((u) => u.id === payload.userId)
+      const i = state.users.findIndex((u) => u.uuid === payload.userUuid)
       if (i !== -1) state.users[i].roles = [payload]
     })
 

--- a/src/client/store/ui/userManagement/stateType.ts
+++ b/src/client/store/ui/userManagement/stateType.ts
@@ -1,6 +1,9 @@
-import { User } from 'meta/user'
+import { CountryUserSummary, User } from 'meta/user'
 
 export interface UserManagementState {
   user?: User
-  users: Array<User>
+  /**
+   * @deprecated
+   */
+  users: Array<CountryUserSummary>
 }


### PR DESCRIPTION
Deprecate useUsers and userManagement state:

Usage for `useUsers`:

src/client/pages/CountryHome/FraHome/CountryMessageBoard/hooks/useMessageBoardUsers.tsx (merge to collaborators)
src/client/components/PageLayout/Toolbar/Status/StatusConfirm/hooks/useRecipients.ts (use tablePaginated)
