### PR TITLE
4253 - Data History: ODP comparison - Conditional history table renders

### DIFF
--- a/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristics.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristics.tsx
@@ -13,6 +13,7 @@ import DefinitionLink from 'client/components/DefinitionLink'
 import DiffText from 'client/components/DiffText'
 
 import { useForestCharacteristicsTotalsChange } from './hooks/useForestCharacteristicsTotalsChange'
+import { useHistoryHasNaturallyRegeneratingAndPlantationForest } from './hooks/useHistoryHasNaturallyRegeneratingAndPlantationForest'
 import ForestCharacteristicsNaturallyRegenerating from './ForestCharacteristicsNaturallyRegenerating'
 import ForestCharacteristicsPlantation from './ForestCharacteristicsPlantation'
 import ForestCharacteristicsRow from './ForestCharacteristicsRow'
@@ -65,6 +66,9 @@ const ForestCharacteristics: React.FC<Props> = (props) => {
     totalOtherPlantedForestPercentArea,
   })
 
+  const { historyHasNaturallyRegeneratingForest, historyHasPlantationForest } =
+    useHistoryHasNaturallyRegeneratingAndPlantationForest()
+
   const nationalClasses = originalDataPoint.nationalClasses.filter((nationalClass) => !nationalClass.placeHolder)
   const plantationTotal = ODPs.calcTotalSubFieldArea({
     originalDataPoint,
@@ -77,7 +81,7 @@ const ForestCharacteristics: React.FC<Props> = (props) => {
     subField: 'forestNaturalPercent',
   })
 
-  const hasPlantation = plantationTotal && Numbers.greaterThanOrEqualTo(plantationTotal, 0)
+  const hasPlantationForest = plantationTotal && Numbers.greaterThanOrEqualTo(plantationTotal, 0)
   //  naturally regenerating forest is not available in Cycle 2020
   const hasNaturallyRegeneratingForest =
     cycleName !== '2020' &&
@@ -178,8 +182,12 @@ const ForestCharacteristics: React.FC<Props> = (props) => {
           </table>
         </div>
       </div>
-      {hasNaturallyRegeneratingForest && <ForestCharacteristicsNaturallyRegenerating canEditData={canEditData} />}
-      {hasPlantation && <ForestCharacteristicsPlantation canEditData={canEditData} />}
+      {(hasNaturallyRegeneratingForest || historyHasNaturallyRegeneratingForest) && (
+        <ForestCharacteristicsNaturallyRegenerating canEditData={canEditData} />
+      )}
+      {(hasPlantationForest || historyHasPlantationForest) && (
+        <ForestCharacteristicsPlantation canEditData={canEditData} />
+      )}
     </div>
   )
 }

--- a/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/hooks/useHistoryHasNaturallyRegeneratingAndPlantationForest.ts
+++ b/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/hooks/useHistoryHasNaturallyRegeneratingAndPlantationForest.ts
@@ -1,0 +1,50 @@
+import { useMemo } from 'react'
+
+import { Numbers } from 'utils/numbers'
+import { Objects } from 'utils/objects'
+
+import { ODPs } from 'meta/assessment'
+
+import { useHistoryLastApprovedIsActive } from 'client/store/data'
+import { useLastApprovedOriginalDataPoint } from 'client/store/data/hooks/useLastApprovedOriginalDataPoint'
+
+type Returned = {
+  historyHasNaturallyRegeneratingForest: boolean
+  historyHasPlantationForest: boolean
+}
+
+export const useHistoryHasNaturallyRegeneratingAndPlantationForest = (): Returned => {
+  const originalDataPointHistory = useLastApprovedOriginalDataPoint()
+  const historyLastApprovedIsActive = useHistoryLastApprovedIsActive()
+
+  return useMemo<Returned>(() => {
+    const canCalculate = !Objects.isEmpty(originalDataPointHistory)
+
+    if (!historyLastApprovedIsActive || !canCalculate) {
+      return {
+        historyHasNaturallyRegeneratingForest: false,
+        historyHasPlantationForest: false,
+      }
+    }
+
+    const plantationTotal = ODPs.calcTotalSubFieldArea({
+      originalDataPoint: originalDataPointHistory,
+      field: 'forestPercent',
+      subField: 'forestPlantationPercent',
+    })
+    const historyHasPlantationForest = plantationTotal && Numbers.greaterThanOrEqualTo(plantationTotal, 0)
+
+    const naturallyRegeneratingForestTotal = ODPs.calcTotalSubFieldArea({
+      originalDataPoint: originalDataPointHistory,
+      field: 'forestPercent',
+      subField: 'forestNaturalPercent',
+    })
+    const historyHasNaturallyRegeneratingForest =
+      naturallyRegeneratingForestTotal && Numbers.greaterThanOrEqualTo(naturallyRegeneratingForestTotal, 0)
+
+    return {
+      historyHasNaturallyRegeneratingForest,
+      historyHasPlantationForest,
+    }
+  }, [historyLastApprovedIsActive, originalDataPointHistory])
+}


### PR DESCRIPTION
If the current ODP has naturally regenerating or plantation forest, the diff tables for those are always rendered respectively regardless of the ODP history data.

Now in this PR we are handling the case where the current ODP does not have naturally regenerating or plantation forest, but the history ODP does.


https://github.com/user-attachments/assets/eb2a0f97-96e3-4398-94c2-76c6161a5c29






Closes #4253


