### PR TITLE
4534 - Cache assessments

### DIFF
--- a/src/meta/assessment/assessment/index.ts
+++ b/src/meta/assessment/assessment/index.ts
@@ -1,4 +1,4 @@
-import { Cycle, CycleUuid } from 'meta/assessment/cycle'
+import { Cycle, CycleName, CycleUuid } from 'meta/assessment/cycle'
 import { AssessmentMetaCache } from 'meta/assessment/metaCache'
 
 export type AssessmentName = string
@@ -15,11 +15,13 @@ export type AssessmentProps = {
 }
 
 export interface Assessment {
-  id: number
-  uuid: string
+  cycleIndexesByName: Record<CycleName, number>
+  cycleIndexesByUuid: Record<CycleUuid, number>
   cycles: Array<Cycle>
-  props: AssessmentProps
+  id: number
   metaCache?: Record<CycleUuid, AssessmentMetaCache>
+  props: AssessmentProps
+  uuid: string
 }
 
 export type RecordAssessments = Record<AssessmentName, Assessment>

--- a/src/server/controller/cache/generateAssessments.ts
+++ b/src/server/controller/cache/generateAssessments.ts
@@ -1,0 +1,12 @@
+import { BaseProtocol, DB } from 'server/db'
+import { AssessmentRedisRepository } from 'server/repository/redis/assessment'
+import { Logger } from 'server/utils/logger'
+
+export const generateAssessments = async (client: BaseProtocol = DB): Promise<void> => {
+  const assessments = await AssessmentRedisRepository.getAssessmentMap({ force: true }, client)
+
+  Object.entries(assessments).forEach(([assessmentName, assessment]) => {
+    const cycleNames = assessment.cycles.map((cycle) => cycle.name).join(', ')
+    Logger.info(`${assessmentName} - with ${assessment.cycles.length}: ${cycleNames}`)
+  })
+}

--- a/src/server/controller/cache/index.ts
+++ b/src/server/controller/cache/index.ts
@@ -1,7 +1,9 @@
 import { generateArea } from 'server/controller/cache/generateArea'
+import { generateAssessments } from 'server/controller/cache/generateAssessments'
 import { generateExplorerMetadata } from 'server/controller/cache/generateExplorerMetadata'
 
 export const CacheController = {
   generateArea,
+  generateAssessments,
   generateExplorerMetadata,
 }

--- a/src/server/repository/redis/assessment/getAssessmentMap.ts
+++ b/src/server/repository/redis/assessment/getAssessmentMap.ts
@@ -1,0 +1,68 @@
+import { Objects } from 'utils/objects'
+
+import { Assessment, AssessmentName } from 'meta/assessment/assessment'
+import { CycleName, CycleUuid } from 'meta/assessment/cycle'
+
+import { AssessmentController } from 'server/controller/assessment'
+import { BaseProtocol, DB } from 'server/db'
+import { getKeyId, Keys } from 'server/repository/redis/keys'
+import { RedisData } from 'server/repository/redis/redisData'
+
+type Props = {
+  force: boolean
+}
+
+type AssessmentMap = Record<AssessmentName, Assessment>
+
+const _setCache = async (props: { key: string; assessmentMap: AssessmentMap }): Promise<void> => {
+  const { assessmentMap, key } = props
+  const redis = RedisData.getInstance()
+  await redis.hmset(
+    key,
+    ...Object.entries(assessmentMap).flatMap(([assessmentName, assessment]) => [
+      assessmentName,
+      JSON.stringify(assessment),
+    ])
+  )
+}
+
+const _cacheAssessments = async (client: BaseProtocol): Promise<AssessmentMap> => {
+  const assessments = await AssessmentController.getAll({}, client)
+  const assessmentMap = assessments.reduce<AssessmentMap>((acc, assessment) => {
+    const indexesByName = assessment.cycles.reduce<Record<CycleName, number>>((acc, cycle, i) => {
+      return Objects.setInPath({ path: [cycle.name], obj: acc, value: i })
+    }, {})
+    const indexesByUuid = assessment.cycles.reduce<Record<CycleUuid, number>>((acc, cycle, i) => {
+      return Objects.setInPath({ path: [cycle.uuid], obj: acc, value: i })
+    }, {})
+    const value = { ...assessment, indexesByName, indexesByUuid }
+    return Objects.setInPath({ path: [assessment.props.name], obj: acc, value })
+  }, {})
+
+  const key = getKeyId({ key: Keys.Assessment.assessment })
+  await _setCache({ key, assessmentMap })
+  // TODO: Next: Add meta cache generation to './generateMetacCache'
+
+  return assessmentMap
+}
+
+export const getAssessmentMap = async (props: Props, client: BaseProtocol = DB): Promise<AssessmentMap> => {
+  const { force = false } = props
+
+  const redis = RedisData.getInstance()
+  const key = getKeyId({ key: Keys.Assessment.assessment })
+
+  const cachedData = await redis.hgetall(key)
+  const cachedKeys = Object.keys(cachedData)
+
+  if (Objects.isEmpty(cachedKeys) || force) {
+    return _cacheAssessments(client)
+  }
+
+  return Object.entries(cachedData).reduce<AssessmentMap>(
+    (acc, [assessmentName, assessment]: [AssessmentName, string]) => {
+      return Objects.setInPath({ path: [assessmentName], obj: acc, value: JSON.parse(assessment) })
+    },
+    {}
+  )
+}

