### PR TITLE
4556 - PDF - Fix table rows content splitting

### DIFF
--- a/src/client/components/EditorWYSIWYG/EditorWYSIWYG.scss
+++ b/src/client/components/EditorWYSIWYG/EditorWYSIWYG.scss
@@ -70,5 +70,10 @@ div.editorWYSIWYG {
     td[nowrap] {
       white-space: normal;
     }
+
+    tr {
+      break-inside: avoid-page;
+      page-break-inside: avoid;
+    }
   }
 }


### PR DESCRIPTION
Before
<img width="460" alt="Amazonia" src="https://github.com/user-attachments/assets/c5d61a30-ea77-4373-82b2-832ea3e87ab6" />


After
<img width="419" alt="Amazonia" src="https://github.com/user-attachments/assets/16ce22fc-d28b-4a44-852f-6b0141a18fe8" />


other instances like this one mentioned in the issue:
<img width="840" alt="image" src="https://github.com/user-attachments/assets/aff9aeb0-9ee1-4739-a0ff-5079809db82b" />

are already fixed by the footer spacing PR previously made:
<img width="977" alt="image" src="https://github.com/user-attachments/assets/154c4a0e-0e8a-4f34-bcd4-7afd7e001edb" />

Only detail that couldn't be fixed was stretching the first col height to match the carried over row (This is the only place I've seen it happen so far). 
