### PR TITLE
4133 - Kiosk v1 - Hide quiz & Add responsiveness 

### DIFF
--- a/src/client/pages/Kiosk/InteractiveStories/InteractiveStories.scss
+++ b/src/client/pages/Kiosk/InteractiveStories/InteractiveStories.scss
@@ -1,5 +1,5 @@
 .kiosk-interactive-stories__grid-container {
   display: grid;
-  gap: 64px;
+  gap: min(3.33dvw, 5.925dvh);
   grid-template-columns: repeat(2, 1fr);
 }

--- a/src/client/pages/Kiosk/InteractiveStories/InteractiveStories.tsx
+++ b/src/client/pages/Kiosk/InteractiveStories/InteractiveStories.tsx
@@ -37,11 +37,13 @@ const cards: Array<KioskCardProps> = [
 const InteractiveStories: React.FC = () => {
   return (
     <div className="kiosk-content">
-      <h1 className="kiosk-content__title">Interactive Stories</h1>
-      <div className="kiosk-interactive-stories__grid-container">
-        {cards.map(({ altText, imageUrl, link, title }) => (
-          <Card key={title} altText={altText} imageUrl={imageUrl} link={link} title={title} />
-        ))}
+      <div>
+        <h1 className="kiosk-content__title">Interactive Stories</h1>
+        <div className="kiosk-interactive-stories__grid-container">
+          {cards.map(({ altText, imageUrl, link, title }) => (
+            <Card key={title} altText={altText} imageUrl={imageUrl} link={link} title={title} />
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/src/client/pages/Kiosk/Kiosk.scss
+++ b/src/client/pages/Kiosk/Kiosk.scss
@@ -2,9 +2,8 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  gap: 32px;
   justify-content: space-around;
-  padding: 48px;
+  padding: min(2.5dvw, 4.44dvh);
 }
 
 .kiosk-content__embedded-object {
@@ -14,12 +13,14 @@
 
 .kiosk-content__grid-container {
   display: grid;
-  gap: 64px;
+  gap: min(3.33dvw, 5.925dvh);
   grid-template-columns: repeat(3, 1fr);
 }
 
 .kiosk-content__title {
   color: #ef7a2d;
-  font-size: 64px;
+  font-size: min(3.33dvw, 5.925dvh);
   font-weight: 900;
+  margin-bottom: min(3.2dvw, 6dvh);
+  text-align: center;
 }

--- a/src/client/pages/Kiosk/Kiosk.tsx
+++ b/src/client/pages/Kiosk/Kiosk.tsx
@@ -42,11 +42,13 @@ const cards: Array<KioskCardProps> = [
 const Kiosk: React.FC = () => {
   return (
     <div className="kiosk-content">
-      <h1 className="kiosk-content__title">Global Forest Resources Assessment</h1>
-      <div className="kiosk-content__grid-container">
-        {cards.map(({ altText, imageUrl, link, title }) => (
-          <Card key={title} altText={altText} imageUrl={imageUrl} link={link} title={title} />
-        ))}
+      <div>
+        <h1 className="kiosk-content__title">Global Forest Resources Assessment</h1>
+        <div className="kiosk-content__grid-container">
+          {cards.map(({ altText, imageUrl, link, title }) => (
+            <Card key={title} altText={altText} imageUrl={imageUrl} link={link} title={title} />
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/src/client/pages/Kiosk/KioskLayout/KioskLayout.scss
+++ b/src/client/pages/Kiosk/KioskLayout/KioskLayout.scss
@@ -1,6 +1,6 @@
 .kiosk-container {
   display: grid;
-  grid-template-columns: 400px 1fr;
+  grid-template-columns: 20dvw 1fr;
   height: 100dvh;
   width: 100%;
 }

--- a/src/client/pages/Kiosk/KioskLayout/SidePanel/SidePanel.scss
+++ b/src/client/pages/Kiosk/KioskLayout/SidePanel/SidePanel.scss
@@ -3,13 +3,22 @@ $title: #ef7a2d;
 
 .kiosk-side-panel__partners {
   display: flex;
-  gap: 24px;
+  gap: 6%;
   width: 100%;
+}
 
-  img {
-    height: 50px;
-    width: auto;
-  }
+.kiosk-side-panel__partners-eu,
+.kiosk-side-panel__partners-nicfi {
+  height: auto;
+  object-fit: contain;
+}
+
+.kiosk-side-panel__partners-eu {
+  width: 25%;
+}
+
+.kiosk-side-panel__partners-nicfi {
+  width: 35%;
 }
 
 .kiosk-side-panel__footer {
@@ -20,7 +29,7 @@ $title: #ef7a2d;
   justify-content: center;
 
   p {
-    font-size: 16px;
+    font-size: min(0.89dvw, 1.5dvh);
     font-weight: 300;
   }
 }
@@ -30,16 +39,16 @@ $title: #ef7a2d;
   background-color: $side-panel-bg;
   color: $title;
   display: flex;
-  font-size: 32px;
+  font-size: min(1.66dvw, 3dvh);
   font-weight: 900;
-  height: 50px;
+  height: 15%;
   justify-content: center;
   left: 50%;
   pointer-events: none;
   position: absolute;
   top: 50%;
   transform: translate(-50%, -50%);
-  width: 250px;
+  width: 70%;
 }
 
 .kiosk-side-panel__quiz-img {
@@ -55,11 +64,12 @@ $title: #ef7a2d;
 .kiosk-side-panel__quiz {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0.75dvh;
   text-align: center;
 
   h1 {
     color: black;
+    font-size: min(1.46dvw, 2.6dvh);
     font-weight: 700;
     line-height: 1.25;
     margin: 0;
@@ -71,20 +81,24 @@ $title: #ef7a2d;
   justify-content: space-between;
 
   img {
-    height: 60px;
-    width: auto;
+    height: min-content;
+    object-fit: contain;
+    width: 60%;
   }
 }
 
 .kiosk-side-panel__home-button {
   all: unset;
+  aspect-ratio: 1 / 1;
   cursor: pointer;
+  height: auto;
+  width: 35%;
 
   .icon {
     color: $title;
-    height: 120px;
+    height: 100%;
     margin-top: -10px;
-    width: 120px;
+    width: 100%;
   }
 }
 
@@ -94,5 +108,5 @@ $title: #ef7a2d;
   flex-direction: column;
   height: 100%;
   justify-content: space-between;
-  padding: 24px;
+  padding: 6%;
 }

--- a/src/client/pages/Kiosk/KioskLayout/SidePanel/SidePanel.tsx
+++ b/src/client/pages/Kiosk/KioskLayout/SidePanel/SidePanel.tsx
@@ -22,13 +22,13 @@ const SidePanel: React.FC = () => {
           <Icon name="home-circle" />
         </button>
       </div>
-      {/* <div className="kiosk-side-panel__quiz">
-        <h1>Get to know FRA and test your knowledge!</h1>
+      <div className="kiosk-side-panel__quiz">
+        {/* <h1>Get to know FRA and test your knowledge!</h1> */}
         <div className="kiosk-side-panel__quiz-img-container">
-          <div className="kiosk-side-panel__quiz-title">FRA quiz</div>
+          {/* <div className="kiosk-side-panel__quiz-title">FRA quiz</div> */}
           <img alt="quiz" className="kiosk-side-panel__quiz-img" src="/img/kiosk/quiz-bubbles.png" />
         </div>
-      </div> */}
+      </div>
       <div className="kiosk-side-panel__footer">
         <p>
           <i>Created with the financial support of:</i>

--- a/src/client/pages/Kiosk/KioskLayout/SidePanel/SidePanel.tsx
+++ b/src/client/pages/Kiosk/KioskLayout/SidePanel/SidePanel.tsx
@@ -22,13 +22,13 @@ const SidePanel: React.FC = () => {
           <Icon name="home-circle" />
         </button>
       </div>
-      <div className="kiosk-side-panel__quiz">
+      {/* <div className="kiosk-side-panel__quiz">
         <h1>Get to know FRA and test your knowledge!</h1>
         <div className="kiosk-side-panel__quiz-img-container">
           <div className="kiosk-side-panel__quiz-title">FRA quiz</div>
           <img alt="quiz" className="kiosk-side-panel__quiz-img" src="/img/kiosk/quiz-bubbles.png" />
         </div>
-      </div>
+      </div> */}
       <div className="kiosk-side-panel__footer">
         <p>
           <i>Created with the financial support of:</i>

--- a/src/client/pages/Kiosk/KioskLayout/SidePanel/SidePanel.tsx
+++ b/src/client/pages/Kiosk/KioskLayout/SidePanel/SidePanel.tsx
@@ -34,8 +34,8 @@ const SidePanel: React.FC = () => {
           <i>Created with the financial support of:</i>
         </p>
         <div className="kiosk-side-panel__partners">
-          <img alt="EU" className="quiz-image" src="/img/partners/EU.jpg" />
-          <img alt="NICFI" className="quiz-image" src="/img/partners/NICFI_3_lines.png" />
+          <img alt="EU" className="kiosk-side-panel__partners-eu" src="/img/partners/EU.jpg" />
+          <img alt="NICFI" className="kiosk-side-panel__partners-nicfi" src="/img/partners/NICFI.png" />
         </div>
       </div>
     </div>

--- a/src/client/pages/Kiosk/components/Card/Card.scss
+++ b/src/client/pages/Kiosk/components/Card/Card.scss
@@ -2,18 +2,18 @@
   all: unset;
   aspect-ratio: 1 / 1;
   background-color: #dcf0f5;
-  border-radius: 40px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  border-radius: min(2dvw, 3.7dvh);
+  box-shadow: 0 min(0.2dvw, 0.37dvh) min(0.3125dvw, 0.555dvh) rgba(0, 0, 0, 0.1);
   display: block;
   overflow: hidden;
   position: relative;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
-  width: 380px;
+  width: min(20dvw, 35dvh);
 }
 
 .kiosk-content__card-button:hover,
 .kiosk-content__card-button:focus {
-  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 min(0.3125dvw, 0.555dvh) min(0.52dvw, 0.92dvh) rgba(0, 0, 0, 0.15);
   transform: scale(1.05);
 }
 
@@ -29,7 +29,7 @@
   bottom: calc(10%);
   color: white;
   display: flex;
-  font-size: 48px;
+  font-size: min(2.5dvw, 4.44dvh);
   font-weight: bold;
   height: 33%;
   justify-content: center;
@@ -37,7 +37,7 @@
   line-height: 1.25;
   position: absolute;
   text-align: center;
-  text-shadow: 2px 2px 0px rgba(0, 0, 0, 0.7);
+  text-shadow: min(0.1dvw, 0.18dvh) min(0.1dvw, 0.18dvh) 0px rgba(0, 0, 0, 0.7);
   transition: opacity 0.3s ease-in-out;
   width: 100%;
 }


### PR DESCRIPTION
Entire Kiosk working:

https://github.com/user-attachments/assets/d05c88f5-9e42-42b8-bda5-71fc6f52b3a7

After this PR, the main PR is ready to merge. Unless there is something new to add.

(UPDATED) Responsiveness: 

https://github.com/user-attachments/assets/c1c9f24f-5e5e-4f7f-9ca3-2c95c1cbb023

To make the embedded content look bigger for higher resolutions, we need to zoom in the browser as seen in the end of the video. This is the only way since it's not possible to manipulate the object content.
