### PR TITLE
4001 - Datatable Use Datagrid - Hide taxon DropdownIndicator, Vertically center input disabled & Cache fix

### DIFF
--- a/src/client/components/Inputs/Select/hooks/useComponents.tsx
+++ b/src/client/components/Inputs/Select/hooks/useComponents.tsx
@@ -17,7 +17,8 @@ import { SelectProps } from 'client/components/Inputs/Select/types'
 type Returned = ReactSelectProps['components']
 
 export const useComponents = (props: SelectProps): Returned => {
-  const { collapsibleGroups, inputHidden, isMulti, multiLabelSummaryKey, selectableGroups } = props
+  const { collapsibleGroups, hideDropdownIndicator, inputHidden, isMulti, multiLabelSummaryKey, selectableGroups } =
+    props
 
   return useMemo<Returned>(() => {
     const components: Returned = {
@@ -41,7 +42,8 @@ export const useComponents = (props: SelectProps): Returned => {
         return <originalComponents.Input {...originalInputProps} isHidden={inputHidden} />
       }
     }
+    if (hideDropdownIndicator) components.DropdownIndicator = null
 
     return components
-  }, [collapsibleGroups, inputHidden, isMulti, multiLabelSummaryKey, selectableGroups])
+  }, [collapsibleGroups, hideDropdownIndicator, inputHidden, isMulti, multiLabelSummaryKey, selectableGroups])
 }

--- a/src/client/components/Inputs/Select/types.ts
+++ b/src/client/components/Inputs/Select/types.ts
@@ -42,6 +42,7 @@ export type SelectProps = SelectBaseProps &
     collapsibleGroups?: boolean
     createOptionLabelKey?: string
     disabled?: boolean
+    hideDropdownIndicator?: boolean
     inputHidden?: boolean
     isCreatable?: boolean
     multiLabelSummaryKey?: string

