### PR TITLE
4943 - Admin edit profile: Sets Disabled even when not choosing

### DIFF
--- a/src/server/middleware/formDataBodyMiddleware.ts
+++ b/src/server/middleware/formDataBodyMiddleware.ts
@@ -5,7 +5,10 @@ export const parseBody: RequestHandler = (req, _res, next) => {
   if (!Objects.isEmpty(req.body)) {
     const body = {}
     Object.entries(req.body).forEach(([key, value]) => {
-      Objects.set(body, key, value)
+      let parsedValue = value
+      if (value === 'true') parsedValue = true
+      if (value === 'false') parsedValue = false
+      Objects.set(body, key, parsedValue)
     })
     // eslint-disable-next-line no-param-reassign
     req.body = body


### PR DESCRIPTION
Everything was parsed as string, so the check failed (now works)

```
  const { disabled } = userEditForm.user // 'false' or 'true' string before change in PR
  if (Users.isAdministrator(user) && !Objects.isNil(disabled)) {
    userEditProps.user.status = disabled ? UserStatus.disabled : UserStatus.active
  }
```