### PR TITLE
4555 - PDF - Title & Content Separation fix

### DIFF
--- a/src/client/components/DataGrid/DataCell/DataCell.scss
+++ b/src/client/components/DataGrid/DataCell/DataCell.scss
@@ -168,3 +168,9 @@ $highlight-top-bottom: inset 0 1px $ui-accent, inset 0 -1px $ui-accent;
     border: unset;
   }
 }
+
+@include print {
+  .data-cell:not(:has(.editorWYSIWYG)) {
+    @include print-break-inside-avoid-page;
+  }
+}

--- a/src/client/components/DataGrid/DataGrid/DataGrid.tsx
+++ b/src/client/components/DataGrid/DataGrid/DataGrid.tsx
@@ -17,7 +17,7 @@ const DataGrid = forwardRef<HTMLDivElement, Props>((props, outerRef) => {
   }, [gridColumn, gridTemplateColumns, withActions])
 
   return (
-    <div ref={outerRef} className={classNames('data-grid print-break-inside-avoid', className)} style={style}>
+    <div ref={outerRef} className={classNames('data-grid', className)} style={style}>
       {React.Children.toArray(children)}
     </div>
   )

--- a/src/client/components/EditorWYSIWYG/EditorWYSIWYG.scss
+++ b/src/client/components/EditorWYSIWYG/EditorWYSIWYG.scss
@@ -72,8 +72,7 @@ div.editorWYSIWYG {
     }
 
     tr {
-      break-inside: avoid-page;
-      page-break-inside: avoid;
+      @include print-break-inside-avoid-page;
     }
   }
 }

--- a/src/client/pages/OriginalDataPoint/components/ExtentOfForest/ExtentOfForest.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ExtentOfForest/ExtentOfForest.tsx
@@ -73,7 +73,7 @@ const ExtentOfForest: React.FC<Props> = (props) => {
           />
         </div>
       )}
-      <div className="fra-table__container print-break-inside-avoid">
+      <div className="fra-table__container">
         <div className="fra-table__scroll-wrapper">
           <table ref={tableRef} className="fra-table ">
             <tbody>

--- a/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristics.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristics.tsx
@@ -111,7 +111,7 @@ const ForestCharacteristics: React.FC<Props> = (props) => {
         </div>
       )}
 
-      <div className="fra-table__container print-break-inside-avoid">
+      <div className="fra-table__container">
         <div className="fra-table__scroll-wrapper">
           <table ref={tableRef} className="fra-table">
             <tbody>

--- a/src/client/pages/OriginalDataPoint/components/NationalClasses/NationalClasses.tsx
+++ b/src/client/pages/OriginalDataPoint/components/NationalClasses/NationalClasses.tsx
@@ -17,7 +17,7 @@ const NationalClasses: React.FC<Props> = (props) => {
   const gridRef = useRef<HTMLDivElement>(null)
 
   return (
-    <div className="odp__section print-break-inside-avoid">
+    <div className="odp__section">
       <Title gridRef={gridRef} year={year} />
       <Prefill canEditData={canEditData} originalDataPoint={originalDataPoint} />
       <NationalClassesTable gridRef={gridRef} originalDataPoint={originalDataPoint} />

--- a/src/client/pages/Print/OriginalDataPointsPrint/OriginalDataPointsPrint.tsx
+++ b/src/client/pages/Print/OriginalDataPointsPrint/OriginalDataPointsPrint.tsx
@@ -55,7 +55,7 @@ const OriginalDataPointsPrint: React.FC<Props> = (props) => {
         </>
       )}
 
-      <div className="odp__section-print-mode print-break-inside-avoid">
+      <div className="odp__section-print-mode">
         <h3 className="subhead">{i18n.t('nationalDataPoint.reclassificationLabel')}</h3>
         {originalDataPoints.map((originalDataPoint) => {
           const Component = isExtendOfForest ? ExtentOfForest : ForestCharacteristics
@@ -68,7 +68,7 @@ const OriginalDataPointsPrint: React.FC<Props> = (props) => {
       </div>
 
       {isExtendOfForest && hasDescriptions && (
-        <div className="odp__section-print-mode print-break-inside-avoid">
+        <div className="odp__section-print-mode">
           <h3 className="subhead">{i18n.t('dataSource.comments')}</h3>
           <DataGrid className="odp__section" gridTemplateColumns="100px 1fr">
             {originalDataPoints.map((originalDataPoint, i) => {

--- a/src/client/pages/Print/style.scss
+++ b/src/client/pages/Print/style.scss
@@ -23,6 +23,10 @@
   .fra-table {
     margin: 0 1px;
     width: calc(100% - 2px);
+
+    tr {
+      @include print-break-inside-avoid-page;
+    }
   }
 
   .fra-table__header-cell-left,

--- a/src/client/pages/Section/Contacts/Contacts.tsx
+++ b/src/client/pages/Section/Contacts/Contacts.tsx
@@ -41,7 +41,7 @@ const Contacts: React.FC = () => {
   if ((print || !Users.isAdministrator(user)) && hideContactsTable) return null
 
   return (
-    <div className="contacts print-break-inside-avoid">
+    <div className="contacts">
       <ContactsTitle />
 
       {!hideContactsTable && (

--- a/src/client/pages/Section/Descriptions/CommentableDescription/CommentableDescription.tsx
+++ b/src/client/pages/Section/Descriptions/CommentableDescription/CommentableDescription.tsx
@@ -42,7 +42,7 @@ const CommentableDescription: React.FC<Props> = (props) => {
   const onChange = useOnChange({ sectionName, name })
 
   return (
-    <DataGrid className="description print-break-inside-avoid" withActions={canEdit}>
+    <DataGrid className="description" withActions={canEdit}>
       <Title name={name} title={title} />
 
       <DataRow>

--- a/src/client/style/_partials/_print.scss
+++ b/src/client/style/_partials/_print.scss
@@ -3,3 +3,8 @@
     @content;
   }
 }
+
+@mixin print-break-inside-avoid-page {
+  break-inside: avoid-page;
+  page-break-inside: avoid;
+}


### PR DESCRIPTION
Before/after
<img width="966" alt="image" src="https://github.com/user-attachments/assets/9102f316-0e99-40c8-be7f-80ba618c4e1d" />

<img width="835" alt="image" src="https://github.com/user-attachments/assets/9850d071-d9bf-45c6-ba05-f1189e13ae79" />

To consider: Because the data cells now don't split between pages, some borders can look like this when the next row goes to the next page:
<img width="670" alt="image" src="https://github.com/user-attachments/assets/50f30411-d8d8-49e2-a88a-38c6c3158430" />

This is because of how draw the borders. Ideally the border bottom would be there, but targeting that last row in the page didn't seem possible with css. 