### PR TITLE
4583 - Firefox crashing fix

### DIFF
--- a/src/client/pages/Section/Descriptions/CommentableDescription/hooks/useDescriptionErrorState.ts
+++ b/src/client/pages/Section/Descriptions/CommentableDescription/hooks/useDescriptionErrorState.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 
-import { Objects } from 'utils/objects'
+import { Parser } from 'htmlparser2'
 
 import { CommentableDescriptionName } from 'meta/assessment/descriptionValue'
 import { SectionName } from 'meta/assessment/section'
@@ -8,14 +8,26 @@ import { SectionName } from 'meta/assessment/section'
 import { useCommentableDescriptionValue } from 'client/store/data'
 
 const isHTMLEmpty = (html: string): boolean => {
-  if (Objects.isEmpty(html?.trim())) return true
+  if (!html) return true
 
-  const strippedHtml = html
-    .replace(/<[^>]*>/g, '')
-    .replace(/&nbsp;/g, ' ')
-    .trim()
+  let hasVisibleText = false
+  const parser = new Parser(
+    {
+      ontext(text) {
+        // Stop parsing as soon as a non-whitespace character is found
+        if (/\S/.test(text)) {
+          hasVisibleText = true
+          parser.pause()
+        }
+      },
+    },
+    { decodeEntities: true }
+  )
 
-  return !strippedHtml
+  parser.write(html)
+  parser.end()
+
+  return !hasVisibleText
 }
 
 type Props = {

--- a/src/client/pages/Section/Descriptions/CommentableDescription/hooks/useDescriptionErrorState.ts
+++ b/src/client/pages/Section/Descriptions/CommentableDescription/hooks/useDescriptionErrorState.ts
@@ -8,6 +8,8 @@ import { SectionName } from 'meta/assessment/section'
 import { useCommentableDescriptionValue } from 'client/store/data'
 
 const isHTMLEmpty = (html: string): boolean => {
+  // Objects.isEmpty() calls trim() internally, which causes
+  // crashes with large strings in Firefox. It is avoided here.
   if (!html) return true
 
   let hasVisibleText = false


### PR DESCRIPTION
Previously in `useDescriptionErrorState.ts -> isHTMLEmpty ` we used `Objects.isEmpty(DOMs.parseDOMValue(value.text))`, and then we changed it for a regex to avoid creating a virtual DOM.

There are two different issues to be addressed:
1. In Firefox, the trim() function with large strings crashes the app:
<img width="904" alt="image" src="https://github.com/user-attachments/assets/df891f65-8a0f-475a-8e80-0b3eb922b916" />

This seems to be an internal Firefox specific issue.


2. in Firefox and Chrome, when navigating to, for example, 2b Forest growing stock composition in FRA Latest USA, the app freezes for a while due to the regex evaluation taking a long time on the large html that is there.
<img width="1101" alt="image" src="https://github.com/user-attachments/assets/49732a2e-a7ab-489e-a62e-db024408fbbc" />


Fix: 
1. Avoiding calling `trim()` on the html
2. Using `htmlparser2` `Parse`, which stream parses the html, does not create a virtual DOM, and can be stopped early if a visible text has already been found. This way there is no need to go through all the html, making the method call very quick and avoiding the app freezing. 
