### PR TITLE
4001 - Datatable use Datagrid - Bug fix: handle null values in sanitizer functions

### DIFF
--- a/src/client/utils/sanitizer/decimal.ts
+++ b/src/client/utils/sanitizer/decimal.ts
@@ -1,7 +1,8 @@
 import { Numbers } from 'utils/numbers'
 import { Objects } from 'utils/objects'
 
-export const acceptableAsDecimal = (newValue: string) => {
+export const acceptableAsDecimal = (newValue: string | null) => {
+  if (Objects.isNil(newValue)) return false
   const newValueTrimmed = newValue.trim()
   if (newValueTrimmed === '') return true
   if (newValueTrimmed.includes('e')) return false

--- a/src/client/utils/sanitizer/integer.ts
+++ b/src/client/utils/sanitizer/integer.ts
@@ -1,7 +1,8 @@
 import { Numbers } from 'utils/numbers'
 import { Objects } from 'utils/objects'
 
-export const acceptableAsInteger = (newValue: string) => {
+export const acceptableAsInteger = (newValue: string | null) => {
+  if (Objects.isNil(newValue)) return false
   const newValueTrimmed = newValue.trim()
   if (newValueTrimmed === '') return true
   if (newValueTrimmed.includes('e')) return false


### PR DESCRIPTION
Small bug fix after doing the final testing round for all tables. After this the main PR will be opened. 

This fixes the case where the node raw value was not defined, so the input value was null and the sanitizer function was run onBlur with that empty value, causing `newValue.trim()` to fail.  