### PR TITLE
4496 - PDF - Column Readability

### DIFF
--- a/src/client/components/EditorWYSIWYG/EditorWYSIWYG.scss
+++ b/src/client/components/EditorWYSIWYG/EditorWYSIWYG.scss
@@ -4,6 +4,10 @@ div.editorWYSIWYG {
   height: 100%;
   word-break: break-word;
 
+  table {
+    word-break: normal;
+  }
+
   p,
   table,
   ul {


### PR DESCRIPTION
Enabling in the video
```
table {
    word-break: normal;
}
```
:

https://github.com/user-attachments/assets/7263e2f8-3aba-4353-91b9-6f261389f987

PDF:
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/b7d59ef3-3637-41a8-8af6-3950b216612c" />
after:
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/cc797085-82d2-49ee-a9f0-d69be0ff93a1" />
