### PR TITLE
4610 - PDF - Fix blank page: Remove hints container in print view

### DIFF
--- a/src/client/pages/Section/Title/Title.tsx
+++ b/src/client/pages/Section/Title/Title.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import { SectionName } from 'meta/assessment/section'
 
+import { useIsPrintRoute } from 'client/hooks/useIsRoute'
 import { useCycleRouteParams } from 'client/hooks/useRouteParams'
 import { Components, TitleDefault } from 'client/pages/Section/Title/Components'
 import Hints, { HintsSustainableDevelopment } from 'client/pages/Section/Title/Hints'
@@ -19,6 +20,8 @@ const Title: React.FC<Props> = (props) => {
 
   const { assessmentName } = useCycleRouteParams()
 
+  const { print } = useIsPrintRoute()
+
   const Component = Components[assessmentName]?.[sectionName] ?? TitleDefault
   const HintsComponent = HintsComponents[sectionName] ?? Hints
 
@@ -26,7 +29,7 @@ const Title: React.FC<Props> = (props) => {
     <div className="section__title">
       {React.createElement(Component, { subSection })}
 
-      <HintsComponent subSection={subSection} />
+      {!print && <HintsComponent subSection={subSection} />}
     </div>
   )
 }


### PR DESCRIPTION

The issue was this empty div for the hints affecting the layout in the print view:

<img width="1402" alt="image" src="https://github.com/user-attachments/assets/890414a3-fd0a-4402-9fc4-b4964eb76280" />


fixed:
<img width="889" alt="image" src="https://github.com/user-attachments/assets/50799f48-f68b-48b1-854c-dc239f797f25" />
