### PR TITLE
3426 - JSEP Array support

### DIFF
--- a/src/lib/expressionEvaluator/javascript/evaluator.test.ts
+++ b/src/lib/expressionEvaluator/javascript/evaluator.test.ts
@@ -59,6 +59,19 @@ const queries: Array<Query> = [
   { expression: `{name: 'test', value: 34}`, result: { name: 'test', value: 34 } },
   { expression: '{x: 1 + 1, y: 2 * 3}', result: { x: 2, y: 6 } },
   { expression: '{nested: {a: 1, b: 2}}', result: { nested: { a: 1, b: 2 } } },
+  { expression: '{a: [1, 2, 3]}', result: { a: [1, 2, 3] } },
+  // array literals
+  { expression: '[1, 2, 3]', result: [1, 2, 3] },
+  { expression: `['a', 'b', 'c']`, result: ['a', 'b', 'c'] },
+  { expression: '[1 + 1, 2 * 3, 10 / 2]', result: [2, 6, 5] },
+  {
+    expression: '[[1, 2], [3, 4]]',
+    result: [
+      [1, 2],
+      [3, 4],
+    ],
+  },
+  { expression: '[{a: 1}, {b: 2}]', result: [{ a: 1 }, { b: 2 }] },
 ]
 
 describe('JavascriptExpressionEvaluator test', () => {

--- a/src/lib/expressionEvaluator/javascript/node/array.ts
+++ b/src/lib/expressionEvaluator/javascript/node/array.ts
@@ -2,8 +2,8 @@ import { ExpressionContext } from '../../context'
 import { ArrayExpression, ExpressionNodeEvaluator } from '../../node'
 
 export class ArrayEvaluator<C extends ExpressionContext> extends ExpressionNodeEvaluator<C, ArrayExpression> {
-  // eslint-disable-next-line class-methods-use-this
-  evaluate(): any {
-    throw new Error('array expression not supported')
+  evaluate(expressionNode: ArrayExpression): Array<unknown> {
+    const { elements } = expressionNode
+    return elements.map((element) => this.evaluator.evaluateNode(element, this.context))
   }
 }


### PR DESCRIPTION
```
    ✓ {a: [1, 2, 3]} (1 ms)
    ✓ [1, 2, 3] (2 ms)
    ✓ ['a', 'b', 'c'] (2 ms)
    ✓ [1 + 1, 2 * 3, 10 / 2] (2 ms)
    ✓ [[1, 2], [3, 4]] (1 ms)
    ✓ [{a: 1}, {b: 2}] (1 ms)
```

```
AST [1,2,3]

{
      "type": "ArrayExpression",
      "elements": [
        {
          "type": "Literal",
          "value": 1,
          "raw": "1"
        },
        {
          "type": "Literal",
          "value": 2,
          "raw": "2"
        },
        {
          "type": "Literal",
          "value": 3,
          "raw": "3"
        }
      ]
    }


```