### PR TITLE
4185 - Update country names in english

### DIFF
--- a/src/i18n/resources/en/area.json
+++ b/src/i18n/resources/en/area.json
@@ -309,7 +309,7 @@
     "listName": "Guatemala"
   },
   "GUF": {
-    "listName": "French Guyana"
+    "listName": "French Guiana"
   },
   "GUM": {
     "listName": "Guam"
@@ -426,7 +426,7 @@
     "listName": "Latvia"
   },
   "MAF": {
-    "listName": "Saint-Martin (French Part)"
+    "listName": "Saint Martin (French Part)"
   },
   "MAR": {
     "listName": "Morocco"
@@ -516,7 +516,7 @@
     "listName": "Niue"
   },
   "NLD": {
-    "listName": "Netherlands (Kingdom of the)"
+    "listName": "Netherlands"
   },
   "NOR": {
     "listName": "Norway"

--- a/src/i18n/resources/en/area.json
+++ b/src/i18n/resources/en/area.json
@@ -516,7 +516,7 @@
     "listName": "Niue"
   },
   "NLD": {
-    "listName": "Netherlands"
+    "listName": "Netherlands (Kingdom of the)"
   },
   "NOR": {
     "listName": "Norway"


### PR DESCRIPTION
I went over all country names in English, and there are no mismatches with the list provided besides "French Guiana", "Saint Martin (French Part)" and "Netherlands". Except Türkiye as we have it (prev Turkey), but that's probably because the source site is not fully up to date. 