--- a/src/server/repository/redis/assessment/getAssessmentMap.ts
+++ b/src/server/repository/redis/assessment/getAssessmentMap.ts
@@ -5,7 +5,7 @@ import { CycleName, CycleUuid } from 'meta/assessment/cycle'
 
 import { AssessmentController } from 'server/controller/assessment'
 import { BaseProtocol, DB } from 'server/db'
-import { Keys } from 'server/repository/redis/keys'
+import { getKeysAssessments } from 'server/repository/redis/keys'
 import { RedisData } from 'server/repository/redis/redisData'
 
 type Props = {
@@ -39,9 +39,8 @@ const _cacheAssessments = async (client: BaseProtocol): Promise<AssessmentMap> =
     return Objects.setInPath({ path: [assessment.props.name], obj: acc, value })
   }, {})
 
-  const key = Keys.Assessment.assessment
+  const key = getKeysAssessments()
   await _setCache({ key, assessmentMap })
-  // TODO: Next: Add meta cache generation to './generateMetacCache'
 
   return assessmentMap
 }
@@ -50,7 +49,7 @@ export const getAssessmentMap = async (props: Props, client: BaseProtocol = DB):
   const { force = false } = props
 
   const redis = RedisData.getInstance()
-  const key = Keys.Assessment.assessment
+  const key = getKeysAssessments()
 
   const cachedData = await redis.hgetall(key)
   const cachedKeys = Object.keys(cachedData)

--- a/src/server/repository/redis/assessment/getAssessmentMap.ts
+++ b/src/server/repository/redis/assessment/getAssessmentMap.ts
@@ -5,7 +5,7 @@ import { CycleName, CycleUuid } from 'meta/assessment/cycle'
 
 import { AssessmentController } from 'server/controller/assessment'
 import { BaseProtocol, DB } from 'server/db'
-import { getKeyId, Keys } from 'server/repository/redis/keys'
+import { Keys } from 'server/repository/redis/keys'
 import { RedisData } from 'server/repository/redis/redisData'
 
 type Props = {
@@ -39,7 +39,7 @@ const _cacheAssessments = async (client: BaseProtocol): Promise<AssessmentMap> =
     return Objects.setInPath({ path: [assessment.props.name], obj: acc, value })
   }, {})
 
-  const key = getKeyId({ key: Keys.Assessment.assessment })
+  const key = Keys.Assessment.assessment
   await _setCache({ key, assessmentMap })
   // TODO: Next: Add meta cache generation to './generateMetacCache'
 
@@ -50,7 +50,7 @@ export const getAssessmentMap = async (props: Props, client: BaseProtocol = DB):
   const { force = false } = props
 
   const redis = RedisData.getInstance()
-  const key = getKeyId({ key: Keys.Assessment.assessment })
+  const key = Keys.Assessment.assessment
 
   const cachedData = await redis.hgetall(key)
   const cachedKeys = Object.keys(cachedData)

--- a/src/server/repository/redis/assessment/index.ts
+++ b/src/server/repository/redis/assessment/index.ts
@@ -1,0 +1,5 @@
+import { getAssessmentMap } from 'server/repository/redis/assessment/getAssessmentMap'
+
+export const AssessmentRedisRepository = {
+  getAssessmentMap,
+}

--- a/src/server/repository/redis/keys.ts
+++ b/src/server/repository/redis/keys.ts
@@ -56,11 +56,6 @@ type PropsCountry = PropsCycle & {
   countryIso: CountryIso
 }
 
