### PR TITLE
4591 - Original Data Point Comments Separation - Message topics

### DIFF
--- a/src/client/pages/OriginalDataPoint/components/Comments/Comments.tsx
+++ b/src/client/pages/OriginalDataPoint/components/Comments/Comments.tsx
@@ -28,7 +28,7 @@ const Comments: React.FC<Props> = (props) => {
   const originalDataPoint = useOriginalDataPoint()
   const isDataLocked = useIsDataLocked()
   const updateComment = useUpdateComment({ field })
-  const actions = useCommentsActions()
+  const actions = useCommentsActions({ field })
   const [open, setOpen] = useState<boolean>(false)
   const displayHistory = useODPDisplayHistory()
 

--- a/src/client/pages/OriginalDataPoint/components/Comments/useCommentsActions.ts
+++ b/src/client/pages/OriginalDataPoint/components/Comments/useCommentsActions.ts
@@ -1,22 +1,45 @@
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { OriginalDataPointCommentKey } from 'meta/assessment/originalDataPoint'
+import { SectionNames } from 'meta/assessment/section'
+import { TableNames } from 'meta/assessment/table'
 import { Topics } from 'meta/messageCenter'
 
 import { useOriginalDataPoint } from 'client/store/data/originalDataPoint/hooks/originalDataPoint'
 import { DataRowAction, DataRowActionType } from 'client/components/DataGrid'
 import { useShowReviewIndicator } from 'client/pages/OriginalDataPoint/hooks/useShowReviewIndicator'
 
-export const useCommentsActions = (): Array<DataRowAction> => {
+type Props = {
+  field: OriginalDataPointCommentKey
+}
+
+const commentTopicSuffix: Record<OriginalDataPointCommentKey, string> = {
+  [TableNames.extentOfForest]: 'nationalDataPointExtentOfForestComments',
+  [TableNames.forestCharacteristics]: 'nationalDataPointForestCharacteristicsComments',
+}
+
+const commentSectionName: Record<OriginalDataPointCommentKey, SectionNames> = {
+  [TableNames.extentOfForest]: SectionNames.extentOfForest,
+  [TableNames.forestCharacteristics]: SectionNames.forestCharacteristics,
+}
+
+export const useCommentsActions = (props: Props): Array<DataRowAction> => {
+  const { field } = props
   const { t } = useTranslation()
   const originalDataPoint = useOriginalDataPoint()
-  const showReviewIndicator = useShowReviewIndicator()
+  const sectionName = commentSectionName[field]
+  const showReviewIndicator = useShowReviewIndicator(sectionName)
 
   return useMemo<Array<DataRowAction>>(() => {
     if (!showReviewIndicator) return []
 
-    const title = t('nationalDataPoint.nationalDataPoint')
-    const topicKey = Topics.getOdpReviewTopicKey(originalDataPoint.id, 'nationalDataPointComments')
+    const sectionLabel =
+      field === TableNames.forestCharacteristics
+        ? t('nationalDataPoint.forestCharacteristics')
+        : t('extentOfForest.extentOfForest')
+    const title = `${t('nationalDataPoint.nationalDataPoint')} – ${sectionLabel}`
+    const topicKey = Topics.getOdpReviewTopicKey(originalDataPoint.id, commentTopicSuffix[field])
     return [{ type: DataRowActionType.Review, title, topicKey }]
-  }, [originalDataPoint.id, showReviewIndicator, t])
+  }, [field, originalDataPoint.id, showReviewIndicator, t])
 }

--- a/src/client/pages/OriginalDataPoint/components/Comments/useCommentsActions.ts
+++ b/src/client/pages/OriginalDataPoint/components/Comments/useCommentsActions.ts
@@ -39,7 +39,9 @@ export const useCommentsActions = (props: Props): Array<DataRowAction> => {
         ? t('nationalDataPoint.forestCharacteristics')
         : t('extentOfForest.extentOfForest')
     const title = `${t('nationalDataPoint.nationalDataPoint')} – ${sectionLabel}`
+    const subtitle = t('review.comments')
+
     const topicKey = Topics.getOdpReviewTopicKey(originalDataPoint.id, commentTopicSuffix[field])
-    return [{ type: DataRowActionType.Review, title, topicKey }]
+    return [{ subtitle, title, topicKey, type: DataRowActionType.Review }]
   }, [field, originalDataPoint.id, showReviewIndicator, t])
 }

--- a/src/tools/migrations/steps/steps/20251023213324-step-separate-odp-comments.ts
+++ b/src/tools/migrations/steps/steps/20251023213324-step-separate-odp-comments.ts
@@ -78,6 +78,19 @@ const _updateOriginalDataPointTable = async (props: UpdateTableProps): Promise<v
   }
 }
 
+const _updateOdpMessageTopics = async (props: UpdateTableProps): Promise<void> => {
+  const { client, schemaName } = props
+  const oldSuffix = 'nationalDataPointComments'
+  const newSuffix = 'nationalDataPointExtentOfForestComments'
+
+  await client.none(`
+      update ${schemaName}.message_topic
+      set key = regexp_replace(key, '${oldSuffix}$', '${newSuffix}')
+      where key like '%${oldSuffix}'
+        and key like 'odp-%'
+    `)
+}
+
 type UpdateActivityLogProps = {
   client: BaseProtocol
 }
@@ -134,6 +147,7 @@ export default async (client: BaseProtocol): Promise<void> => {
     await Promises.each(assessment.cycles, async (cycle) => {
       const schemaName = Schemas.getNameCycle(assessment, cycle)
       await _updateOriginalDataPointTable({ client, schemaName })
+      await _updateOdpMessageTopics({ client, schemaName })
 
       // Update activity log materialized views to include new odp comment columns logs
       const countries = await AreaController.getCountries({ assessment, cycle }, client)


### PR DESCRIPTION
TODO: 
 - [x] Migrate all message topics with keys including "nationalDataPointComments" to "nationalDataPointExtentOfForestComments"
 

https://github.com/user-attachments/assets/e8cd0e23-a917-4780-8e0f-adc66b179ae7


 