### PR TITLE
4205 - Data Explorer UI - Format values & change select style

### DIFF
--- a/src/client/components/Inputs/SelectSecondary/SelectSecondary.scss
+++ b/src/client/components/Inputs/SelectSecondary/SelectSecondary.scss
@@ -1,0 +1,62 @@
+@use 'sass:color';
+
+@import 'src/client/style/partials';
+
+$btnHeight: $spacing-s;
+
+div.select-secondary__container {
+  background-color: white;
+  border-radius: 2px;
+  border: 1px solid $ui-accent;
+  min-width: 100px;
+
+  div.select__control {
+    min-height: $btnHeight;
+    padding: 0 $spacing-xxs;
+  }
+
+  div.select__valueContainer {
+    font-size: $font-xs;
+    font-weight: 400;
+  }
+
+  div.select__singleValue {
+    color: $text-body;
+  }
+
+  div.select__dropdownIndicator {
+    svg {
+      color: $text-body;
+      height: 12px;
+      width: 12px;
+    }
+  }
+
+  // menu and options
+  div.select__menu {
+    border-color: $ui-accent;
+    font-size: $font-xs;
+
+    &.bottom {
+      margin-top: 1px;
+    }
+
+    &.top {
+      margin-bottom: 1px;
+    }
+  }
+
+  div.select__option {
+    font-weight: normal;
+    padding: $spacing-xxxs 6px;
+
+    &.isFocused {
+      background-color: rgba($ui-accent, 0.1);
+    }
+
+    &.isSelected {
+      color: $text-body;
+      font-weight: 600;
+    }
+  }
+}

--- a/src/client/components/Inputs/SelectSecondary/SelectSecondary.tsx
+++ b/src/client/components/Inputs/SelectSecondary/SelectSecondary.tsx
@@ -1,0 +1,25 @@
+import './SelectSecondary.scss'
+import React from 'react'
+
+import Select from 'client/components/Inputs/Select'
+import { SelectProps } from 'client/components/Inputs/Select/types'
+
+const SelectSecondary: React.FC<SelectProps> = (props) => {
+  const { disabled, isClearable, isMulti, maxMenuHeight, onChange, options, placeholder, value } = props
+
+  return (
+    <Select
+      classNames={{ container: 'select-secondary__container' }}
+      disabled={disabled}
+      isClearable={isClearable}
+      isMulti={isMulti}
+      maxMenuHeight={maxMenuHeight}
+      onChange={onChange}
+      options={options}
+      placeholder={placeholder}
+      value={value}
+    />
+  )
+}
+
+export default SelectSecondary

--- a/src/client/components/Inputs/SelectSecondary/index.ts
+++ b/src/client/components/Inputs/SelectSecondary/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SelectSecondary'

--- a/src/client/pages/Explorer/ResultGrid/MeasureTitle/MeasureTitle.tsx
+++ b/src/client/pages/Explorer/ResultGrid/MeasureTitle/MeasureTitle.tsx
@@ -9,7 +9,7 @@ import { Measures } from 'meta/measurement/measures'
 
 import { useExplorerSectionMetadata } from 'client/store/explorer/metadata/hooks/metadata'
 import { useExplorerUnits } from 'client/store/explorer/selection/hooks/units'
-import SelectPrimary from 'client/components/Inputs/SelectPrimary'
+import SelectSecondary from 'client/components/Inputs/SelectSecondary'
 
 import { useOnUnitChange } from './hooks/useOnUnitChange'
 import { useUnitOptions } from './hooks/useUnitOptions'