-// Identity function
-export const getKeyId = ({ key }: { key: Key }): Key => {
-  return key
-}
-
 export const getKeyAssessment = (props: PropsAssessment): string => {
   const { assessment, key } = props
   return `${key}:${assessment.props.name}`

--- a/src/server/repository/redis/keys.ts
+++ b/src/server/repository/redis/keys.ts
@@ -1,15 +1,30 @@
 import { CountryIso } from 'meta/area'
-import { Assessment } from 'meta/assessment/assessment'
+import { Assessment as AssessmentType } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 
 // ===== Keys
 
+enum Area {
+  country = 'area:country',
+  regionGroups = 'area:regionGroups',
+}
+
+enum Assessment {
+  assessment = 'assessment',
+}
+
 enum Data {
   data = 'data',
 }
+
+enum Explorer {
+  metadata = 'explorer:metadata',
+}
+
 enum Row {
   row = 'row',
 }
+
 enum Section {
   sections = 'sections',
   sectionsIndex = 'sectionsIndex',
@@ -17,16 +32,8 @@ enum Section {
   subSectionsIndex = 'subSectionsIndex',
 }
 
-enum Area {
-  country = 'area:country',
-  regionGroups = 'area:regionGroups',
-}
-
-enum Explorer {
-  metadata = 'explorer:metadata',
-}
-
 export const Keys = {
+  Assessment,
   Data,
   Row,
   Section,
@@ -36,15 +43,22 @@ export const Keys = {
 
 // ===== Getters
 
+type Key = string
+
 type PropsAssessment = {
-  assessment: Assessment
-  key: string
+  assessment: AssessmentType
+  key: Key
 }
 type PropsCycle = PropsAssessment & {
   cycle: Cycle
 }
 type PropsCountry = PropsCycle & {
   countryIso: CountryIso
+}
+
+// Identity function
+export const getKeyId = ({ key }: { key: Key }): Key => {
+  return key
 }
 
 export const getKeyAssessment = (props: PropsAssessment): string => {
@@ -62,5 +76,5 @@ export const getKeyCountry = (props: PropsCountry): string => {
   return `${getKeyCycle({ assessment, cycle, key })}-${countryIso}`
 }
 
-export const getKeyRow = (props: { assessment: Assessment }): string =>
+export const getKeyRow = (props: { assessment: AssessmentType }): string =>
   getKeyAssessment({ assessment: props.assessment, key: Keys.Row.row })

--- a/src/server/repository/redis/keys.ts
+++ b/src/server/repository/redis/keys.ts
@@ -9,8 +9,8 @@ enum Area {
   regionGroups = 'area:regionGroups',
 }
 
-enum Assessment {
-  assessment = 'assessment',
+enum Assessments {
+  assessments = 'assessments',
 }
 
 enum Data {
@@ -33,7 +33,7 @@ enum Section {
 }
 
 export const Keys = {
-  Assessment,
+  Assessments,
   Data,
   Row,
   Section,
@@ -73,3 +73,7 @@ export const getKeyCountry = (props: PropsCountry): string => {
 
 export const getKeyRow = (props: { assessment: AssessmentType }): string =>
   getKeyAssessment({ assessment: props.assessment, key: Keys.Row.row })
+
+export const getKeysAssessments = (): string => {
+  return Keys.Assessments.assessments
+}


### PR DESCRIPTION
Note: Incremental PRs - target branch feature/issue branch

Example log
```
10:17:06 info: fra - with 3: 2020, 2025, latest
10:17:06 info: panEuropean - with 2: 2020, 2025
```

`assessment` map visible in Redis:
<img width="463" height="534" alt="kuva" src="https://github.com/user-attachments/assets/a51af567-dc76-4471-8f55-3014129ecf60" />

with following data:

<img width="1231" height="660" alt="kuva" src="https://github.com/user-attachments/assets/9034bded-b275-4a20-95a4-4f107c606582" />

...where notable change is new props `indexesByName` and `indexesByUuid`

```
  "indexesByName": {
    "2020": 0,
    "2025": 1,
    "latest": 2
  },
  "indexesByUuid": {
    "66817a08-dc93-4151-b5ed-176d8f04e9b7": 0,
    "66da2217-da42-492f-9ff4-c99a59e6675c": 1,
    "9fa1fd86-b4e3-46e4-bf48-125f082ea501": 2
  }
```


Next up: Meta cache map