### PR TITLE
4933 - Data Sources: Align different col styles

### DIFF
--- a/src/client/pages/Section/Descriptions/NationalDataDescriptions/DataSources/DataSources.scss
+++ b/src/client/pages/Section/Descriptions/NationalDataDescriptions/DataSources/DataSources.scss
@@ -17,3 +17,17 @@
     text-transform: uppercase;
   }
 }
+
+.data-source div.multiselect__container div.select__control {
+  padding: $spacing-xxs;
+}
+
+.data-source div.select__multiValueLabel {
+  color: $text-body;
+  font-size: $font-m;
+  padding: unset;
+
+  &.isDisabled {
+    white-space: break-spaces;
+  }
+}

--- a/src/client/pages/Section/Descriptions/NationalDataDescriptions/DataSources/DataSources.scss
+++ b/src/client/pages/Section/Descriptions/NationalDataDescriptions/DataSources/DataSources.scss
@@ -18,12 +18,9 @@
   }
 }
 
-.data-source div.multiselect__container div.select__control.isDisabled,
+.data-source div.multiselect__container div.select__control,
 .data-source div.select__control {
   align-content: start;
-}
-
-.data-source div.multiselect__container div.select__control {
   padding: $spacing-xxs;
 }
 

--- a/src/client/pages/Section/Descriptions/NationalDataDescriptions/DataSources/DataSources.scss
+++ b/src/client/pages/Section/Descriptions/NationalDataDescriptions/DataSources/DataSources.scss
@@ -18,6 +18,11 @@
   }
 }
 
+.data-source div.multiselect__container div.select__control.isDisabled,
+.data-source div.select__control {
+  align-content: start;
+}
+
 .data-source div.multiselect__container div.select__control {
   padding: $spacing-xxs;
 }

--- a/src/client/pages/Section/Descriptions/NationalDataDescriptions/DataSources/DataSources.tsx
+++ b/src/client/pages/Section/Descriptions/NationalDataDescriptions/DataSources/DataSources.tsx
@@ -69,6 +69,7 @@ export const DataSources: React.FC<Props> = (props: Props) => {
           {editable && <ButtonCopy disabled={dataSources.length !== 1} sectionName={sectionName} />}
 
           <DataGrid
+            className="data-source"
             gridColumn={canEdit ? `1/3` : undefined}
             gridTemplateColumns="minmax(200px, 1fr) minmax(200px, 1fr) minmax(200px, 1fr) minmax(150px, 1fr) minmax(150px, 1fr)"
             withActions={canEdit}
@@ -124,7 +125,7 @@ export const DataSources: React.FC<Props> = (props: Props) => {
             <div className="data-sources__readOnlyText">
               <h5>{t('nationalDataPoint.dataSource2025ExplanatoryText')}</h5>
               <div className="description__editor-container">
-                <EditorWYSIWYG disabled onChange={() => ({})} value={text} />
+                <EditorWYSIWYG disabled onChange={(): object => ({})} value={text} />
               </div>
             </div>
           )}


### PR DESCRIPTION
Resolves #4933 

Reading:

<img width="2112" height="1052" alt="image" src="https://github.com/user-attachments/assets/470c4d69-c542-4453-987a-49ec835300c8" />

Writing:

<img width="2145" height="1056" alt="image" src="https://github.com/user-attachments/assets/587f1619-042e-43d2-84d6-1b17cf37edea" />


<img width="415" height="59" alt="image" src="https://github.com/user-attachments/assets/716eee6b-ed90-4c19-88c1-34ab7af3e749" />

