### PR TITLE
4307 - Data History: DiffDOM - Modify text element

### DIFF
--- a/src/client/components/DiffDOM/DiffDOM.tsx
+++ b/src/client/components/DiffDOM/DiffDOM.tsx
@@ -11,7 +11,7 @@ const DiffDOM: React.FC<DiffDOMProps> = (props) => {
   const __html = useMemo<string>(() => cleanDOM(prev), [prev])
   useDOMChanges({ current, prev, ref })
 
-  return <div ref={ref} className="editorWYSIWYG jodit-wysiwyg" dangerouslySetInnerHTML={{ __html }} />
+  return <div ref={ref} className="editorWYSIWYG jodit-wysiwyg diff-text" dangerouslySetInnerHTML={{ __html }} />
 }
 
 export default DiffDOM

--- a/src/client/components/DiffDOM/hooks/_addElement.ts
+++ b/src/client/components/DiffDOM/hooks/_addElement.ts
@@ -4,9 +4,5 @@ import { applyDiffClassToElement } from './utils'
 
 export const addElement = (info: DiffInfo<DiffInfoAction.addElement>) => {
   // eslint-disable-next-line no-param-reassign
-  info.diff.element = {
-    nodeName: 'div',
-    attributes: { class: 'diff-text' },
-    childNodes: info.diff.element ? [applyDiffClassToElement(info.diff.element, DiffType.added)] : [],
-  }
+  info.diff.element = applyDiffClassToElement(info.diff.element, DiffType.added)
 }

--- a/src/client/components/DiffDOM/hooks/_getTextDiffNode.ts
+++ b/src/client/components/DiffDOM/hooks/_getTextDiffNode.ts
@@ -1,11 +1,11 @@
 import * as Diff from 'diff'
 
 export const getTextDiffNode = (currentValue: string, newValue: string): HTMLDivElement => {
-  const changes = Diff.diffChars(currentValue.replaceAll('&nbsp;', '\u00A0'), newValue.replaceAll('&nbsp;', '\u00A0'))
+  const changes = Diff.diffLines(currentValue.replaceAll('&nbsp;', '\u00A0'), newValue.replaceAll('&nbsp;', '\u00A0'))
 
   const newNode = document.createElement('div')
 
-  changes.forEach((change) => {
+  changes.forEach((change, i) => {
     const { added, removed, value } = change
 
     value.split('\n\r').forEach((text) => {
@@ -14,6 +14,10 @@ export const getTextDiffNode = (currentValue: string, newValue: string): HTMLDiv
       if (removed) span.classList.add('removed')
       span.textContent = text
       newNode.appendChild(span)
+
+      if (i < changes.length - 1) {
+        newNode.appendChild(document.createElement('br'))
+      }
     })
   })
 

--- a/src/client/components/DiffDOM/hooks/_getTextDiffNode.ts
+++ b/src/client/components/DiffDOM/hooks/_getTextDiffNode.ts
@@ -1,0 +1,21 @@
+import * as Diff from 'diff'
+
+export const getTextDiffNode = (currentValue: string, newValue: string): HTMLDivElement => {
+  const changes = Diff.diffChars(currentValue.replaceAll('&nbsp;', '\u00A0'), newValue.replaceAll('&nbsp;', '\u00A0'))
+
+  const newNode = document.createElement('div')
+
+  changes.forEach((change) => {
+    const { added, removed, value } = change
+
+    value.split('\n\r').forEach((text) => {
+      const span = document.createElement('span')
+      if (added) span.classList.add('added')
+      if (removed) span.classList.add('removed')
+      span.textContent = text
+      newNode.appendChild(span)
+    })
+  })
+
+  return newNode
+}

--- a/src/client/components/DiffDOM/hooks/useDOMChanges.ts
+++ b/src/client/components/DiffDOM/hooks/useDOMChanges.ts
@@ -5,6 +5,7 @@ import { DiffDOM, stringToObj } from 'diff-dom'
 import { DiffDOMProps, DiffInfo, DiffInfoAction } from 'client/components/DiffDOM/types'
 
 import { addElement } from './_addElement'
+import { getTextDiffNode } from './_getTextDiffNode'
 import { replaceElement } from './_replaceElement'
 import { normalizeDiffDOM } from './utils'
 
@@ -24,10 +25,16 @@ export const useDOMChanges = (props: Props) => {
             replaceElement(info as DiffInfo<DiffInfoAction.replaceElement>)
             return false
           case DiffInfoAction.addElement:
-            addElement(info as DiffInfo<DiffInfoAction.addElement>) // TODO: Find a way to avoid typecast
+            addElement(info as DiffInfo<DiffInfoAction.addElement>)
             return false
           default:
             return false
+        }
+      },
+      textDiff(node, currentValue, _expectedValue, newValue) {
+        if (currentValue === newValue) return
+        if (node instanceof Text) {
+          node.replaceWith(getTextDiffNode(currentValue, newValue))
         }
       },
     })

--- a/src/client/components/DiffDOM/hooks/useDOMChanges.ts
+++ b/src/client/components/DiffDOM/hooks/useDOMChanges.ts
@@ -32,7 +32,6 @@ export const useDOMChanges = (props: Props) => {
         }
       },
       textDiff(node, currentValue, _expectedValue, newValue) {
-        if (currentValue === newValue) return
         if (node instanceof Text) {
           node.replaceWith(getTextDiffNode(currentValue, newValue))
         }


### PR DESCRIPTION
Adding diffs with `textDiff`, which  is called internally on the modifyTextElement case ([as seen here](https://github.com/fiduswriter/diffDOM/blob/main/src/diffDOM/dom/apply.ts#L83))

(UPDATED)

https://github.com/user-attachments/assets/ab014ccc-3070-4da2-9a62-1ab45cc67002


