### PR TITLE
4239 - Update upload-artifact to v4

### DIFF
--- a/.github/workflows/heroku-db-partial-backup.yml
+++ b/.github/workflows/heroku-db-partial-backup.yml
@@ -54,7 +54,7 @@ jobs:
         run: ./src/tools/heroku/encrypt.sh
 
       - name: Upload encrypted backup artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: encrypted-database-backup-${{ github.event.inputs.environment }}-${{ github.run_id }}
           path: ./backups/*.gpg

--- a/.github/workflows/test.js.yml
+++ b/.github/workflows/test.js.yml
@@ -78,7 +78,7 @@ jobs:
           PGDATABASE: frap-dev
           PGUSER: frap
           PGPASSWORD: frap
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
Based on the guide to migrate Artifact actions `v3` to `v4`, we just need to update the version number as we are not using the features that require further changes (like Multiple uploads to the same named Artifact, Overwriting an Artifact, Merging multiple artifacts, Hidden files)

https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md