### PR TITLE
4253 - Data History: ODP comparison (empty dataset) - Grid table diffs

### DIFF
--- a/src/client/components/DiffText/DiffText.tsx
+++ b/src/client/components/DiffText/DiffText.tsx
@@ -23,6 +23,7 @@ const DiffText: React.FC<Props> = (props) => {
             {value.split('\n\r').map((text, j) => (
               <React.Fragment key={`${key}_${String(j)}`}>
                 <span className={classNames({ added, removed })}>{text}</span>
+                <br />
               </React.Fragment>
             ))}
           </React.Fragment>

--- a/src/client/pages/OriginalDataPoint/OriginalDataPoint.tsx
+++ b/src/client/pages/OriginalDataPoint/OriginalDataPoint.tsx
@@ -17,6 +17,7 @@ import NationalClasses from './components/NationalClasses'
 import OriginalData from './components/OriginalData'
 import YearSelection from './components/YearSelection'
 import { useGetOriginalDataPoint } from './hooks/useGetOriginalDataPoint'
+import { useGetOriginalDataPointHistory } from './hooks/useGetOriginalDataPointHistory'
 import { useGetReviewStatus } from './hooks/useGetReviewStatus'
 import { useReservedYears } from './hooks/useReservedYears'
 
@@ -31,6 +32,7 @@ const OriginalDataPoint: React.FC = () => {
 
   useReservedYears()
   useGetOriginalDataPoint()
+  useGetOriginalDataPointHistory()
   useGetReviewStatus()
 
   if (originalDataPoint.countryIso !== countryIso) navigate('/')

--- a/src/client/pages/OriginalDataPoint/components/DataSources/AdditionalComments/AdditionalComments.tsx
+++ b/src/client/pages/OriginalDataPoint/components/DataSources/AdditionalComments/AdditionalComments.tsx
@@ -4,8 +4,10 @@ import { useTranslation } from 'react-i18next'
 import { OriginalDataPoint } from 'meta/assessment'
 import { Topics } from 'meta/messageCenter'
 
+import { useHistoryLastApprovedIsActive } from 'client/store/data'
 import { DataCell, DataRow, DataRowAction, DataRowActionType } from 'client/components/DataGrid'
 import TextArea from 'client/components/Inputs/TextArea'
+import ODPDiffText from 'client/pages/OriginalDataPoint/components/ODPDiffText/ODPDiffText'
 import { useShowReviewIndicator } from 'client/pages/OriginalDataPoint/hooks/useShowReviewIndicator'
 
 import { useIsDisabled } from '../hooks/useIsDisabled'
@@ -22,6 +24,8 @@ const AdditionalComments: React.FC<Props> = (props: Props) => {
   const reviewIndicator = useShowReviewIndicator()
   const disabled = useIsDisabled()
   const updateOriginalDataPoint = useUpdateDataSources()
+
+  const historyLastApprovedIsActive = useHistoryLastApprovedIsActive()
 
   const onChange = useCallback<ChangeEventHandler<HTMLTextAreaElement>>(
     (event) => {
@@ -58,11 +62,15 @@ const AdditionalComments: React.FC<Props> = (props: Props) => {
         {t('nationalDataPoint.additionalComments')}
       </DataCell>
       <DataCell lastCol lastRow>
-        <TextArea
-          disabled={disabled}
-          onChange={onChange}
-          value={originalDataPoint.dataSourceAdditionalComments ?? ''}
-        />
+        {historyLastApprovedIsActive ? (
+          <ODPDiffText originalDataPoint={originalDataPoint} path={['dataSourceAdditionalComments']} />
+        ) : (
+          <TextArea
+            disabled={disabled}
+            onChange={onChange}
+            value={originalDataPoint.dataSourceAdditionalComments ?? ''}
+          />
+        )}
       </DataCell>
     </DataRow>
   )

--- a/src/client/pages/OriginalDataPoint/components/DataSources/MethodsUsed/MethodsUsed.tsx
+++ b/src/client/pages/OriginalDataPoint/components/DataSources/MethodsUsed/MethodsUsed.tsx
@@ -4,8 +4,10 @@ import { useTranslation } from 'react-i18next'
 import { ODPDataSourceMethod, OriginalDataPoint } from 'meta/assessment/originalDataPoint'
 import { Topics } from 'meta/messageCenter'
 
+import { useHistoryLastApprovedIsActive } from 'client/store/data'
 import { DataCell, DataRow, DataRowAction, DataRowActionType } from 'client/components/DataGrid'
 import Select, { Option } from 'client/components/Inputs/Select'
+import ODPDiffText from 'client/pages/OriginalDataPoint/components/ODPDiffText/ODPDiffText'
 import { useShowReviewIndicator } from 'client/pages/OriginalDataPoint/hooks/useShowReviewIndicator'
 
 import { useIsDisabled } from '../hooks/useIsDisabled'
@@ -24,6 +26,7 @@ const MethodsUsed: React.FC<Props> = (props: Props) => {
   const reviewIndicator = useShowReviewIndicator()
   const disabled = useIsDisabled()
   const updateOriginalDataPoint = useUpdateDataSources()
+  const historyLastApprovedIsActive = useHistoryLastApprovedIsActive()
 
   const options = useMemo<Array<Option>>(
     () =>
@@ -58,13 +61,17 @@ const MethodsUsed: React.FC<Props> = (props: Props) => {
     <DataRow actions={actions}>
       <DataCell header>{t('nationalDataPoint.methodsUsed')}</DataCell>
       <DataCell lastCol>
-        <Select
-          disabled={disabled}
-          isMulti
-          onChange={onChange}
-          options={options}
-          value={originalDataPoint.dataSourceMethods ?? []}
-        />
+        {historyLastApprovedIsActive ? (
+          <ODPDiffText originalDataPoint={originalDataPoint} path={['dataSourceMethods']} />
+        ) : (
+          <Select
+            disabled={disabled}
+            isMulti
+            onChange={onChange}
+            options={options}
+            value={originalDataPoint.dataSourceMethods ?? []}
+          />
+        )}
       </DataCell>
     </DataRow>
   )

--- a/src/client/pages/OriginalDataPoint/components/DataSources/References/References.tsx
+++ b/src/client/pages/OriginalDataPoint/components/DataSources/References/References.tsx
@@ -6,8 +6,10 @@ import { Objects } from 'utils/objects'
 import { OriginalDataPoint } from 'meta/assessment'
 import { Topics } from 'meta/messageCenter'
 
+import { useHistoryLastApprovedIsActive } from 'client/store/data'
 import { DataCell, DataRow, DataRowAction, DataRowActionType } from 'client/components/DataGrid'
 import { EditorWYSIWYGLinks } from 'client/components/EditorWYSIWYG'
+import ODPDiffText from 'client/pages/OriginalDataPoint/components/ODPDiffText/ODPDiffText'
 import { useShowReviewIndicator } from 'client/pages/OriginalDataPoint/hooks/useShowReviewIndicator'
 
 import { useIsDisabled } from '../hooks/useIsDisabled'
@@ -25,6 +27,7 @@ const References: React.FC<Props> = (props: Props) => {
 
   const reviewIndicator = useShowReviewIndicator()
   const disabled = useIsDisabled()
+  const historyLastApprovedIsActive = useHistoryLastApprovedIsActive()
 
   const updateOriginalDataPoint = useUpdateDataSources()
 
@@ -53,12 +56,16 @@ const References: React.FC<Props> = (props: Props) => {
     <DataRow actions={actions}>
       <DataCell header>{t('nationalDataPoint.references')}</DataCell>
       <DataCell lastCol>
-        <EditorWYSIWYGLinks
-          disabled={disabled}
-          onChange={onChange}
-          repository
-          value={originalDataPoint.dataSourceReferences ?? ''}
-        />
+        {historyLastApprovedIsActive ? (
+          <ODPDiffText originalDataPoint={originalDataPoint} path={['dataSourceReferences']} />
+        ) : (
+          <EditorWYSIWYGLinks
+            disabled={disabled}
+            onChange={onChange}
+            repository
+            value={originalDataPoint.dataSourceReferences ?? ''}
+          />
+        )}
       </DataCell>
     </DataRow>
   )

--- a/src/client/pages/OriginalDataPoint/components/NationalClasses/components/NationalClass.tsx
+++ b/src/client/pages/OriginalDataPoint/components/NationalClasses/components/NationalClass.tsx
@@ -3,10 +3,12 @@ import { useTranslation } from 'react-i18next'
 
 import { ODPs, OriginalDataPoint } from 'meta/assessment'
 
+import { useHistoryLastApprovedIsActive } from 'client/store/data'
 import { useIsPrintRoute } from 'client/hooks/useIsRoute'
 import { DataCell, DataRow } from 'client/components/DataGrid'
 import InputText from 'client/components/Inputs/InputText'
 import TextArea from 'client/components/Inputs/TextArea'
+import ODPDiffText from 'client/pages/OriginalDataPoint/components/ODPDiffText/ODPDiffText'
 // import { useNationalClassNameComments } from 'client/pages/OriginalDataPoint/hooks'
 import { useIsEditODPEnabled } from 'client/pages/OriginalDataPoint/hooks/useIsEditODPEnabled'
 
@@ -31,6 +33,8 @@ const NationalClass: React.FC<Props> = (props) => {
   const actions = useRowActions({ canEdit: canEditData && !placeHolder, index, originalDataPoint })
   const { onChangeDefinition, onChangeName, onPasteDefinition, onPasteName } = useOnChangeNationalClass({ index })
 
+  const historyLastApprovedIsActive = useHistoryLastApprovedIsActive()
+
   const lastRow = canEditData && !print ? placeHolder : index === nationalClasses.length - (print ? 1 : 2)
   // TODO next pr
   // const target = [originalDataPoint.id, 'class', `${uuid}`, 'definition'] as string[]
@@ -46,22 +50,30 @@ const NationalClass: React.FC<Props> = (props) => {
   return (
     <DataRow actions={actions}>
       <DataCell error={error} lastRow={lastRow}>
-        <InputText
-          disabled={!canEditData}
-          onChange={onChangeName}
-          onPaste={onPasteName}
-          placeholder={placeHolder && index === 0 ? t('nationalDataPoint.enterOrCopyPasteNationalClasses') : ''}
-          value={name ?? ''}
-        />
+        {historyLastApprovedIsActive ? (
+          <ODPDiffText originalDataPoint={originalDataPoint} path={['nationalClasses', index, 'name']} />
+        ) : (
+          <InputText
+            disabled={!canEditData}
+            onChange={onChangeName}
+            onPaste={onPasteName}
+            placeholder={placeHolder && index === 0 ? t('nationalDataPoint.enterOrCopyPasteNationalClasses') : ''}
+            value={name ?? ''}
+          />
+        )}
       </DataCell>
 
       <DataCell lastCol lastRow={lastRow}>
-        <TextArea
-          disabled={!canEditData}
-          onChange={onChangeDefinition}
-          onPaste={onPasteDefinition}
-          value={definition ?? ''}
-        />
+        {historyLastApprovedIsActive ? (
+          <ODPDiffText originalDataPoint={originalDataPoint} path={['nationalClasses', index, 'definition']} />
+        ) : (
+          <TextArea
+            disabled={!canEditData}
+            onChange={onChangeDefinition}
+            onPaste={onPasteDefinition}
+            value={definition ?? ''}
+          />
+        )}
       </DataCell>
     </DataRow>
   )

--- a/src/client/pages/OriginalDataPoint/components/ODPDiffText/ODPDiffText.scss
+++ b/src/client/pages/OriginalDataPoint/components/ODPDiffText/ODPDiffText.scss
@@ -1,0 +1,5 @@
+@import 'src/client/style/partials';
+
+.odp-diff-text {
+  padding: $spacing-xxs;
+}

--- a/src/client/pages/OriginalDataPoint/components/ODPDiffText/ODPDiffText.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ODPDiffText/ODPDiffText.tsx
@@ -1,0 +1,22 @@
+import './ODPDiffText.scss'
+import React from 'react'
+
+import { OriginalDataPoint } from 'meta/assessment'
+
+import DiffText from 'client/components/DiffText'
+import { useFieldChanges } from 'client/pages/OriginalDataPoint/hooks/useFieldChanges'
+
+type Props = {
+  originalDataPoint: OriginalDataPoint
+  path: Array<string | number>
+}
+
+const ODPDiffText: React.FC<Props> = (props) => {
+  const { originalDataPoint, path } = props
+
+  const changes = useFieldChanges({ originalDataPoint, path })
+
+  return <DiffText changes={changes} className="odp-diff-text" />
+}
+
+export default ODPDiffText

--- a/src/client/pages/OriginalDataPoint/hooks/useFieldChanges.ts
+++ b/src/client/pages/OriginalDataPoint/hooks/useFieldChanges.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react'
+import { TFunction, useTranslation } from 'react-i18next'
+
+import * as Diff from 'diff'
+import { Change } from 'diff'
+import { Objects } from 'utils/objects'
+
+import { OriginalDataPoint } from 'meta/assessment'
+
+import { useLastApprovedOriginalDataPoint } from 'client/store/data/hooks/useLastApprovedOriginalDataPoint'
+import { DOMs } from 'client/utils/dom'
+
+type Props = {
+  originalDataPoint: OriginalDataPoint
+  path: Array<string | number>
+}
+
+type Returned = Array<Change>
+
+const _getSourceMethodText = (values: Array<string> | undefined, t: TFunction): string =>
+  (values ?? [])?.map((value) => t(`nationalDataPoint.dataSourceMethodsOptions.${value}`)).join('\n\r')
+
+export const useFieldChanges = (props: Props): Returned => {
+  const { originalDataPoint, path } = props
+
+  const { t } = useTranslation()
+  const originalDataPointHistory = useLastApprovedOriginalDataPoint()
+
+  return useMemo<Returned>(() => {
+    const valuePrev = Objects.getInPath(originalDataPointHistory, path)
+    const valueCurrent = Objects.getInPath(originalDataPoint, path)
+
+    const isSourceMethods = path.includes('dataSourceMethods')
+    if (isSourceMethods) {
+      const multipleMethods = valueCurrent?.length > 0
+
+      const methodsPrev = _getSourceMethodText(valuePrev, t)
+      const methodsCurrent = _getSourceMethodText(valueCurrent, t)
+
+      return multipleMethods ? Diff.diffLines(methodsPrev, methodsCurrent) : Diff.diffChars(methodsPrev, methodsCurrent)
+    }
+
+    const textPrev = DOMs.getHtmlTextContent(valuePrev ?? '')
+    const textCurrent = DOMs.getHtmlTextContent(valueCurrent ?? '')
+    return Diff.diffChars(textPrev, textCurrent, {
+      ignoreCase: false,
+    })
+  }, [originalDataPoint, originalDataPointHistory, path, t])
+}

--- a/src/client/pages/OriginalDataPoint/hooks/useGetOriginalDataPointHistory.ts
+++ b/src/client/pages/OriginalDataPoint/hooks/useGetOriginalDataPointHistory.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+
+import { useAppDispatch } from 'client/store'
+import { DataActions, useHistoryLastApprovedIsActive } from 'client/store/data'
+import { useSection } from 'client/store/metadata'
+import { useOriginalDataPointRouteParams } from 'client/hooks/useRouteParams'
+
+export const useGetOriginalDataPointHistory = () => {
+  const { assessmentName, countryIso, cycleName, year } = useOriginalDataPointRouteParams()
+
+  const dispatch = useAppDispatch()
+  const section = useSection()
+  const sectionName = section?.props.name
+
+  const historyLastApprovedIsActive = useHistoryLastApprovedIsActive()
+
+  useEffect(() => {
+    if (year === '-1') return
+    if (!historyLastApprovedIsActive) return
+
+    dispatch(
+      DataActions.getOriginalDataPointHistory({
+        assessmentName,
+        countryIso,
+        cycleName,
+        sectionName,
+        year,
+      })
+    )
+  }, [assessmentName, countryIso, cycleName, dispatch, historyLastApprovedIsActive, sectionName, year])
+}

--- a/src/client/store/data/actions/getOriginalDataPointHistory.ts
+++ b/src/client/store/data/actions/getOriginalDataPointHistory.ts
@@ -1,0 +1,27 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axios from 'axios'
+
+import { ApiEndPoint } from 'meta/api/endpoint'
+import { CycleParams } from 'meta/api/request'
+import { OriginalDataPoint, SectionName } from 'meta/assessment'
+
+type Props = CycleParams & { sectionName: SectionName; year: string }
+
+type Returned = OriginalDataPoint
+
+export const getOriginalDataPointHistory = createAsyncThunk<Returned, Props>(
+  'data/originalDataPoint/history/get',
+  async ({ assessmentName, countryIso, cycleName, sectionName, year }) => {
+    const { data } = await axios.get(ApiEndPoint.CycleData.OriginalDataPoint.history(), {
+      params: {
+        assessmentName,
+        countryIso,
+        cycleName,
+        sectionName,
+        year,
+      },
+    })
+
+    return data
+  }
+)

--- a/src/client/store/data/actions/index.ts
+++ b/src/client/store/data/actions/index.ts
@@ -11,6 +11,7 @@ import { getDescriptionsHistory } from './getDescriptionsHistory'
 import { getLinkedDataSources } from './getLinkedDataSources'
 import { getNodeValuesEstimations } from './getNodeValuesEstimations'
 import { getODPLastUpdatedTimestamp } from './getODPLastUpdatedTimestamp'
+import { getOriginalDataPointHistory } from './getOriginalDataPointHistory'
 import { getTableData } from './getTableData'
 import { getTableDataHistory } from './getTableDataHistory'
 import { postEstimate } from './postEstimate'
@@ -31,6 +32,7 @@ export const DataActions = {
 
   // Original Data Point
   getODPLastUpdatedTimestamp,
+  getOriginalDataPointHistory,
 
   // Estimations
   postEstimate,

--- a/src/client/store/data/extraReducers/getOriginalDataPointHistory.ts
+++ b/src/client/store/data/extraReducers/getOriginalDataPointHistory.ts
@@ -1,0 +1,16 @@
+import { ActionReducerMapBuilder } from '@reduxjs/toolkit'
+import { Objects } from 'utils/objects'
+
+import { getOriginalDataPointHistory } from 'client/store/data/actions/getOriginalDataPointHistory'
+import { DataState } from 'client/store/data/state'
+
+export const getOriginalDataPointHistoryReducer = (builder: ActionReducerMapBuilder<DataState>) =>
+  builder.addCase(getOriginalDataPointHistory.fulfilled, (state, { meta, payload }) => {
+    const { assessmentName, countryIso, cycleName, year } = meta.arg
+
+    Objects.setInPath({
+      obj: state,
+      path: ['history', 'lastApproved', 'originalDataPoints', assessmentName, cycleName, countryIso, year],
+      value: payload,
+    })
+  })

--- a/src/client/store/data/hooks/useLastApprovedOriginalDataPoint.ts
+++ b/src/client/store/data/hooks/useLastApprovedOriginalDataPoint.ts
@@ -1,0 +1,18 @@
+import { OriginalDataPoint } from 'meta/assessment'
+
+import { useAppSelector } from 'client/store'
+import { DataSelector } from 'client/store/data/selectors'
+import { useOriginalDataPointRouteParams } from 'client/hooks/useRouteParams'
+
+export const useLastApprovedOriginalDataPoint = (): OriginalDataPoint => {
+  const { assessmentName, countryIso, cycleName, year } = useOriginalDataPointRouteParams()
+
+  return useAppSelector((state) =>
+    DataSelector.History.getLastApprovedOriginalDataPoint(state, {
+      assessmentName,
+      countryIso,
+      cycleName,
+      year,
+    })
+  )
+}

--- a/src/client/store/data/selectors/index.ts
+++ b/src/client/store/data/selectors/index.ts
@@ -37,6 +37,12 @@ const getLastApprovedDescriptions = createSelector(
     lastApproved?.descriptions?.[assessmentName]?.[cycleName]?.[countryIso]?.[sectionName]
 )
 
+const getLastApprovedOriginalDataPoint = createSelector(
+  [getHistoryLastApproved, (_, params: Params & { year: string }) => params],
+  (lastApproved, { assessmentName, countryIso, cycleName, year }) =>
+    lastApproved?.originalDataPoints?.[assessmentName]?.[cycleName]?.[countryIso]?.[year]
+)
+
 const getLastApprovedTableData = createSelector(getHistoryLastApproved, (lastApproved) => lastApproved?.tableData)
 
 export const DataSelector = {
@@ -52,5 +58,7 @@ export const DataSelector = {
     getLastApprovedDescriptions,
     // tabledata
     getLastApprovedTableData,
+    // originalDataPoint
+    getLastApprovedOriginalDataPoint,
   },
 }

--- a/src/client/store/data/slice.ts
+++ b/src/client/store/data/slice.ts
@@ -22,6 +22,7 @@ import { updateContact } from './actions/updateContact'
 import { updateDescription } from './actions/updateDescription'
 import { updateNodeValues } from './actions/updateNodeValues'
 import { getDescriptionsHistoryReducer } from './extraReducers/getDescriptionsHistory'
+import { getOriginalDataPointHistoryReducer } from './extraReducers/getOriginalDataPointHistory'
 import { setNodeValuesReducer } from './extraReducers/setNodeValues'
 import { deleteOriginalDataPoint } from './reducers/deleteOriginalDataPoint'
 import { resetHistoryActivities } from './reducers/resetHistoryActivities'
@@ -220,6 +221,7 @@ export const DataSlice = createSlice({
     // == History reducers
     getDescriptionsHistoryReducer(builder)
     getTableDataHistoryReducer(builder)
+    getOriginalDataPointHistoryReducer(builder)
   },
 })
 

--- a/src/client/store/data/state.ts
+++ b/src/client/store/data/state.ts
@@ -12,6 +12,7 @@ import {
   TableName,
   VariableName,
 } from 'meta/assessment'
+import { RecordAssessmentOriginalDataPoint } from 'meta/assessment/originalDataPoint'
 import { Contact } from 'meta/cycleData'
 import { HistoryTarget } from 'meta/cycleData/historyActivities'
 import { RecordAssessmentData } from 'meta/data'
@@ -63,6 +64,7 @@ export type HistoryActivitiesState = {
 export type HistoryLastApprovedState = {
   active?: boolean
   descriptions?: DescriptionsState
+  originalDataPoints?: RecordAssessmentOriginalDataPoint
   tableData?: RecordAssessmentData
 }
 

--- a/src/client/store/ui/originalDataPoint/slice.ts
+++ b/src/client/store/ui/originalDataPoint/slice.ts
@@ -1,4 +1,4 @@
-import { createSlice, isAnyOf, PayloadAction, Reducer } from '@reduxjs/toolkit'
+import { ActionReducerMapBuilder, createSlice, isAnyOf, PayloadAction, Reducer } from '@reduxjs/toolkit'
 
 import { ODPReservedYear } from 'meta/assessment'
 
@@ -28,7 +28,7 @@ export const originalDataPointSlice = createSlice({
       state.reservedYears = payload
     },
   },
-  extraReducers: (builder) => {
+  extraReducers: (builder: ActionReducerMapBuilder<OriginalDataPointState>) => {
     builder.addCase(
       getOriginalDataPointReservedYears.fulfilled,
       (state, { payload }: PayloadAction<Array<ODPReservedYear>>) => {
@@ -69,17 +69,17 @@ export const originalDataPointSlice = createSlice({
 
 export const OriginalDataPointActions = {
   ...originalDataPointSlice.actions,
-  getOriginalDataPoint,
+  copyNationalClasses,
   createOriginalDataPoint,
   deleteOriginalDataPoint,
   deleteOriginalDataPointNationalClass,
+  getOriginalDataPoint,
+  getOriginalDataPointReservedYears,
   updateOriginalDataPointDataSources,
   updateOriginalDataPointDescription,
   updateOriginalDataPointNationalClasses,
   updateOriginalDataPointOriginalData,
   updateOriginalDataPointYear,
-  copyNationalClasses,
-  getOriginalDataPointReservedYears,
 }
 
 export default originalDataPointSlice.reducer as Reducer<OriginalDataPointState>

--- a/src/client/store/ui/originalDataPoint/stateType.ts
+++ b/src/client/store/ui/originalDataPoint/stateType.ts
@@ -2,6 +2,6 @@ import { ODPReservedYear, OriginalDataPoint } from 'meta/assessment'
 
 export type OriginalDataPointState = {
   data?: OriginalDataPoint
-  updating?: boolean
   reservedYears: Array<ODPReservedYear>
+  updating?: boolean
 }

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -41,9 +41,16 @@ const findElementByName = <Returned extends Element>(element: Element, name: str
   return undefined
 }
 
+const getHtmlTextContent = (html: string): string => {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(html ?? '', 'text/html')
+  return doc.documentElement.textContent || ''
+}
+
 export const DOMs = {
   elementOffset,
   findElementByName,
-  scrollTo,
+  getHtmlTextContent,
   parseDOMValue,
+  scrollTo,
 }

--- a/src/meta/api/endpoint/ApiEndPoint.ts
+++ b/src/meta/api/endpoint/ApiEndPoint.ts
@@ -77,6 +77,7 @@ export const ApiEndPoint = {
       one: () => apiPath('cycle-data', 'original-data-points', 'original-data-point'),
       many: () => apiPath('cycle-data', 'original-data-points'),
       lastUpdatedTimestamp: () => apiPath('cycle-data', 'original-data-points', 'last-updated-timestamp'),
+      history: () => apiPath('cycle-data', 'original-data-points', 'original-data-point', 'history'),
 
       dataSources: () => apiPath('cycle-data', 'original-data-points', 'original-data-point', 'data-sources'),
       description: () => apiPath('cycle-data', 'original-data-points', 'original-data-point', 'description'),

--- a/src/meta/assessment/originalDataPoint/RecordAssessmentOriginalDataPoint.ts
+++ b/src/meta/assessment/originalDataPoint/RecordAssessmentOriginalDataPoint.ts
@@ -1,0 +1,7 @@
+import { AreaCode } from 'meta/area'
+import { AssessmentName, CycleName, OriginalDataPoint } from 'meta/assessment'
+
+export type RecordYearOriginalDataPoint = Record<string, OriginalDataPoint>
+export type RecordCountryOriginalDataPoint = { [key in AreaCode]?: RecordYearOriginalDataPoint }
+export type RecordCycleOriginalDataPoint = Record<CycleName, RecordCountryOriginalDataPoint>
+export type RecordAssessmentOriginalDataPoint = Record<AssessmentName, RecordCycleOriginalDataPoint>

--- a/src/meta/assessment/originalDataPoint/index.ts
+++ b/src/meta/assessment/originalDataPoint/index.ts
@@ -6,3 +6,9 @@ export type { ODPReservedYear } from './odpReservedYear'
 export { ODPs } from './odps'
 export type { ODPValidation, ODPValidationNationalClass, ODPValidationYear } from './odpValidation'
 export type { OriginalDataPoint } from './originalDataPoint'
+export type {
+  RecordAssessmentOriginalDataPoint,
+  RecordCountryOriginalDataPoint,
+  RecordCycleOriginalDataPoint,
+  RecordYearOriginalDataPoint,
+} from './RecordAssessmentOriginalDataPoint'

--- a/src/server/api/cycleData/index.ts
+++ b/src/server/api/cycleData/index.ts
@@ -31,6 +31,7 @@ import { deleteOriginalDataPoint } from './originalDataPoint/deleteOriginalDataP
 import { deleteOriginalDataPointNationalClass } from './originalDataPoint/deleteOriginalDataPointNationalClass'
 import { getLastUpdatedTimestamp } from './originalDataPoint/getLastUpdatedTimestamp'
 import { getOriginalDataPoint } from './originalDataPoint/getOdp'
+import { getOriginalDataPointHistory } from './originalDataPoint/getOriginalDataPointHistory'
 import { getOriginalDataPoints } from './originalDataPoint/getOriginalDataPoints'
 import { getReservedYears } from './originalDataPoint/getReservedYears'
 import { updateOriginalDataPointDataSources } from './originalDataPoint/updateOriginalDataPointDataSources'
@@ -123,6 +124,11 @@ export const CycleDataApi = {
       ApiEndPoint.CycleData.OriginalDataPoint.year(),
       AuthMiddleware.requireEditTableData,
       updateOriginalDataPointYear
+    )
+    express.get(
+      ApiEndPoint.CycleData.OriginalDataPoint.history(),
+      AuthMiddleware.requireViewHistory,
+      getOriginalDataPointHistory
     )
     // OriginalDataPoint NationalClasses
     express.put(

--- a/src/server/api/cycleData/originalDataPoint/getOriginalDataPointHistory.ts
+++ b/src/server/api/cycleData/originalDataPoint/getOriginalDataPointHistory.ts
@@ -1,0 +1,26 @@
+import { Response } from 'express'
+
+import { CycleDataRequest } from 'meta/api/request'
+
+import { Requests } from 'server/utils'
+
+export const getOriginalDataPointHistory = async (_req: CycleDataRequest, res: Response) => {
+  try {
+    // TODO: Add suport for non-empty last cycle odps
+    const odpHistory = {
+      // Example of the object:
+      // countryIso: 'FIN',
+      // year: '1990',
+      // dataSourceAdditionalComments: '',
+      // dataSourceMethods: [],
+      // dataSourceReferences: '',
+      // description: '',
+      // nationalClasses: [],
+      // values: {},
+    }
+
+    Requests.send(res, odpHistory)
+  } catch (e) {
+    Requests.sendErr(res, e)
+  }
+}

--- a/src/utils/objects/getInPath.ts
+++ b/src/utils/objects/getInPath.ts
@@ -1,3 +1,3 @@
-export const getInPath = (obj: any, path: string[]) => {
+export const getInPath = (obj: any, path: Array<string | number>) => {
   return path.reduce((acc, pathPart) => acc?.[pathPart], obj)
 }


### PR DESCRIPTION
Initial ODP history PR, cherry picked from: [f595ba614a1eb99c8fa97ec59e4a59523e89bdc0](https://github.com/openforis/fra-platform/pull/4328/commits/f595ba614a1eb99c8fa97ec59e4a59523e89bdc0)

https://github.com/user-attachments/assets/ccc88859-169a-4e01-b1f7-5d7c3a9d3a19

* 4253 - ODP history: Dummy API

* 4253 - ODP history: Fetch and update store

* 4253 - ODP history: data sources diffs

* 4253 - ODP history: NationalClass diffs

* 4253 - ODP history: update new reducer imports

* 4253 - ODP history: move odp history store definitions under store->data

* 4253 - ODP history: fix diff text and conditional renders

* 4253 - ODP history: Rename DiffView to ODPDiffText and add paddings

* 4253 - ODP history: Remove unnecessary type cast

* 4253 - ODP history: make history store var plural

* 4253 - ODP history: odp history return empty obj

* 4253 - ODP history: add DOMs getHtmlTextContent utility