### PR TITLE
4560 - PDF - Fix Table 3a overflowing

### DIFF
--- a/src/client/components/EditorWYSIWYG/EditorWYSIWYG.scss
+++ b/src/client/components/EditorWYSIWYG/EditorWYSIWYG.scss
@@ -66,5 +66,9 @@ div.editorWYSIWYG {
     table {
       width: auto;
     }
+
+    td[nowrap] {
+      white-space: normal;
+    }
   }
 }


### PR DESCRIPTION
<img width="388" alt="image" src="https://github.com/user-attachments/assets/16a338dd-54ea-4e2c-ac9b-65371e6d2f4e" />

User-entered tables before/after
<img width="42" alt="image" src="https://github.com/user-attachments/assets/831762ec-2bcc-4909-9f12-6986b82d8b81" />


<img width="73" alt="image" src="https://github.com/user-attachments/assets/c417fb81-4e74-4865-9980-69a844aea026" />
