### PR TITLE
fixed year in title for JRC Forest 2020 in English. Added to missing languages too. 

### DIFF
--- a/src/i18n/resources/ar/geo.json
+++ b/src/i18n/resources/ar/geo.json
@@ -61,7 +61,7 @@
         "hansenGfc2020": "هانسن جي إف سي (2020)",
         "hansenGfc2020WithPercent": "$t(geo.sections.forest.layerTitles.hansenGfc2020) {{hansenPercent}} %",
         "jaxa2017": "وكالة الفضاء اليابانية (2017)",
-        "jrc2020": "JRC Forest 2000",
+        "jrc2020": "غابات المركز المشترك للأبحاث 2020",
         "modis": "موديس",
         "tanDemX2019": "تانديم-إكس (2019)"
       },

--- a/src/i18n/resources/en/geo.json
+++ b/src/i18n/resources/en/geo.json
@@ -61,7 +61,7 @@
         "hansenGfc2020": "Hansen GFC (2020)",
         "hansenGfc2020WithPercent": "$t(geo.sections.forest.layerTitles.hansenGfc2020) {{hansenPercent}} %",
         "jaxa2017": "JAXA (2017)",
-        "jrc2020": "JRC Forest 2000",
+        "jrc2020": "JRC Forest 2020",
         "modis": "MODIS",
         "tanDemX2019": "TanDEM-X (2019)"
       },

--- a/src/i18n/resources/es/geo.json
+++ b/src/i18n/resources/es/geo.json
@@ -61,7 +61,7 @@
         "hansenGfc2020": "Hansen GFC (2020)",
         "hansenGfc2020WithPercent": "$t(geo.sections.forest.layerTitles.hansenGfc2020) {{hansenPercent}} %",
         "jaxa2017": "JAXA (2017)",
-        "jrc2020": "JRC Bosque 2000",
+        "jrc2020": "JRC Forest 2020",
         "modis": "MODIS",
         "tanDemX2019": "TanDEM-X (2019)"
       },

--- a/src/i18n/resources/fr/geo.json
+++ b/src/i18n/resources/fr/geo.json
@@ -61,7 +61,7 @@
         "hansenGfc2020": "Hansen GFC (2020)",
         "hansenGfc2020WithPercent": "$t(geo.sections.forest.layerTitles.hansenGfc2020) {{hansenPercent}} %",
         "jaxa2017": "JAXA (2017)",
-        "jrc2020": "JRC Forest 2000",
+        "jrc2020": "JRC Forest 2020",
         "modis": "MODIS",
         "tanDemX2019": "TanDEM-X (2019)"
       },

--- a/src/i18n/resources/ru/geo.json
+++ b/src/i18n/resources/ru/geo.json
@@ -61,7 +61,7 @@
         "hansenGfc2020": "Hansen GFC (2020)",
         "hansenGfc2020WithPercent": "$t(geo.sections.forest.layerTitles.hansenGfc2020) {{hansenPercent}} %",
         "jaxa2017": "JAXA (2017)",
-        "jrc2020": "JRC Forest 2000",
+        "jrc2020": "JRC Forest 2020",
         "modis": "MODIS",
         "tanDemX2019": "TanDEM-X (2019)"
       },

--- a/src/i18n/resources/zh/geo.json
+++ b/src/i18n/resources/zh/geo.json
@@ -61,7 +61,7 @@
         "hansenGfc2020": "Hansen GFC (2020)",
         "hansenGfc2020WithPercent": "$t(geo.sections.forest.layerTitles.hansenGfc2020) {{hansenPercent}} %",
         "jaxa2017": "JAXA (2017)",
-        "jrc2020": "JRC Forest 2000",
+        "jrc2020": "JRC Forest 2020",
         "modis": "MODIS",
         "tanDemX2019": "TanDEM-X (2019)"
       },


### PR DESCRIPTION
Based on up to date repo this time (hopefully).
JRC forest layer from 2000 to 2020, updated titles in other languages (the same as it's what we use as the official layer name