### PR TITLE
3426 - JSEP Object

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "@googlemaps/js-api-loader": "^1.13.10",
     "@googlemaps/react-wrapper": "^1.1.29",
     "@hookform/resolvers": "^5.1.1",
+    "@jsep-plugin/object": "^1.2.2",
     "@openforis/arena-core": "^0.0.79",
     "@reduxjs/toolkit": "^2.8.2",
     "@socket.io/redis-streams-adapter": "^0.1.0",

--- a/src/lib/expressionEvaluator/context.ts
+++ b/src/lib/expressionEvaluator/context.ts
@@ -1,4 +1,4 @@
-export interface ExpressionContext {
-  object?: any
+export interface ExpressionContext<T = unknown> {
+  object?: T
   evaluateToNode?: boolean
 }

--- a/src/lib/expressionEvaluator/javascript/evaluator.test.ts
+++ b/src/lib/expressionEvaluator/javascript/evaluator.test.ts
@@ -54,6 +54,11 @@ const queries: Array<Query> = [
   { expression: `isEmpty('')`, result: true },
   { expression: 'isEmpty(1)', result: false },
   { expression: 'isEmpty(0)', result: false },
+  // object literals
+  { expression: '{a: 1, b: 2}', result: { a: 1, b: 2 } },
+  { expression: `{name: 'test', value: 34}`, result: { name: 'test', value: 34 } },
+  { expression: '{x: 1 + 1, y: 2 * 3}', result: { x: 2, y: 6 } },
+  { expression: '{nested: {a: 1, b: 2}}', result: { nested: { a: 1, b: 2 } } },
 ]
 
 describe('JavascriptExpressionEvaluator test', () => {

--- a/src/lib/expressionEvaluator/javascript/evaluator.ts
+++ b/src/lib/expressionEvaluator/javascript/evaluator.ts
@@ -10,6 +10,7 @@ import { ConditionalEvaluator } from './node/conditional'
 import { IdentifierEvaluator } from './node/identifier'
 import { LiteralEvaluator } from './node/literal'
 import { MemberEvaluator } from './node/member'
+import { ObjectEvaluator } from './node/object'
 import { SequenceEvaluator } from './node/sequence'
 import { ThisEvaluator } from './node/this'
 import { UnaryEvaluator } from './node/unary'
@@ -29,6 +30,7 @@ const defaultEvaluators = {
   [ExpressionNodeType.Identifier]: IdentifierEvaluator,
   [ExpressionNodeType.Literal]: LiteralEvaluator,
   [ExpressionNodeType.Member]: MemberEvaluator,
+  [ExpressionNodeType.Object]: ObjectEvaluator,
   [ExpressionNodeType.Sequence]: SequenceEvaluator,
   [ExpressionNodeType.This]: ThisEvaluator,
   [ExpressionNodeType.Unary]: UnaryEvaluator,

--- a/src/lib/expressionEvaluator/javascript/node/object.ts
+++ b/src/lib/expressionEvaluator/javascript/node/object.ts
@@ -1,0 +1,20 @@
+import { ExpressionContext } from '../../context'
+import { ExpressionNodeEvaluator, ObjectExpression } from '../../node'
+
+export class ObjectEvaluator<C extends ExpressionContext> extends ExpressionNodeEvaluator<C, ObjectExpression> {
+  evaluate(expressionNode: ObjectExpression): any {
+    const { properties } = expressionNode
+    const result: Record<string, any> = {}
+
+    // Modify this to support computed keys, e.g.: [x]: 1
+    // Update const key = evaluateNode
+    properties.forEach((property) => {
+      // @ts-ignore
+      const key = property.key.name
+      const value = this.evaluator.evaluateNode(property.value, this.context)
+      result[key] = value
+    })
+
+    return result
+  }
+}

--- a/src/lib/expressionEvaluator/javascript/parser/jsep.ts
+++ b/src/lib/expressionEvaluator/javascript/parser/jsep.ts
@@ -1,7 +1,12 @@
+import * as jsepObjectImport from '@jsep-plugin/object'
 import * as jsepImport from 'jsep'
 
 // @ts-ignore
 const jsep = jsepImport.default || jsepImport
+// @ts-ignore
+const jsepObject = jsepObjectImport.default || jsepObjectImport
+
+jsep.plugins.register(jsepObject)
 
 // Add exponentiation operator (right-to-left)
 jsep.addBinaryOp('**', 11, true)

--- a/src/lib/expressionEvaluator/node.ts
+++ b/src/lib/expressionEvaluator/node.ts
@@ -10,6 +10,7 @@ export enum ExpressionNodeType {
   Identifier = 'Identifier',
   Literal = 'Literal',
   Member = 'MemberExpression',
+  Object = 'ObjectExpression',
   Sequence = 'SequenceExpression',
   This = 'ThisExpression',
   Unary = 'UnaryExpression',
@@ -50,6 +51,17 @@ export interface MemberExpression extends ExpressionNode<ExpressionNodeType.Memb
   property: ExpressionNode<ExpressionNodeType>
   optional?: boolean
 }
+
+export interface ObjectExpression extends ExpressionNode<ExpressionNodeType.Object> {
+  properties: Array<{
+    type: 'Property'
+    // Enable this to support computed keys, e.g. [x]: 1
+    // computed: boolean
+    key: ExpressionNode<ExpressionNodeType>
+    value: ExpressionNode<ExpressionNodeType>
+  }>
+}
+
 export interface SequenceExpression extends ExpressionNode<ExpressionNodeType.Sequence> {
   expression: ExpressionNode<ExpressionNodeType>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2289,6 +2289,11 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
+"@jsep-plugin/object@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@jsep-plugin/object/-/object-1.2.2.tgz#ee10e9b4531063d61ce5bd47f5abb4b9e8be6e65"
+  integrity sha512-GZsC7gI5oBR+mfDFJqULf5a76FRVKednNCdSco96HM1NUbZSdDT7t/fkClUf6In64L5JORCIyhOhE6wJA6AZYg==
+
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz#4fc56c15c580b9adb7dc3c333a134e540b44bfb1"


### PR DESCRIPTION
```
    ✓ {a: 1, b: 2} (1 ms)                                                                                                                                                                                                                                                                                           
    ✓ {name: 'test', value: 34} (1 ms)                                                                                                                                                                                                                                                                              
    ✓ {x: 1 + 1, y: 2 * 3}                                                                                                                                                                                                                                                                                          
    ✓ {nested: {a: 1, b: 2}}      
```

Related:
https://github.com/EricSmekens/jsep/blob/master/packages/object/types/tsd.d.ts


```
--- AST from plugin: {a: 1, b: 2}

     {
      "type": "ObjectExpression",
      "properties": [
        {
          "type": "Property",
          "computed": false,
          "key": {
            "type": "Identifier",
            "name": "a"
          },
          "value": {
            "type": "Literal",
            "value": 1,
            "raw": "1"
          },
          "shorthand": false
        },
        {
          "type": "Property",
          "computed": false,
          "key": {
            "type": "Identifier",
            "name": "b"
          },
          "value": {
            "type": "Literal",
            "value": 2,
            "raw": "2"
          },
          "shorthand": false
        }
      ]
    }

```