### PR TITLE
4931 - EditorWYSIWYGLinks: inline toolbar

### DIFF
--- a/src/client/components/EditorWYSIWYG/EditorWYSIWYG.tsx
+++ b/src/client/components/EditorWYSIWYG/EditorWYSIWYG.tsx
@@ -19,10 +19,11 @@ export type EditorWYSIWYGProps = {
   onlyLinks?: boolean
   repository?: boolean
   value: string
+  className?: string
 }
 
 const EditorWYSIWYG: React.FC<EditorWYSIWYGProps> = (props: EditorWYSIWYGProps) => {
-  const { disabled, onChange, onlyLinks, options, repository, value } = props
+  const { className, disabled, onChange, onlyLinks, options, repository, value } = props
 
   const { configs } = useConfigs({ onlyLinks, options, repository })
   const onBlur = useOnBlur({ onChange, value })
@@ -31,7 +32,11 @@ const EditorWYSIWYG: React.FC<EditorWYSIWYGProps> = (props: EditorWYSIWYGProps) 
   return (
     <>
       <div
-        className={classNames('editorWYSIWYG', { disabled }, { 'validation-error': validationError.length > 0 })}
+        className={classNames(
+          'editorWYSIWYG',
+          { disabled, [className]: className },
+          { 'validation-error': validationError.length > 0 }
+        )}
         data-tooltip-content={validationError}
         data-tooltip-id={TooltipId.error}
       >

--- a/src/client/components/EditorWYSIWYG/EditorWYSIWYGLinks/EditorWYSIWYGLinks.scss
+++ b/src/client/components/EditorWYSIWYG/EditorWYSIWYGLinks/EditorWYSIWYGLinks.scss
@@ -1,0 +1,14 @@
+// Editor with links: Display toolbar to the right when displaying inline editor
+.editor-wysiwyg-links .jodit-container.jodit {
+  align-items: center;
+  display: grid !important;
+  grid-template-columns: 1fr auto !important;
+  justify-content: center;
+}
+
+.editor-wysiwyg-links .jodit-container.jodit .jodit-toolbar__box {
+  background-color: transparent !important;
+  border: unset !important;
+  // Move toolbar to end of the row
+  order: 1;
+}

--- a/src/client/components/EditorWYSIWYG/EditorWYSIWYGLinks/EditorWYSIWYGLinks.tsx
+++ b/src/client/components/EditorWYSIWYG/EditorWYSIWYGLinks/EditorWYSIWYGLinks.tsx
@@ -1,4 +1,4 @@
-import '../EditorWYSIWYG.scss'
+import './EditorWYSIWYGLinks.scss'
 import React from 'react'
 
 import { useIsPrintRoute } from 'client/hooks/useIsRoute'
@@ -22,6 +22,7 @@ const EditorWYSIWYGLinks: React.FC<Props> = (props: Props) => {
 
   return (
     <EditorWYSIWYGWithRepositoryContext
+      className="editor-wysiwyg-links"
       disabled={disabled}
       onChange={onChange}
       onlyLinks


### PR DESCRIPTION
Examples;


Single button (Profile editing)

<img width="769" height="156" alt="image" src="https://github.com/user-attachments/assets/444cb584-d7cb-41b9-8842-fccb603347c7" />

Single button (Profile editing, long text)
<img width="822" height="206" alt="image" src="https://github.com/user-attachments/assets/318471c9-e94d-40fe-93e5-cdae8d6ec201" />


Two buttons (Profile editing, fake, for comparison)

<img width="1040" height="271" alt="image" src="https://github.com/user-attachments/assets/050ad5cc-d969-43ea-977b-f87e45400c66" />

Two buttons (ODP)

<img width="1094" height="343" alt="image" src="https://github.com/user-attachments/assets/85961f12-6212-414d-a7a3-0d7e009ba742" />

Other editors (Main editor, e.g. Comments)
<img width="568" height="146" alt="image" src="https://github.com/user-attachments/assets/179afb7d-7bb7-4d4e-8ade-d75e524ab055" />
