### PR TITLE
5034 - Kiosk - Remove 2020 from FRA2020 data platform link

### DIFF
--- a/src/client/pages/Kiosk/Fra2020DataPlatform/index.ts
+++ b/src/client/pages/Kiosk/Fra2020DataPlatform/index.ts
@@ -1,1 +1,0 @@
-export { default } from './Fra2020DataPlatform'

--- a/src/client/pages/Kiosk/FraDataPlatform/FraDataPlatform.tsx
+++ b/src/client/pages/Kiosk/FraDataPlatform/FraDataPlatform.tsx
@@ -6,7 +6,7 @@ const FraDataPlatform: React.FC = () => {
     <object
       aria-label="FRA data platform"
       className="kiosk-content__embedded-object"
-      data="https://fra-data.fao.org/assessments/fra/2020"
+      data="https://fra-data.fao.org/"
       type="text/html"
     />
   )

--- a/src/client/pages/Kiosk/FraDataPlatform/FraDataPlatform.tsx
+++ b/src/client/pages/Kiosk/FraDataPlatform/FraDataPlatform.tsx
@@ -1,10 +1,10 @@
 import 'client/pages/Kiosk/Kiosk.scss'
 import React from 'react'
 
-const Fra2020DataPlatform: React.FC = () => {
+const FraDataPlatform: React.FC = () => {
   return (
     <object
-      aria-label="FRA 2020 data platform"
+      aria-label="FRA data platform"
       className="kiosk-content__embedded-object"
       data="https://fra-data.fao.org/assessments/fra/2020"
       type="text/html"
@@ -12,4 +12,4 @@ const Fra2020DataPlatform: React.FC = () => {
   )
 }
 
-export default Fra2020DataPlatform
+export default FraDataPlatform

--- a/src/client/pages/Kiosk/FraDataPlatform/index.ts
+++ b/src/client/pages/Kiosk/FraDataPlatform/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FraDataPlatform'

--- a/src/client/pages/Kiosk/Kiosk.tsx
+++ b/src/client/pages/Kiosk/Kiosk.tsx
@@ -20,10 +20,10 @@ const cards: Array<KioskCardProps> = [
     title: 'Recent \n highlights',
   },
   {
-    altText: 'FRA2020 data platform',
+    altText: 'FRA data platform',
     imageUrl: '/img/map.png',
-    link: Routes.Fra2020DataPlatform.path.relative,
-    title: 'FRA2020 \n data platform',
+    link: Routes.FraDataPlatform.path.relative,
+    title: 'FRA \n data platform',
   },
   {
     altText: 'Latest activities',

--- a/src/client/pages/PageRoutes/hooks/_KioskRoutes.tsx
+++ b/src/client/pages/PageRoutes/hooks/_KioskRoutes.tsx
@@ -20,11 +20,11 @@ const ForestKids = React.lazy(
       'client/pages/Kiosk/ForestKids'
     )
 )
-const Fra2020DataPlatform = React.lazy(
+const FraDataPlatform = React.lazy(
   () =>
     import(
       /* webpackChunkName: "kiosk" */
-      'client/pages/Kiosk/Fra2020DataPlatform'
+      'client/pages/Kiosk/FraDataPlatform'
     )
 )
 const FraProcess = React.lazy(
@@ -97,7 +97,7 @@ export const KioskRoutes: React.ReactElement = (
     <Route element={<FraProcess />} path={Routes.FraProcess.path.relative} />
     <Route element={<LatestActivities />} path={Routes.LatestActivities.path.relative} />
     <Route element={<RecentHighlights />} path={Routes.RecentHighlights.path.relative} />
-    <Route element={<Fra2020DataPlatform />} path={Routes.Fra2020DataPlatform.path.relative} />
+    <Route element={<FraDataPlatform />} path={Routes.FraDataPlatform.path.relative} />
 
     <Route path={Routes.InteractiveStories.path.relative}>
       <Route element={<InteractiveStories />} index />

--- a/src/meta/routes/routes.ts
+++ b/src/meta/routes/routes.ts
@@ -56,7 +56,7 @@ const LoginResetPassword = createRoute<CycleRouteParams, LoginResetPasswordQuery
 // Kiosk routes and sub routes
 const Kiosk = createRoute({ path: 'kiosk', parent: Root })
 const ForestKids = createRoute({ path: 'forest-kids', parent: Kiosk })
-const Fra2020DataPlatform = createRoute({ path: 'fra-2020-data-platform', parent: Kiosk })
+const FraDataPlatform = createRoute({ path: 'fra-data-platform', parent: Kiosk })
 const FraProcess = createRoute({ path: 'fra-process', parent: Kiosk })
 const LatestActivities = createRoute({ path: 'latest-activities', parent: Kiosk })
 const RecentHighlights = createRoute({ path: 'recent-highlights', parent: Kiosk })
@@ -101,7 +101,7 @@ export const Routes = {
   // kiosk
   Kiosk,
   ForestKids,
-  Fra2020DataPlatform,
+  FraDataPlatform,
   FraProcess,
   LatestActivities,
   RecentHighlights,


### PR DESCRIPTION
<img width="1796" height="1187" alt="image" src="https://github.com/user-attachments/assets/7224c228-f02d-45b3-8ed3-f8197e5b83a9" />
