### PR TITLE
4258 - Fix default (fallback) profile picture

### DIFF
--- a/src/server/controller/user/getProfilePicture.ts
+++ b/src/server/controller/user/getProfilePicture.ts
@@ -12,7 +12,8 @@ export const getProfilePicture = async (
 ): Promise<UserProfilePicture> => {
   const { id } = props
   const userProfilePicture = await UserRepository.getProfilePicture({ id }, client)
-  const key = userProfilePicture.uuid
+  const key = userProfilePicture?.uuid
+  if (!key) return null
   const data = await FileStorage.getFile({ key })
   return {
     ...userProfilePicture,

--- a/src/server/repository/public/user/getProfilePicture.ts
+++ b/src/server/repository/public/user/getProfilePicture.ts
@@ -26,7 +26,7 @@ export const getProfilePicture = async (
     `
         select f.uuid, f.name
         from public.users u
-            left join file f on u.profile_picture_file_uuid = f.uuid
+            join file f on u.profile_picture_file_uuid = f.uuid
         ${where}
     `,
     [value]


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/10021d45-8139-466e-b099-359490198766)

Problem was using left join the join the file table -> always returning null values for uuid and name when profile picture not found