### PR TITLE
4032 - Fix migrations

### DIFF
--- a/src/test/migrations/index.ts
+++ b/src/test/migrations/index.ts
@@ -1,6 +1,8 @@
 import 'tsconfig-paths/register'
 import 'dotenv/config'
 
+import { Promises } from 'utils/promises'
+
 import { VisitCycleLinksQueueFactory } from 'server/controller/cycleData/links/visitCycleLinks/queueFactory'
 import { WorkerFactory as VisitLinksWorkerFactory } from 'server/controller/cycleData/links/visitCycleLinks/workerFactory'
 import { UpdateDependenciesQueueFactory } from 'server/controller/cycleData/updateDependencies/queueFactory'
@@ -55,8 +57,7 @@ const exec = async () => {
   await init()
 
   await client.tx(async (t) => {
-    // eslint-disable-next-line no-restricted-syntax
-    for await (const file of migrationSteps) {
+    await Promises.each(migrationSteps, async (file) => {
       try {
         Logger.info(`Running migration ${file}`)
         // eslint-disable-next-line @typescript-eslint/no-var-requires,global-require,import/no-dynamic-require
@@ -65,7 +66,7 @@ const exec = async () => {
       } catch (e) {
         Logger.error(e)
       }
-    }
+    })
   })
 
   if (!process.argv.includes('--watch')) {

--- a/src/test/migrations/steps/20241016104908-step-users_role-invitation-split.ts
+++ b/src/test/migrations/steps/20241016104908-step-users_role-invitation-split.ts
@@ -90,6 +90,7 @@ export default async () => {
   await client.query(`create unique index if not exists users_uuid_key on public.users (uuid);`)
 
   // ---- 2. Move users_role table to _legacy schema
+  await client.query(`create schema if not exists _legacy;`) // eg running vs partial db
   await client.query(`alter table public.users_role set schema _legacy;`)
 
   // ---- 3. Create users_invitation table


### PR DESCRIPTION
Fix migrations:
- For somea reason using `for await (const file of migrationSteps) {` messes up running the migrations when one migration is not using transcation (eg 20241016104908-step-users_role-invitation-split.ts) and other ones are running under transcation.
- Create schema _legacy if it doesn't exist (partial db copy support)