### PR TITLE
Client/styles cleanup: form -> select [part 1: Data Export]

### DIFF
--- a/src/client/components/EditorWYSIWYG/EditorWYSIWYG.scss
+++ b/src/client/components/EditorWYSIWYG/EditorWYSIWYG.scss
@@ -21,6 +21,7 @@ div.editorWYSIWYG {
     @extend .link;
     @extend .color-blue;
   }
+
   div.jodit-react-container,
   div.jodit-container,
   div.jodit-workplace {

--- a/src/client/components/Inputs/Select/types.ts
+++ b/src/client/components/Inputs/Select/types.ts
@@ -16,26 +16,22 @@ export type OptionsOrGroups = ReadonlyArray<Option | OptionsGroup>
 
 export type ValueInput = string | Array<string> | null
 
-type SelectBaseProps =
-  | Pick<
-      ReactSelectProps,
-      | 'formatOptionLabel'
-      | 'inputValue'
-      | 'isClearable'
-      | 'isMulti'
-      | 'isOptionDisabled'
-      | 'maxMenuHeight'
-      | 'onBlur'
-      | 'onFocus'
-      | 'onInputChange'
-      | 'onMenuClose'
-      | 'onMenuOpen'
-      | 'placeholder'
-    > &
-      Pick<
-        CreatableProps<Option, boolean, OptionsGroup>,
-        'createOptionPosition' | 'onCreateOption' | 'isValidNewOption'
-      >
+type SelectBaseProps = Pick<
+  ReactSelectProps,
+  | 'formatOptionLabel'
+  | 'inputValue'
+  | 'isClearable'
+  | 'isMulti'
+  | 'isOptionDisabled'
+  | 'maxMenuHeight'
+  | 'onBlur'
+  | 'onFocus'
+  | 'onInputChange'
+  | 'onMenuClose'
+  | 'onMenuOpen'
+  | 'placeholder'
+> &
+  Pick<CreatableProps<Option, boolean, OptionsGroup>, 'createOptionPosition' | 'onCreateOption' | 'isValidNewOption'>
 
 type SelectClassNamesProps = {
   classNames?: { container?: string }

--- a/src/client/pages/CountryHome/Repository/RepositoryLink/RepositoryLink.scss
+++ b/src/client/pages/CountryHome/Repository/RepositoryLink/RepositoryLink.scss
@@ -1,9 +1,0 @@
-@import 'src/client/style/partials';
-
-.repository-link {
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
-}

--- a/src/client/pages/CountryHome/Repository/RepositoryLink/RepositoryLink.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryLink/RepositoryLink.tsx
@@ -1,4 +1,3 @@
-import './RepositoryLink.scss'
 import React from 'react'
 
 import { RepositoryItem } from 'meta/cycleData/repository/item'
@@ -7,6 +6,7 @@ import { Translations } from 'meta/translation/translations'
 
 import { useLanguage } from 'client/hooks/language'
 import { useCountryRouteParams } from 'client/hooks/routeParams'
+import Link from 'client/components/Links/Link'
 
 type Props = {
   datum: RepositoryItem
@@ -22,9 +22,9 @@ const RepositoryLink: React.FC<Props> = (props) => {
   const url = RepositoryItems.getURL({ repositoryItem: datum, assessmentName, cycleName, countryIso })
 
   return (
-    <a className="repository-link" href={url} rel="noreferrer" target="_blank">
+    <Link rel="noreferrer" target="_blank" to={url}>
       {label}
-    </a>
+    </Link>
   )
 }
 

--- a/src/client/pages/DataExport/ColumnSelect/ColumnSelect.tsx
+++ b/src/client/pages/DataExport/ColumnSelect/ColumnSelect.tsx
@@ -10,6 +10,8 @@ import { useDataExportSelection } from 'client/store/dataExport/hooks/dataExport
 import { DataExportSelection } from 'client/store/dataExport/state'
 import { useAppDispatch } from 'client/store/hooks'
 import ButtonCheckBox, { ButtonCheckboxVariant } from 'client/components/Buttons/ButtonCheckbox'
+import MultiSelect from 'client/components/Inputs/MultiSelect'
+import { Option } from 'client/components/Inputs/Select'
 import { getColumnLabelKeys } from 'client/pages/DataExport/utils'
 import { Breakpoints } from 'client/utils/breakpoints'
 
@@ -46,33 +48,31 @@ const ColumnSelect: React.FC<{ columns: Array<string> }> = ({ columns }) => {
     <div className="export__form-section">
       <div className="export__form-section-header select-all">
         <h4>{t('common.column')}</h4>
-        <ButtonCheckBox
-          checked={selectionColumns.length > 0 && selectionColumns.length === columns.length}
-          className="btn-all"
-          label={t(selectionColumns.length > 0 ? 'common.unselectAll' : 'common.selectAll')}
-          onClick={() => updateSelection(selection.sections[sectionName].columns.length > 0 ? [] : columns.map(String))}
-          variant={ButtonCheckboxVariant.checkbox}
-        />
+        <MediaQuery minWidth={Breakpoints.laptop}>
+          <ButtonCheckBox
+            checked={selectionColumns.length > 0 && selectionColumns.length === columns.length}
+            className="btn-all"
+            label={t(selectionColumns.length > 0 ? 'common.unselectAll' : 'common.selectAll')}
+            onClick={() =>
+              updateSelection(selection.sections[sectionName].columns.length > 0 ? [] : columns.map(String))
+            }
+            variant={ButtonCheckboxVariant.checkbox}
+          />
+        </MediaQuery>
       </div>
 
       <MediaQuery maxWidth={Breakpoints.laptop - 1}>
-        <select
-          multiple
-          onChange={(event) => {
-            const columnsUpdate = Array.from(event.target.selectedOptions, (option) => String(option.value))
-            updateSelection(columnsUpdate)
-          }}
-          value={selectionColumns}
-        >
-          {columns.map((column: string) => {
+        <MultiSelect
+          multiLabelSummaryKey="common.column"
+          onChange={updateSelection}
+          options={columns.map<Option>((column) => {
             const label = getColumnLabelKeys(column, sectionName, assessmentName).map(t).join(' ')
-            return (
-              <option key={column} value={column}>
-                {label}
-              </option>
-            )
+            return { label, value: column }
           })}
-        </select>
+          placeholder={t('common.select')}
+          toggleAll
+          value={selectionColumns}
+        />
       </MediaQuery>
       <MediaQuery minWidth={Breakpoints.laptop}>
         <>

--- a/src/client/pages/DataExport/CountrySelect/CountrySelect.tsx
+++ b/src/client/pages/DataExport/CountrySelect/CountrySelect.tsx
@@ -8,11 +8,14 @@ import { Strings } from 'utils/strings'
 
 import { Areas } from 'meta/area/areas'
 import { Country } from 'meta/area/country'
+import { Users } from 'meta/user/users'
 
 import { DataExportActions } from 'client/store/dataExport/actions'
 import { useDataExportCountries, useDataExportSelection } from 'client/store/dataExport/hooks/dataExport'
 import { useAppDispatch } from 'client/store/hooks'
+import { useUser } from 'client/store/user/hooks/user'
 import ButtonCheckBox, { ButtonCheckboxVariant } from 'client/components/Buttons/ButtonCheckbox'
+import CountryMultiSelect from 'client/components/CountryMultiSelect'
 import { Breakpoints } from 'client/utils/breakpoints'
 
 const CountrySelect: React.FC = () => {
@@ -21,6 +24,7 @@ const CountrySelect: React.FC = () => {
   const { sectionName } = useParams<{ sectionName: string }>()
   const countries = useDataExportCountries()
   const selection = useDataExportSelection(sectionName)
+  const user = useUser()
 
   const [countriesFiltered, setCountriesFiltered] = useState<Array<Country>>(countries)
   const inputRef = useRef(null)
@@ -63,46 +67,36 @@ const CountrySelect: React.FC = () => {
   return (
     <div className="export__form-section">
       <div className="export__form-section-header select-all search">
-        <h4>{t('common.country')}</h4>
-        <input
-          ref={inputRef}
-          className="text-input"
-          onChange={filterCountriesThrottle}
-          placeholder={t('emoji.picker.search')}
-          type="text"
-        />
-        <ButtonCheckBox
-          checked={selection.countryISOs.length > 0 && selection.countryISOs.length === countries.length}
-          className="btn-all"
-          label={t(selection.countryISOs.length > 0 ? 'common.unselectAll' : 'common.selectAll')}
-          onClick={(): void => {
-            const countryISOs: Array<string> =
-              selection.countryISOs.length > 0 ? [] : countries.map((country) => country.countryIso)
-            updateSelection(countryISOs)
-          }}
-          variant={ButtonCheckboxVariant.checkbox}
-        />
+        <h4>{t('common.countries')}</h4>
+        <MediaQuery minWidth={Breakpoints.laptop}>
+          <input
+            ref={inputRef}
+            className="text-input"
+            onChange={filterCountriesThrottle}
+            placeholder={t('emoji.picker.search')}
+            type="text"
+          />
+          <ButtonCheckBox
+            checked={selection.countryISOs.length > 0 && selection.countryISOs.length === countries.length}
+            className="btn-all"
+            label={t(selection.countryISOs.length > 0 ? 'common.unselectAll' : 'common.selectAll')}
+            onClick={(): void => {
+              const countryISOs: Array<string> =
+                selection.countryISOs.length > 0 ? [] : countries.map((country) => country.countryIso)
+              updateSelection(countryISOs)
+            }}
+            variant={ButtonCheckboxVariant.checkbox}
+          />
+        </MediaQuery>
       </div>
 
       <MediaQuery maxWidth={Breakpoints.laptop - 1}>
-        <select
-          multiple
-          onChange={(event): void => {
-            const countryISOsUpdate = Array.from(event.target.selectedOptions, (option) => option.value)
-            updateSelection(countryISOsUpdate)
-          }}
-          size={5}
+        <CountryMultiSelect
+          allowAtlantis={user && Users.isAdministrator(user)}
+          allowedCountries={countriesFiltered.map((c) => c.countryIso)}
+          onChange={updateSelection}
           value={selection.countryISOs}
-        >
-          {countriesFiltered.map((country: Country) => {
-            const { countryIso } = country
-            return (
-              <option key={countryIso} value={countryIso}>
-                {t(Areas.getTranslationKey(country.countryIso))}
-              </option>
-            )
-          })}
-        </select>
+        />
       </MediaQuery>
 
       <MediaQuery minWidth={Breakpoints.laptop}>

--- a/src/client/pages/DataExport/DataExport.scss
+++ b/src/client/pages/DataExport/DataExport.scss
@@ -18,6 +18,7 @@
   position: sticky;
   left: 0;
   flex: 1 100%;
+  z-index: $z-index-explorer-filters;
 
   @include min-width($laptop) {
     height: 300px;
@@ -29,13 +30,15 @@
 
 .export__form-section {
   display: grid;
+  grid-auto-rows: 30px;
   grid-row-gap: $spacing-xxxs;
   position: relative;
 
   @include min-width($laptop) {
-    overflow: hidden;
-    grid-template-rows: 60px 1px 1fr;
+    grid-auto-rows: unset;
     grid-row-gap: unset;
+    grid-template-rows: 60px 1px 1fr;
+    overflow: hidden;
   }
 
   &:not(:last-child) {
@@ -47,15 +50,8 @@
   .divider {
     border-bottom: 1px solid $ui-border-light;
   }
-
-  select {
-    border: 1px solid $ui-border;
-    width: 100%;
-    background-color: white;
-  }
-
-  option {
-    color: $text-body;
+  .country-multiselect__container {
+    min-width: 100%;
   }
 }
 
@@ -117,9 +113,9 @@
 }
 
 .export__form-section-header-withLink {
-  display: grid;
-  grid-template-columns: repeat(2, auto);
-  grid-column-gap: $spacing-xxs;
+  align-items: center;
+  display: flex;
+  gap: $spacing-xxs;
 }
 
 .export__form-section-variables {

--- a/src/client/pages/DataExport/ResultsTable/ResultsTable.scss
+++ b/src/client/pages/DataExport/ResultsTable/ResultsTable.scss
@@ -12,13 +12,6 @@
     text-align: left;
   }
 
-  .select-s {
-    border: unset;
-    color: $text-body;
-    font-weight: 600;
-    font-size: $font-s;
-  }
-
   .timestamp {
     opacity: 0;
   }

--- a/src/client/pages/DataExport/ResultsTable/ResultsTable.scss
+++ b/src/client/pages/DataExport/ResultsTable/ResultsTable.scss
@@ -23,3 +23,14 @@
     opacity: 0;
   }
 }
+
+.results-table__title {
+  align-items: center;
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+
+  .select__control {
+    padding: unset;
+  }
+}

--- a/src/client/pages/DataExport/ResultsTable/ResultsTable.tsx
+++ b/src/client/pages/DataExport/ResultsTable/ResultsTable.tsx
@@ -97,6 +97,7 @@ const ResultsTable: React.FC<{ tableName: string }> = ({ tableName }) => {
                         baseUnit={unit ?? baseUnit}
                         onUnitChange={onUnitChange}
                         resultsLoading={resultsLoading}
+                        unit={units[variableName] ?? unit ?? baseUnit}
                         variable={variableName}
                       />
                     )}
@@ -113,6 +114,7 @@ const ResultsTable: React.FC<{ tableName: string }> = ({ tableName }) => {
                     baseUnit={baseUnit}
                     onUnitChange={onUnitChange}
                     resultsLoading={resultsLoading}
+                    unit={units[variable] ?? baseUnit}
                     variable={variable}
                   />
                 </th>

--- a/src/client/pages/DataExport/ResultsTable/Title/Title.tsx
+++ b/src/client/pages/DataExport/ResultsTable/Title/Title.tsx
@@ -11,17 +11,19 @@ import { UnitName } from 'meta/measurement/unitName'
 
 import { useCycle } from 'client/store/meta/hooks/cycles'
 import { useTableSections } from 'client/store/meta/hooks/tableSections'
+import Select, { Option } from 'client/components/Inputs/Select'
 import { getUnitLabelKey } from 'client/pages/DataExport/utils'
 
 type Props = {
   baseUnit?: UnitName
   onUnitChange: (value: UnitName, variable: string) => void
   resultsLoading: boolean
+  unit: UnitName
   variable: string
 }
 
 const Title: React.FC<Props> = (props) => {
-  const { baseUnit = UnitName.haThousand, onUnitChange, resultsLoading, variable } = props
+  const { baseUnit = UnitName.haThousand, onUnitChange, resultsLoading, unit, variable } = props
 
   const { t } = useTranslation()
   const { sectionName } = useParams<{ sectionName: string }>()
@@ -37,40 +39,40 @@ const Title: React.FC<Props> = (props) => {
   const rowSpecVariable = rowSpecs.find((row: Row) => row.props.variableName === variable)
   const labelVariable = Cols.getLabel({ cycle, col: rowSpecVariable.cols[0], t })
 
+  const options = Object.keys(UnitFactors[baseUnit] ?? {}).reduce<Array<Option>>(
+    (acc, unit) => {
+      if (unit !== baseUnit) {
+        acc.push({ label: t(getUnitLabelKey(unit)), value: unit })
+      }
+      return acc
+    },
+    [{ label: t(getUnitLabelKey(baseUnit)), value: baseUnit }]
+  )
+
   if (resultsLoading) {
     return <div>{t('description.loading')}</div>
   }
 
   return (
-    <>
+    <div className="results-table__title">
       <span>{labelVariable}</span>
       {Object.keys(UnitFactors).includes(baseUnit) ? (
         <>
           <span> (</span>
-          <select
-            className="select-s"
-            defaultValue={baseUnit}
-            onChange={(event): void => {
-              onUnitChange(event.target.value as UnitName, variable)
+          <Select
+            isClearable={false}
+            onChange={(value: UnitName): void => {
+              onUnitChange(value, variable)
             }}
-          >
-            <option value={baseUnit}>{t(getUnitLabelKey(baseUnit))}</option>
-
-            {Object.keys(UnitFactors[baseUnit]).map(
-              (unit) =>
-                unit !== baseUnit && (
-                  <option key={unit} value={unit}>
-                    {t(getUnitLabelKey(unit))}
-                  </option>
-                )
-            )}
-          </select>
+            options={options}
+            value={unit}
+          />
           <span>)</span>
         </>
       ) : (
         <span>{baseUnit ? ` (${t(`unit.${baseUnit}`)})` : ''}</span>
       )}
-    </>
+    </div>
   )
 }
 

--- a/src/client/pages/DataExport/VariableSelect/VariableSelect.tsx
+++ b/src/client/pages/DataExport/VariableSelect/VariableSelect.tsx
@@ -14,6 +14,8 @@ import { useAppDispatch } from 'client/store/hooks'
 import { useCycle } from 'client/store/meta/hooks/cycles'
 import { useSection } from 'client/store/meta/hooks/sections'
 import ButtonCheckBox, { ButtonCheckboxVariant } from 'client/components/Buttons/ButtonCheckbox'
+import MultiSelect from 'client/components/Inputs/MultiSelect'
+import { Option } from 'client/components/Inputs/Select'
 import DefinitionLink from 'client/components/Links/DefinitionLink'
 import { Breakpoints } from 'client/utils/breakpoints'
 
@@ -64,42 +66,35 @@ const VariableSelect: React.FC<{ variables: Array<Row> }> = ({ variables }) => {
             title={`(${t('definition.definitionLabel')})`}
           />
         </div>
-        <ButtonCheckBox
-          checked={selectionVariables.length > 0 && selectionVariables.length === variables.length}
-          className="btn-all"
-          label={t(selectionVariables.length > 0 ? 'common.unselectAll' : 'common.selectAll')}
-          onClick={() => {
-            updateSelection(
-              selection.sections[sectionName].variables.length > 0 ? [] : variables.map((v) => v.props.variableName)
-            )
-          }}
-          variant={ButtonCheckboxVariant.checkbox}
-        />
+        <MediaQuery minWidth={Breakpoints.laptop}>
+          <ButtonCheckBox
+            checked={selectionVariables.length > 0 && selectionVariables.length === variables.length}
+            className="btn-all"
+            label={t(selectionVariables.length > 0 ? 'common.unselectAll' : 'common.selectAll')}
+            onClick={() => {
+              updateSelection(
+                selection.sections[sectionName].variables.length > 0 ? [] : variables.map((v) => v.props.variableName)
+              )
+            }}
+            variant={ButtonCheckboxVariant.checkbox}
+          />
+        </MediaQuery>
       </div>
 
       <MediaQuery maxWidth={Breakpoints.laptop - 1}>
-        <select
-          multiple
-          onChange={(event) => {
-            const variablesUpdate = Array.from(event.target.selectedOptions, (option) => {
-              return String(option.value)
-            })
-            updateSelection(variablesUpdate)
-          }}
-          value={selectionVariables}
-        >
-          {variables.map((variable) => {
+        <MultiSelect
+          multiLabelSummaryKey="common.variable"
+          onChange={updateSelection}
+          options={variables.map<Option>((variable) => {
             const { variableName } = variable.props
 
             const label = Labels.getCycleLabel({ cycle, labels: variable.cols[0].props.labels, t })
-
-            return (
-              <option key={variableName} value={variableName}>
-                {label}
-              </option>
-            )
+            return { label, value: variableName }
           })}
-        </select>
+          placeholder={t('common.select')}
+          toggleAll
+          value={selectionVariables}
+        />
       </MediaQuery>
       <MediaQuery minWidth={Breakpoints.laptop}>
         <>


### PR DESCRIPTION
Objective: DO NOT USE native select .
Note: Layout refactor is not part of this PR. the Data export will be removed anyway when we implement the new measurement schema.

part 1. Data export 

<img width="540" height="577" alt="image" src="https://github.com/user-attachments/assets/d633d6c3-19d8-4477-837f-97bfb226f127" />

<img width="1145" height="617" alt="image" src="https://github.com/user-attachments/assets/1bfd69d6-dfd7-458a-ad71-a487943d8d48" />
