### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,8 +2,10 @@ queue_rules:
   - name: default
     queue_conditions:
       - "#approved-reviews-by>=1"
-    merge_conditions: []
+    merge_conditions:
+      - "#approved-reviews-by>=1"
     merge_method: squash
+    update_method: rebase
 
 pull_request_rules:
   - name: Automatic branch update
@@ -11,7 +13,6 @@ pull_request_rules:
       - -conflict # skip PRs with conflicts
       - -draft # filter-out GH draft PRs
       - head!=production
-      - head!=staging
     actions:
       update: {}
   - name: Delete head branch after merge
@@ -21,6 +22,10 @@ pull_request_rules:
       delete_head_branch:
         force: true
   - name: Automatic merge using squash
-    conditions: []
+    conditions:
+      - "#approved-reviews-by>=1"
+      - -conflict
+      - -draft
+      - head!=production
     actions:
       queue:


### PR DESCRIPTION
This change has been made by @sorja from the Mergify config editor.

```
  queue_rules:
    - name: default
      update_method: rebase  # <-- This line replaces GitHub's setting

```


Removed from issue branches (`\d{4,}`)
<img width="659" height="163" alt="kuva" src="https://github.com/user-attachments/assets/856a61c5-1a57-4c30-b4c1-6d0a12659d6b" />