--- a/src/client/pages/Section/DataTable/Table/RowData/Cell/Taxon/Taxon.tsx
+++ b/src/client/pages/Section/DataTable/Table/RowData/Cell/Taxon/Taxon.tsx
@@ -32,6 +32,7 @@ const Taxon: React.FC<PropsCell> = (props: PropsCell) => {
         createOptionLabelKey="common.add"
         createOptionPosition="first"
         disabled={disabled}
+        hideDropdownIndicator
         inputHidden={false}
         inputValue={!disabled ? inputValue : null}
         isClearable={false}

--- a/src/client/pages/Section/DataTable/Table/RowData/Cell/Text/Text.scss
+++ b/src/client/pages/Section/DataTable/Table/RowData/Cell/Text/Text.scss
@@ -1,11 +1,8 @@
-.table-grid__data-cell-input-number {
-  text-align: right;
-
+.table-grid__data-cell-input-text {
   &.input-text {
     &.disabled {
       align-items: center;
       display: flex;
-      justify-content: end;
     }
   }
 }

--- a/src/client/pages/Section/DataTable/Table/RowData/Cell/Text/Text.tsx
+++ b/src/client/pages/Section/DataTable/Table/RowData/Cell/Text/Text.tsx
@@ -1,3 +1,4 @@
+import './Text.scss'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -19,6 +20,7 @@ const Text: React.FC<PropsCell> = (props) => {
 
   return (
     <Component
+      className="table-grid__data-cell-input-text"
       disabled={disabled}
       onChange={onChange}
       onPaste={onPaste}

--- a/src/test/migrations/steps/20241114204645-step-fix-datatable-grid-layouts-and-taxon-codes.ts
+++ b/src/test/migrations/steps/20241114204645-step-fix-datatable-grid-layouts-and-taxon-codes.ts
@@ -1,7 +1,13 @@
+import { Objects } from 'utils/objects'
+import { Promises } from 'utils/promises'
+
+import { CountryIso } from 'meta/area'
 import { AssessmentNames } from 'meta/assessment'
 
 import { AssessmentController } from 'server/controller/assessment'
 import { BaseProtocol, Schemas } from 'server/db'
+import { DataRedisRepository } from 'server/repository/redis/data'
+import { Logger } from 'server/utils/logger'
 
 type TableInfo = {
   cycleUuid: string
@@ -661,27 +667,35 @@ const _fixFraTaxonCodes = async (client: BaseProtocol) => {
 
   const schemaAssessment = Schemas.getName(assessment)
 
-  /* eslint-disable no-useless-escape */
   await Promise.all(
-    cycles.map((cycle) => {
+    cycles.map(async (cycle) => {
       const schemaCycle = Schemas.getNameCycle(assessment, cycle)
-      return client.query(`
+      const updatedTables = await client.map<{ countryIso: CountryIso; tableName: string }>(
+        `
             with nodes_to_update as (
               select
                   n.id,
                   n.value,
+                  n.country_iso,
+                  tb.props->>'name' as table_name,
                   t.code as matching_taxon_code,
                   t.scientific_name as original_scientific_name
               from ${schemaCycle}.node n
               join ext_data.taxon t
-                  on lower(trim(both ' ' from regexp_replace(n.value->>'raw', '\s+', ' ', 'g'))) = lower(t.scientific_name)
+                  on lower(trim(both ' ' from regexp_replace(n.value->>'raw', '\\s+', ' ', 'g'))) = lower(t.scientific_name)
               join ${schemaAssessment}.col c
                   on c.uuid = n.col_uuid and c.props->>'colType' = 'taxon'
+              join ${schemaAssessment}.row r
+                  on c.row_id = r.id
+              join ${schemaAssessment}."table" tb
+                  on tb.id = r.table_id
               where n.value->>'taxonCode' is null
             ),
             updated_values as (
               select
                 id,
+                country_iso,
+                table_name,
                 jsonb_set(
                   jsonb_set(value, '{taxonCode}', to_jsonb(matching_taxon_code::text), true),
                   '{raw}',
@@ -689,12 +703,25 @@ const _fixFraTaxonCodes = async (client: BaseProtocol) => {
                   true
                 ) as new_value
               from nodes_to_update
+            ),
+            updated_tables as (
+              update ${schemaCycle}.node
+              set value = updated_values.new_value
+              from updated_values
+              where ${schemaCycle}.node.id = updated_values.id
+              returning updated_values.country_iso, updated_values.table_name
             )
-            update ${schemaCycle}.node
-            set value = updated_values.new_value
-            from updated_values
-            where ${schemaCycle}.node.id = updated_values.id;
-          `)
+            select distinct country_iso, table_name from updated_tables;
+          `,
+        [],
+        (res) => Objects.camelize(res)
+      )
+
+      await Promises.each(updatedTables, ({ countryIso, tableName }) =>
+        DataRedisRepository.cacheCountryTable({ assessment, countryIso, cycle, force: true, tableName }, client)
+      )
+
+      Logger.info(`Generated cache for ${updatedTables.length} tables in ${schemaCycle}.`)
     })
   )
 }
@@ -763,14 +790,6 @@ export default async (client: BaseProtocol) => {
   await Promise.all(
     assessments.map(async (assessment) => {
       await AssessmentController.generateMetadataCache({ assessment }, client)
-
-      if (assessment.props.name === AssessmentNames.fra) {
-        await Promise.all(
-          assessment.cycles.map(async (cycle) => {
-            await AssessmentController.generateDataCache({ assessment, cycle }, client)
-          })
-        )
-      }
     })
   )
 }


### PR DESCRIPTION
- Hiding the Taxon DropdownIndicator:

https://github.com/user-attachments/assets/13e21fc2-8037-4bc6-a675-0b1737896622

- Centering the input text/number when it is disabled:

When the input text (and input number which uses it) is disabled, a div is returned. That div doesn't center the content like the HTML input does, so when the vertical space is big the content is out of place:


https://github.com/user-attachments/assets/7f5c8729-8344-4ca2-a0ce-5bf2941ef708

After the new styles applied:

https://github.com/user-attachments/assets/16c207f4-7eaf-4d58-97b7-b862f28f4541

I decided not to add these changes to InputText directly because other unintended places would be affected. Like Contacts, if I had changed InputText:

https://github.com/user-attachments/assets/487045b0-9e90-4475-b313-771b10196dd1

when it should be like this:
![image](https://github.com/user-attachments/assets/b8bc0268-14df-45b3-9945-1cc1a91a5d93)