@@ -39,7 +39,7 @@ const MeasureTitle: React.FC<Props> = (props) => {
     <div className="measure-title">
       <span>{t(Measures.getTName(measureName))}</span>
       {system && unitOptions.length > 1 && (
-        <SelectPrimary isClearable={false} onChange={onUnitChange} options={unitOptions} value={selectedUnit} />
+        <SelectSecondary isClearable={false} onChange={onUnitChange} options={unitOptions} value={selectedUnit} />
       )}
       {!Objects.isEmpty(system?.baseUnitName) && unitOptions.length <= 1 && (
         <span>{` (${t(`unit.${system.baseUnitName}`)})`}</span>

--- a/src/client/pages/Explorer/ResultGrid/Observation/hooks/useValue.ts
+++ b/src/client/pages/Explorer/ResultGrid/Observation/hooks/useValue.ts
@@ -6,6 +6,8 @@ import { RecordAssessmentDatas } from 'meta/data'
 import { Dimensions } from 'meta/measurement/dimensions'
 import { Measure } from 'meta/measurement/measure'
 import { Measures } from 'meta/measurement/measures'
+import { Observations } from 'meta/measurement/observations'
+import { SystemOfMeasurementName } from 'meta/measurement/systemOfMeasurement'
 import { Units } from 'meta/measurement/units'
 
 import { useExplorerSectionMetadata } from 'client/store/explorer/metadata/hooks/metadata'
@@ -30,7 +32,7 @@ export const useValue = (props: ObservationProps): Returned => {
   )
 
   return useMemo<Returned>(() => {
-    const value = RecordAssessmentDatas.getDatum({
+    const rawValue = RecordAssessmentDatas.getDatum({
       assessmentName,
       colName: Dimensions.dimensionNameToColumnName(dimensionName),
       countryIso,
@@ -40,15 +42,21 @@ export const useValue = (props: ObservationProps): Returned => {
       variableName: Measures.measureNameToVariableName(measureName),
     })
 
-    if (Objects.isEmpty(measure)) return value
+    if (Objects.isEmpty(rawValue)) return rawValue
 
-    const system = systemsOfMeasurements?.[measure.systemName]
-    if (Objects.isEmpty(system)) return value
-    if (Object.keys(system.units).length === 1) return value
+    let valueToFormat = rawValue
+    let systemName: SystemOfMeasurementName | undefined
 
-    const unitName = selectedUnits?.[measureName] ?? system.baseUnitName
+    if (!Objects.isEmpty(measure)) {
+      const system = systemsOfMeasurements?.[measure.systemName]
+      if (!Objects.isEmpty(system)) {
+        const unitName = selectedUnits?.[measureName] ?? system.baseUnitName
+        valueToFormat = Units.convertValue(rawValue, unitName, system)
+        systemName = system.name
+      }
+    }
 
-    return Units.convertValue(value, unitName, system)
+    return Observations.formatValue({ systemName, value: valueToFormat })
   }, [
     assessmentName,
     countryIso,

--- a/src/client/pages/Explorer/ResultGrid/Observation/hooks/useValue.ts
+++ b/src/client/pages/Explorer/ResultGrid/Observation/hooks/useValue.ts
@@ -56,6 +56,11 @@ export const useValue = (props: ObservationProps): Returned => {
       }
     }
 
+    // TODO: Handle special case: growingStockPercent
+    if (dimensionName === 'growingStockPercent') {
+      systemName = SystemOfMeasurementName.percent
+    }
+
     return Observations.formatValue({ systemName, value: valueToFormat })
   }, [
     assessmentName,

--- a/src/meta/measurement/observations/index.ts
+++ b/src/meta/measurement/observations/index.ts
@@ -17,6 +17,7 @@ const formatValue = (props: FormatValueProps): string => {
       SystemOfMeasurementName.mass,
       SystemOfMeasurementName.massPerArea,
       SystemOfMeasurementName.percent,
+      SystemOfMeasurementName.percent,
       SystemOfMeasurementName.volume,
       SystemOfMeasurementName.volumePerArea,
     ].includes(systemName)

--- a/src/meta/measurement/observations/index.ts
+++ b/src/meta/measurement/observations/index.ts
@@ -1,0 +1,32 @@
+import { Numbers } from 'utils/numbers'
+
+import { SystemOfMeasurementName } from '../systemOfMeasurement'
+
+type FormatValueProps = {
+  systemName: SystemOfMeasurementName
+  value: string
+}
+
+const formatValue = (props: FormatValueProps): string => {
+  const { systemName, value } = props
+
+  if (
+    [
+      SystemOfMeasurementName.area,
+      SystemOfMeasurementName.areaPerYear,
+      SystemOfMeasurementName.mass,
+      SystemOfMeasurementName.massPerArea,
+      SystemOfMeasurementName.percent,
+      SystemOfMeasurementName.volume,
+      SystemOfMeasurementName.volumePerArea,
+    ].includes(systemName)
+  ) {
+    return Numbers.format(value, 2)
+  }
+
+  return value
+}
+
+export const Observations = {
+  formatValue,
+}

--- a/src/meta/measurement/systemOfMeasurement/systemOfMeasurementName.ts
+++ b/src/meta/measurement/systemOfMeasurement/systemOfMeasurementName.ts
@@ -3,6 +3,7 @@ export enum SystemOfMeasurementName {
   areaPerYear = 'area/year',
   mass = 'mass',
   massPerArea = 'mass/area',
+  percent = 'percent',
   volume = 'volume',
   volumePerArea = 'volume/area',
 }

--- a/src/meta/measurement/systemOfMeasurement/systemsOfMeasurement.ts
+++ b/src/meta/measurement/systemOfMeasurement/systemsOfMeasurement.ts
@@ -61,4 +61,8 @@ export const systemsOfMeasurement: SystemOfMeasurementSeed = {
     units: [{ name: UnitName.cubicMeterPerHa, symbol: 'm³/ha', conversionFactor: 1 }],
     tableNames: ['growingStockAvg'],
   },
+  [SystemOfMeasurementName.percent]: {
+    units: [{ name: UnitName.percent, symbol: '%', conversionFactor: 1 }],
+    tableNames: [],
+  },
 }

--- a/src/meta/measurement/unit/unitName.ts
+++ b/src/meta/measurement/unit/unitName.ts
@@ -17,6 +17,7 @@ export enum UnitName {
   millionsCubicMeterOverBark = 'millionsCubicMeterOverBark',
   millionTonnes = 'millionTonnes',
   numberOfStudents = 'numberOfStudents',
+  percent = 'percent',
   thousandCubicMeter = 'thousandCubicMeter',
   thousandCubicMeterOverBark = 'thousandCubicMeterOverBark',
   thousandCubicMeterRWE = 'thousandCubicMeterRWE',

--- a/src/tools/createMeasuresDimensions/index.ts
+++ b/src/tools/createMeasuresDimensions/index.ts
@@ -29,6 +29,8 @@ type Props = {
 const _createMeasuresAndDimensionsForTables = async (props: Props) => {
   const { assessment, systemOfMeasurementName, tableNames } = props
 
+  if (Objects.isEmpty(tableNames)) return
+
   const schemaAssessment = Schemas.getName(assessment)
 
   const systemOfMeasurementUuid = systemOfMeasurementName


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/70a33ec8-60c1-4895-9b80-e3a197b082e3)

growingStockPercent:
![image](https://github.com/user-attachments/assets/c2eda069-e3a4-4a92-8c61-513b77ad43c9)


TODO:
- [x] Link ___dimension___ growingStock percent to the format. Currently dimensions are agnostic of system/units. However in this table, dimensions have different formats even though they share the same measurement. 
![image](https://github.com/user-attachments/assets/799bb925-49a5-48ab-b5f3-96141e3bd3d2)

Should we add a special case for this one dimension or should we introduce some way to link dimensions to systems/units/formats as well?