### PR TITLE
Fix Postgres tools version mismatch

### DIFF
--- a/.github/workflows/heroku-db-partial-backup.yml
+++ b/.github/workflows/heroku-db-partial-backup.yml
@@ -28,7 +28,10 @@ jobs:
       - name: Install PostgreSQL client and GPG
         run: |
           sudo apt-get update
-          sudo apt-get install -y postgresql-client gnupg
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get install -y postgresql-15 gnupg
 
       - name: Create Custom Database Backup
         env:

--- a/.github/workflows/heroku-db-partial-backup.yml
+++ b/.github/workflows/heroku-db-partial-backup.yml
@@ -31,7 +31,7 @@ jobs:
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get install -y postgresql-15 gnupg
+          sudo apt-get install -y postgresql-client-15 gnupg
 
       - name: Create Custom Database Backup
         env:

--- a/.github/workflows/heroku-db-partial-backup.yml
+++ b/.github/workflows/heroku-db-partial-backup.yml
@@ -28,10 +28,14 @@ jobs:
       - name: Install PostgreSQL client and GPG
         run: |
           sudo apt-get update
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get install -y curl gnupg2
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/postgresql.list
           sudo apt-get update
-          sudo apt-get install -y postgresql-client-15 gnupg
+          sudo apt-get install -y postgresql-client-15
+
+      - name: Verify PostgreSQL version
+        run: pg_dump --version
 
       - name: Create Custom Database Backup
         env:
@@ -39,6 +43,7 @@ jobs:
           HEROKU_APP: ${{ github.event.inputs.environment == 'production' && secrets.HEROKU_APP_NAME_PRODUCTION || secrets.HEROKU_APP_NAME_DEVELOPMENT }}
           BACKUP_DIR: ./backups
         run: |
+          export PATH="/usr/lib/postgresql/15/bin:$PATH"
           mkdir -p $BACKUP_DIR
           ./src/tools/heroku/partial-backup.sh
 


### PR DESCRIPTION
Fixes Postgres client tools versoin mismatch (eg default installed ones on ubuntu vs installed from apt have mismatched version)

- [x] test output and recreate db from this backup