### PR TITLE
3855 - Include public.file in partial db copy

### DIFF
--- a/src/tools/heroku/partial-backup.sh
+++ b/src/tools/heroku/partial-backup.sh
@@ -40,7 +40,6 @@ if pg_dump "$DATABASE_URL" \
   --no-acl \
   --format=custom \
   --exclude-table-data="public.activity_log" \
-  --exclude-table-data="public.file" \
   --exclude-table-data="assessment_fra.file" \
   --exclude-table-data="assessment_paneuropean.file" \
   --file="$BACKUP_FILE"; then


### PR DESCRIPTION
we can now have the public.file in partial db copy as it only keeps refernces to files