### PR TITLE
4621 - PDF - Adjust Year for data source column width

### DIFF
--- a/src/client/pages/Section/Descriptions/NationalDataDescriptions/DataSources/DataSources.tsx
+++ b/src/client/pages/Section/Descriptions/NationalDataDescriptions/DataSources/DataSources.tsx
@@ -70,7 +70,7 @@ export const DataSources: React.FC<Props> = (props: Props) => {
 
           <DataGrid
             gridColumn={canEdit ? `1/3` : undefined}
-            gridTemplateColumns="minmax(200px, 1fr) minmax(200px, 1fr) minmax(200px, 1fr) minmax(150px, 300px) minmax(150px, 1fr)"
+            gridTemplateColumns="minmax(200px, 1fr) minmax(200px, 1fr) minmax(200px, 1fr) minmax(150px, 1fr) minmax(150px, 1fr)"
             withActions={canEdit}
           >
             <DataCell header>{t(`${keyPrefix}.referenceToTataSource`)}</DataCell>


### PR DESCRIPTION
Before
￼
<img width="843" alt="Pasted Graphic 41" src="https://github.com/user-attachments/assets/cafb63b6-bfb7-42e9-9982-bbf4ee56b179" />

After

<img width="1103" alt="Pasted Graphic 40" src="https://github.com/user-attachments/assets/bf58278a-2962-4a9e-a729-3214a1522643" />

Confirmed with @pengchenglai that same width for all columns is preferred, rather than smaller for the year. 