### PR TITLE
5386: Client/styles cleanup: buttons [part 2]

### DIFF
--- a/src/client/components/Buttons/Button/Button.scss
+++ b/src/client/components/Buttons/Button/Button.scss
@@ -10,7 +10,7 @@
   display: flex;
   font-family: $font-family-1;
   font-weight: 600;
-  justify-content: start;
+  justify-content: center;
   letter-spacing: 0.25px;
   line-height: 0;
   text-decoration: none;
@@ -93,12 +93,11 @@
   }
 }
 
-// === type styles
-@mixin withTheme($colorPrimary, $hoverInverseLighten, $colorSecondary: white) {
-  $hoverPercent: 4%;
-
+// === theme styles
+@mixin withTheme($colorPrimary, $hoverInverseLighten, $colorSecondary: white, $hoverPercent: 4%) {
   background-color: $colorPrimary;
-  border-color: $colorPrimary;
+  //border-color: $colorPrimary;
+  border-color: color.adjust($colorPrimary, $lightness: -5%, $space: hsl);
   color: $colorSecondary;
 
   svg {
@@ -107,15 +106,11 @@
 
   &:hover {
     background-color: color.adjust($colorPrimary, $lightness: $hoverPercent, $space: hsl);
-    color: color.adjust(white, $lightness: -$hoverPercent, $space: hsl);
+    color: color.adjust($colorSecondary, $lightness: -$hoverPercent, $space: hsl);
 
     svg {
       color: color.adjust(white, $lightness: -$hoverPercent, $space: hsl);
     }
-  }
-
-  &.noBorder {
-    border: unset;
   }
 
   &.inverse {
@@ -166,6 +161,10 @@
   @include withTheme($ui-accent, 60%);
 }
 
+.button__type-secondary {
+  @include withTheme($ui-bg, -6%, $text-mute, -5%);
+}
+
 .button__type-transparent {
   @include withTheme(transparent, 0, $ui-black-map);
   border-color: transparent;
@@ -177,5 +176,15 @@
     svg {
       color: $ui-black-map;
     }
+  }
+}
+
+// additional custom properties
+.button {
+  &.noBorder {
+    border: unset;
+  }
+  &.bgTransparent {
+    background-color: transparent;
   }
 }

--- a/src/client/components/Buttons/Button/Button.tsx
+++ b/src/client/components/Buttons/Button/Button.tsx
@@ -6,9 +6,23 @@ import Icon from 'client/components/Icon'
 
 import { useButtonClassName } from './hooks/useButtonClassName'
 
+const defaults: Partial<ButtonProps> = {
+  htmlButtonType: 'button',
+}
+
 const Button: React.FC<ButtonProps> = (props) => {
-  const { dataTooltipContent, dataTooltipId, disabled, icon, iconName, label, onClick, onMouseEnter, onMouseLeave } =
-    props
+  const {
+    dataTooltipContent,
+    dataTooltipId,
+    disabled,
+    htmlButtonType = defaults.htmlButtonType,
+    icon,
+    iconName,
+    label,
+    onClick,
+    onMouseEnter,
+    onMouseLeave,
+  } = props
 
   const className = useButtonClassName(props)
 
@@ -21,7 +35,7 @@ const Button: React.FC<ButtonProps> = (props) => {
       onClick={onClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
-      type="button"
+      type={htmlButtonType}
     >
       {iconName && !icon && <Icon className="icon-white" name={iconName} />}
       {icon && icon}

--- a/src/client/components/Buttons/Button/hooks/useButtonClassName.ts
+++ b/src/client/components/Buttons/Button/hooks/useButtonClassName.ts
@@ -1,11 +1,11 @@
 import { useMemo } from 'react'
-
 import classNames from 'classnames'
 
 import { ButtonProps, ButtonSize, ButtonType } from 'client/components/Buttons/Button/types'
 
 export const useButtonClassName = (props: ButtonProps): string => {
   const {
+    bgTransparent,
     className,
     disabled,
     inverse,
@@ -23,8 +23,8 @@ export const useButtonClassName = (props: ButtonProps): string => {
       `button__type-${type}`,
       { inverse },
       { disabled },
-      { noBorder },
+      { bgTransparent, noBorder },
       className
     )
-  }, [className, disabled, inverse, noBorder, noPrint, size, type])
+  }, [bgTransparent, className, disabled, inverse, noBorder, noPrint, size, type])
 }

--- a/src/client/components/Buttons/Button/types.ts
+++ b/src/client/components/Buttons/Button/types.ts
@@ -1,4 +1,4 @@
-import React, { InputHTMLAttributes } from 'react'
+import React, { ButtonHTMLAttributes } from 'react'
 
 import { TooltipId } from 'meta/tooltip/id'
 
@@ -14,15 +14,19 @@ export enum ButtonType {
   black = 'black',
   danger = 'danger',
   primary = 'primary',
+  secondary = 'secondary',
   transparent = 'transparent',
 }
 
+type HtmlButtonProps = ButtonHTMLAttributes<HTMLButtonElement>
 export type ButtonProps = Pick<
-  InputHTMLAttributes<HTMLButtonElement>,
+  HtmlButtonProps,
   'className' | 'disabled' | 'onClick' | 'onMouseEnter' | 'onMouseLeave'
 > & {
+  bgTransparent?: boolean
   dataTooltipContent?: string | null
   dataTooltipId?: TooltipId
+  htmlButtonType?: HtmlButtonProps['type']
   icon?: React.ReactNode
   iconName?: string
   inverse?: boolean

--- a/src/client/components/CountryMultiSelect/CountryMultiSelect.scss
+++ b/src/client/components/CountryMultiSelect/CountryMultiSelect.scss
@@ -28,34 +28,6 @@ $icon-size: 14px;
   .select__control {
     min-height: unset;
     padding: 0 6px;
-
-    .select__indicatorsContainer {
-      .select__clearIndicator {
-        height: unset;
-        width: unset;
-
-        svg.icon {
-          color: rgba(0, 0, 0, 0.5);
-          height: $icon-size;
-          width: $icon-size;
-        }
-
-        &:hover {
-          background-color: unset;
-
-          svg.icon {
-            color: $ui-destructive;
-          }
-        }
-      }
-    }
-  }
-
-  .select__dropdownIndicator {
-    svg {
-      height: $icon-size;
-      width: $icon-size;
-    }
   }
 
   .select__groupHeading {

--- a/src/client/components/EditorWYSIWYG/AddFromRepository/AddFromRepository.tsx
+++ b/src/client/components/EditorWYSIWYG/AddFromRepository/AddFromRepository.tsx
@@ -7,6 +7,7 @@ import { Translations } from 'meta/translation/translations'
 
 import { useLanguage } from 'client/hooks/language'
 import { useCountryRouteParams } from 'client/hooks/routeParams'
+import Button, { ButtonSize } from 'client/components/Buttons/Button'
 import ButtonCheckBox, { ButtonCheckboxVariant } from 'client/components/Buttons/ButtonCheckbox'
 import { useRepositoryLinkContext } from 'client/components/EditorWYSIWYG/repositoryLinkContext'
 import FileUpload from 'client/components/FileUpload'
@@ -61,9 +62,6 @@ const AddFromRepository: React.FC = () => {
 
       <ModalBody>
         <div className="references-file-list">
-          {/* <ButtonCheckBox onClick={onClickAll} checked={allSelected} label={t('contactPersons.all')} /> */}
-          {/* <div className="divider" /> */}
-
           {repositoryItems?.map((repositoryItem) => {
             const url = RepositoryItems.getURL({ assessmentName, cycleName, countryIso, repositoryItem })
             const label = Translations.getLabel({ translation: repositoryItem.props.translation, language })
@@ -88,9 +86,7 @@ const AddFromRepository: React.FC = () => {
       </ModalBody>
 
       <ModalFooter>
-        <button className="btn btn-primary" onClick={onClose} type="button">
-          {t('common.apply')}
-        </button>
+        <Button iconName="checkbox" label={t('common.apply')} onClick={onClose} size={ButtonSize.m} />
       </ModalFooter>
     </Modal>
   )

--- a/src/client/components/Form/Buttons/Buttons.scss
+++ b/src/client/components/Form/Buttons/Buttons.scss
@@ -1,10 +1,7 @@
 @import 'src/client/style/partials';
 
 .form-button-container {
-  display: flex;
-  gap: $spacing-m;
   grid-column: 1 / -1;
-  justify-content: center;
   margin-top: $spacing-xs;
 
   button {

--- a/src/client/components/Form/Buttons/Buttons.tsx
+++ b/src/client/components/Form/Buttons/Buttons.tsx
@@ -2,6 +2,7 @@ import './Buttons.scss'
 import React from 'react'
 
 import { FormProps } from 'client/components/Form/types'
+import Flex from 'client/components/Layout/Flex'
 
 import Cancel from './Cancel'
 import Submit from './Submit'
@@ -16,10 +17,10 @@ const Buttons: React.FC<ButtonsProps> = (props) => {
   const { disabled, hideCancel, isDirty, isSubmitting, onCancel } = props
 
   return (
-    <div className="form-button-container">
+    <Flex className="form-button-container" gap={'32'} justifyContent={'center'}>
       <Cancel disabled={disabled} hideCancel={hideCancel} onClick={onCancel} />
       <Submit disabled={disabled} isDirty={isDirty} isSubmitting={isSubmitting} />
-    </div>
+    </Flex>
   )
 }
 

--- a/src/client/components/Form/Buttons/Cancel/Cancel.tsx
+++ b/src/client/components/Form/Buttons/Cancel/Cancel.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
+import Button, { ButtonSize, ButtonType } from 'client/components/Buttons/Button'
 import { FormProps } from 'client/components/Form/types'
 
 type CancelProps = Pick<FormProps, 'disabled' | 'hideCancel'> & {
@@ -12,13 +13,11 @@ const Cancel: React.FC<CancelProps> = (props) => {
 
   const { t } = useTranslation()
 
+  const label = t(disabled ? 'common.back' : 'common.cancel')
+
   if (hideCancel) return null
 
-  return (
-    <button className="btn btn-secondary" onClick={onClick} type="button">
-      {t(disabled ? 'common.back' : 'common.cancel')}
-    </button>
-  )
+  return <Button label={label} onClick={onClick} size={ButtonSize.l} type={ButtonType.secondary} />
 }
 
 export default Cancel

--- a/src/client/components/Form/Buttons/Submit/Submit.tsx
+++ b/src/client/components/Form/Buttons/Submit/Submit.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
+import Button, { ButtonSize } from 'client/components/Buttons/Button'
+
 interface SubmitProps {
   disabled?: boolean
   isDirty?: boolean
@@ -9,15 +11,14 @@ interface SubmitProps {
 
 const Submit: React.FC<SubmitProps> = (props) => {
   const { disabled, isDirty, isSubmitting } = props
+
   const { t } = useTranslation()
+
+  const label = isSubmitting ? t('common.submitting') : t('common.submit')
 
   if (disabled) return null
 
-  return (
-    <button className="btn btn-primary" disabled={!isDirty || isSubmitting} type="submit">
-      {isSubmitting ? t('common.submitting') : t('common.submit')}
-    </button>
-  )
+  return <Button disabled={!isDirty || isSubmitting} htmlButtonType="submit" label={label} size={ButtonSize.l} />
 }
 
 export default Submit

--- a/src/client/components/Inputs/MultiSelect/MultiSelect.scss
+++ b/src/client/components/Inputs/MultiSelect/MultiSelect.scss
@@ -19,34 +19,6 @@ div.multiselect__container {
     &.isDisabled {
       align-content: unset;
     }
-
-    div.select__indicatorsContainer {
-      div.select__clearIndicator {
-        height: unset;
-        width: unset;
-
-        svg.icon {
-          color: rgba(0, 0, 0, 0.5);
-          height: $icon-size;
-          width: $icon-size;
-        }
-
-        &:hover {
-          background-color: unset;
-
-          svg.icon {
-            color: $ui-destructive;
-          }
-        }
-      }
-    }
-  }
-
-  div.select__dropdownIndicator {
-    svg {
-      height: $icon-size;
-      width: $icon-size;
-    }
   }
 
   div.select__groupHeading {

--- a/src/client/components/Inputs/Select/Indicators/Indicators.scss
+++ b/src/client/components/Inputs/Select/Indicators/Indicators.scss
@@ -11,29 +11,14 @@ div.select__indicatorsContainer {
   }
 }
 
-@include rtl {
-  div.select__indicatorsContainer {
-    padding-left: unset;
-    padding-right: $spacing-xxxs;
-  }
-}
-
 div.select__clearIndicator {
   align-items: center;
   justify-content: center;
-  padding: 1px;
-  height: 18px;
-  width: 18px;
+  padding: unset;
+  width: 22px;
 
-  svg.icon {
-    color: color.adjust($ui-destructive, $lightness: -7%, $space: hsl);
-  }
-
-  &:hover {
-    background-color: rgba(color.adjust($ui-destructive, $lightness: 30%, $space: hsl), 0.1);
-    svg.icon {
-      color: $ui-destructive;
-    }
+  button {
+    width: 22px;
   }
 }
 
@@ -43,6 +28,8 @@ div.select__clearIndicator {
   justify-items: center;
 
   svg {
+    height: 14px;
+    width: 14px;
     color: $text-body;
   }
 

--- a/src/client/components/Inputs/Select/Indicators/Indicators.tsx
+++ b/src/client/components/Inputs/Select/Indicators/Indicators.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { ClearIndicatorProps, components, DropdownIndicatorProps, IndicatorsContainerProps } from 'react-select'
 import classNames from 'classnames'
 
+import Button, { ButtonSize, ButtonType } from 'client/components/Buttons/Button'
 import Icon from 'client/components/Icon'
 
 export const IndicatorsContainer: React.FC<IndicatorsContainerProps> = (props) => {
@@ -36,7 +37,7 @@ export const ClearIndicator: React.FC<ClearIndicatorProps> = (props) => {
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
     <components.ClearIndicator {...rest} className={classNames(className, 'select__clearIndicator')}>
-      <Icon name="remove" />
+      <Button iconName="remove" inverse size={ButtonSize.m} type={ButtonType.anonymous} />
     </components.ClearIndicator>
   )
 }

--- a/src/client/components/Inputs/Select/Select.scss
+++ b/src/client/components/Inputs/Select/Select.scss
@@ -196,8 +196,8 @@ div.select__wrapper {
 
     div.select__clearIndicator {
       svg {
-        height: 14px;
-        width: 14px;
+        height: 13px;
+        width: 13px;
       }
     }
   }

--- a/src/client/components/Inputs/SelectPrimary/SelectPrimary.scss
+++ b/src/client/components/Inputs/SelectPrimary/SelectPrimary.scss
@@ -25,8 +25,6 @@ div.select-primary__container {
   div.select__dropdownIndicator {
     svg {
       color: white;
-      height: 12px;
-      width: 12px;
     }
   }
 

--- a/src/client/components/Inputs/SelectSecondary/SelectSecondary.scss
+++ b/src/client/components/Inputs/SelectSecondary/SelectSecondary.scss
@@ -27,8 +27,6 @@ div.select-secondary__container {
   div.select__dropdownIndicator {
     svg {
       color: $text-body;
-      height: 12px;
-      width: 12px;
     }
   }
 

--- a/src/client/components/Modal/Modal.scss
+++ b/src/client/components/Modal/Modal.scss
@@ -61,15 +61,7 @@ $border-radius: 2px;
 }
 
 .modal-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-evenly;
   padding: 7px 14px 14px 14px;
-}
-
-.modal-footer__item {
-  margin-left: 5px;
-  margin-right: 5px;
 }
 
 @keyframes animatetop {

--- a/src/client/components/Modal/Modal.tsx
+++ b/src/client/components/Modal/Modal.tsx
@@ -1,9 +1,9 @@
 import './Modal.scss'
 import React, { PropsWithChildren } from 'react'
-
 import classNames from 'classnames'
 
 import Icon from 'client/components/Icon'
+import Flex from 'client/components/Layout/Flex'
 
 type PropsChildren = PropsWithChildren<{ className?: string }>
 
@@ -22,7 +22,9 @@ export const ModalBody: React.FC<PropsChildren> = ({ children, className }) => (
 )
 
 export const ModalFooter: React.FC<PropsChildren> = ({ children, className }) => (
-  <div className={classNames(`modal-footer`, className)}>{React.Children.toArray(children)}</div>
+  <Flex className={classNames(`modal-footer`, className)} gap={'16'} justifyContent={'center'}>
+    {React.Children.toArray(children)}
+  </Flex>
 )
 
 type Props = PropsChildren & {

--- a/src/client/components/Navigation/NavAssessment/Header/Header.scss
+++ b/src/client/components/Navigation/NavAssessment/Header/Header.scss
@@ -9,38 +9,8 @@
   margin: -6px 0;
 
   .btn-toggle {
-    grid-row: 1/3;
     grid-column: 3;
-    justify-self: center;
-    align-self: center;
-    width: $spacing-s;
-    height: $spacing-s;
-    display: grid;
-    align-content: center;
-    justify-content: center;
-    padding: unset;
-    margin-right: -1.5px;
-    transition: all 0.2s;
-
-    svg {
-      color: $text-link;
-      height: 15px;
-      width: 15px;
-      margin: unset;
-    }
-
-    &.active {
-      svg {
-        color: $ui-accent;
-      }
-    }
-
-    &:hover {
-      svg {
-        transform: scale(1.025);
-        color: $text-mute;
-      }
-    }
+    grid-row: 1/3;
   }
 
   .hr {

--- a/src/client/components/Navigation/NavAssessment/Header/Header.tsx
+++ b/src/client/components/Navigation/NavAssessment/Header/Header.tsx
@@ -1,10 +1,8 @@
 import './Header.scss'
 import React from 'react'
 
-import classNames from 'classnames'
-
+import Button, { ButtonSize, ButtonType } from 'client/components/Buttons/Button'
 import Hr from 'client/components/Hr'
-import Icon from 'client/components/Icon'
 
 import LinkLanding from './LinkLanding'
 
@@ -22,13 +20,14 @@ const Header: React.FC<Props> = (props) => {
 
       <div className="nav-header__sep-container">
         <Hr />
-        <button
-          className={classNames('btn-xs', 'btn-secondary', 'btn-transparent', 'btn-toggle')}
+        <Button
+          className="btn-toggle"
+          iconName="unfold"
+          inverse
           onClick={() => setShowSections(!showSections)}
-          type="button"
-        >
-          <Icon name="unfold" />
-        </button>
+          size={ButtonSize.m}
+          type={ButtonType.anonymous}
+        />
       </div>
     </div>
   )

--- a/src/client/components/Navigation/NavAssessment/History/Items/Item/Item.scss
+++ b/src/client/components/Navigation/NavAssessment/History/Items/Item/Item.scss
@@ -37,6 +37,7 @@ $color: color.adjust($ui-bg, $lightness: -20%, $space: hsl);
   align-items: center;
   background-color: transparent;
   border: 1px solid $color;
+  color: $text-body;
   display: grid;
   font-family: $font-family-1;
   font-size: $font-s;

--- a/src/client/components/PageLayout/Header/LanguageSelector/LanguageSelectorMobile.scss
+++ b/src/client/components/PageLayout/Header/LanguageSelector/LanguageSelectorMobile.scss
@@ -7,10 +7,11 @@
 
   button {
     font-weight: 400;
-    font-size: $font-xxs;
     color: $text-mute;
+    text-transform: unset;
+    padding: 0 4px;
 
-    &:disabled {
+    &.disabled {
       font-weight: 600;
       color: $text-body;
       opacity: 1;

--- a/src/client/components/PageLayout/Header/LanguageSelector/LanguageSelectorMobile.tsx
+++ b/src/client/components/PageLayout/Header/LanguageSelector/LanguageSelectorMobile.tsx
@@ -2,28 +2,26 @@ import './LanguageSelectorMobile.scss'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import classNames from 'classnames'
-
 import { Lang, LanguageCodes } from 'meta/lang'
 
-import { useUpdateLanguage } from 'client/hooks/language'
+import { useLanguage, useUpdateLanguage } from 'client/hooks/language'
+import Button, { ButtonType } from 'client/components/Buttons/Button'
 
 const LanguageSelectorMobile: React.FC = () => {
-  const { i18n } = useTranslation()
+  const { t } = useTranslation()
+  const language = useLanguage()
   const updateLanguage = useUpdateLanguage()
 
   return (
     <div className="lang-selector" style={{ gridTemplateColumns: `repeat(${LanguageCodes.length},auto)` }}>
       {LanguageCodes.map((lang: Lang) => (
-        <button
+        <Button
           key={lang}
-          className={classNames('btn', 'btn-xs')}
-          disabled={i18n.resolvedLanguage === lang}
+          disabled={language === lang}
+          label={t(`language.${lang}`)}
           onClick={(): Promise<void> => updateLanguage({ lang })}
-          type="button"
-        >
-          {i18n.t<string>(`language.${lang}`)}
-        </button>
+          type={ButtonType.transparent}
+        />
       ))}
     </div>
   )

--- a/src/client/components/PageLayout/LinkData/LinkData.scss
+++ b/src/client/components/PageLayout/LinkData/LinkData.scss
@@ -2,20 +2,13 @@
 
 @import 'src/client/style/partials';
 
-// reset button style
-button.toolbar__data-link {
-  background: none;
-  border: none;
-}
-
-a.toolbar__data-link,
-button.toolbar__data-link {
+a.toolbar__data-link {
   color: $text-link;
   font-family: $font-family-1;
   font-size: $font-m;
   font-weight: 500;
-  margin: $spacing-xxxs;
   outline: none;
+  padding: $spacing-xxxs;
   text-decoration: none;
   white-space: nowrap;
 
@@ -24,12 +17,8 @@ button.toolbar__data-link {
   }
 
   &.disabled {
-    $disabledColor: color.adjust($text-link, $lightness: 25%, $space: hsl);
-    color: $disabledColor;
+    color: color.adjust($text-link, $lightness: 25%, $space: hsl);
     cursor: default;
-
-    &:hover {
-      color: $disabledColor;
-    }
+    pointer-events: none;
   }
 }

--- a/src/client/components/PageLayout/LinkData/LinkData.tsx
+++ b/src/client/components/PageLayout/LinkData/LinkData.tsx
@@ -2,8 +2,7 @@ import './LinkData.scss'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import MediaQuery from 'react-responsive'
-import { useNavigate } from 'react-router-dom'
-
+import { NavLink } from 'react-router-dom'
 import classNames from 'classnames'
 import { Objects } from 'utils/objects'
 
@@ -23,12 +22,11 @@ const LinkData: React.FC = () => {
   const { assessmentName, countryIso, cycleName, sectionName } = useSectionRouteParams<CountryIso>()
   const isFRA = assessmentName === AssessmentNames.fra
   const isCountryRoute = useIsCountryRoute()
-  const baseParams = { assessmentName, cycleName, countryIso: Global.WO, sectionName }
   const isGeoRoute = useIsGeoRoute()
 
-  const variableDataDisabled = Objects.isNil(sectionName)
+  const baseParams = { assessmentName, cycleName, countryIso: Global.WO, sectionName: sectionName ?? '' }
 
-  const navigate = useNavigate()
+  const variableDataDisabled = Objects.isNil(sectionName)
 
   if (isGeoRoute || !isFRA) {
     return null
@@ -39,21 +37,16 @@ const LinkData: React.FC = () => {
       <LinkDataDownload />
 
       <div className="toolbar__separator" />
-      <button
+
+      <NavLink
         className={classNames('toolbar__data-link', { disabled: variableDataDisabled })}
         data-tooltip-content={t('common.tooltip.dataExplorer')}
         data-tooltip-id={variableDataDisabled ? undefined : TooltipId.white}
-        disabled={variableDataDisabled}
-        onClick={(): void => {
-          const state = { countryISOs: [countryIso] }
-          const path = Routes.Section.generatePath(baseParams)
-
-          navigate(path, { state })
-        }}
-        type="button"
+        state={{ countryISOs: [countryIso] }}
+        to={Routes.Section.generatePath(baseParams)}
       >
         {t('common.variableData')}
-      </button>
+      </NavLink>
 
       {isCountryRoute && (
         <MediaQuery minWidth={Breakpoints.laptop}>

--- a/src/client/components/PageLayout/Toolbar/Status/StatusConfirm/StatusConfirm.tsx
+++ b/src/client/components/PageLayout/Toolbar/Status/StatusConfirm/StatusConfirm.tsx
@@ -9,6 +9,7 @@ import { AreaActions } from 'client/store/area/actions'
 import { useAssessmentCountry } from 'client/store/area/hooks/country'
 import { useAppDispatch } from 'client/store/hooks'
 import { useCountryIso } from 'client/hooks/country'
+import Button, { ButtonSize, ButtonType } from 'client/components/Buttons/Button'
 import ButtonCheckbox, { ButtonCheckboxVariant } from 'client/components/Buttons/ButtonCheckbox'
 import { Modal, ModalBody, ModalClose, ModalFooter, ModalHeader } from 'client/components/Modal'
 import NotifyUsers from 'client/components/PageLayout/Toolbar/Status/StatusConfirm/NotifyUsers'
@@ -31,8 +32,23 @@ const StatusConfirm: React.FC<Props> = (props) => {
   const [notifyUsers, setNotifyUsers] = useState<boolean>(true)
   const [notifySelf, setNotifySelf] = useState<boolean>(true)
 
-  const [textareaValue, setTextareaValue] = useState<string>('')
+  const [message, setMessage] = useState<string>('')
   const { assessmentName, cycleName } = useParams<{ assessmentName: AssessmentName; cycleName: string }>()
+
+  const updateStatus = (): void => {
+    dispatch(
+      AreaActions.updateCountry({
+        notifyUsers,
+        notifySelf,
+        country: { ...country, props: { ...country.props, status: status.status } },
+        countryIso,
+        cycleName,
+        assessmentName,
+        message,
+      })
+    )
+    onClose()
+  }
 
   return (
     <Modal isOpen>
@@ -45,9 +61,9 @@ const StatusConfirm: React.FC<Props> = (props) => {
         <div style={{ height: '160px' }}>
           <textarea
             className="assessment-status-confirm__message"
-            onChange={({ target: { value } }): void => setTextareaValue(value)}
+            onChange={({ target: { value } }): void => setMessage(value)}
             placeholder={t('navigation.changeStatusTextPlaceholder')}
-            value={textareaValue}
+            value={message}
           />
         </div>
 
@@ -62,29 +78,8 @@ const StatusConfirm: React.FC<Props> = (props) => {
       </ModalBody>
 
       <ModalFooter>
-        <button className="btn btn-secondary modal-footer__item" onClick={onClose} type="button">
-          {t('navigation.cancel')}
-        </button>
-        <button
-          className="btn btn-primary modal-footer__item"
-          onClick={(): void => {
-            dispatch(
-              AreaActions.updateCountry({
-                notifyUsers,
-                notifySelf,
-                country: { ...country, props: { ...country.props, status: status.status } },
-                countryIso,
-                cycleName,
-                assessmentName,
-                message: textareaValue,
-              })
-            )
-            onClose()
-          }}
-          type="button"
-        >
-          {t('common.submit')}
-        </button>
+        <Button label={t('common.cancel')} onClick={onClose} size={ButtonSize.l} type={ButtonType.secondary} />
+        <Button label={t('common.submit')} onClick={updateStatus} size={ButtonSize.l} />
       </ModalFooter>
     </Modal>
   )

--- a/src/client/components/PageLayout/Toolbar/ToggleNavigationControl/ToggleNavigationControl.scss
+++ b/src/client/components/PageLayout/Toolbar/ToggleNavigationControl/ToggleNavigationControl.scss
@@ -1,9 +1,0 @@
-@import 'src/client/style/partials';
-
-.toggle-navigation-btn {
-  &.active {
-    svg {
-      color: $ui-accent;
-    }
-  }
-}

--- a/src/client/components/PageLayout/Toolbar/ToggleNavigationControl/ToggleNavigationControl.tsx
+++ b/src/client/components/PageLayout/Toolbar/ToggleNavigationControl/ToggleNavigationControl.tsx
@@ -1,12 +1,10 @@
-import './ToggleNavigationControl.scss'
 import React from 'react'
-import classNames from 'classnames'
 
 import { useAppDispatch } from 'client/store/hooks'
 import { CountryReportActions } from 'client/store/ui/countryReport/actions'
 import { useNavigationVisible } from 'client/store/ui/countryReport/hooks/navigation'
 import { useIsAdminRoute, useIsCycleLandingRoute, useIsGeoRoute } from 'client/hooks/routes'
-import Icon from 'client/components/Icon'
+import Button, { ButtonSize, ButtonType } from 'client/components/Buttons/Button'
 
 const ToggleNavigationControl: React.FC = () => {
   const dispatch = useAppDispatch()
@@ -17,14 +15,16 @@ const ToggleNavigationControl: React.FC = () => {
   const navigationVisible = useNavigationVisible()
 
   return (
-    <button
-      className={classNames('btn toggle-navigation-btn', { active: navigationVisible })}
+    <Button
+      bgTransparent
       disabled={disabled}
+      iconName="menu-left"
+      inverse={navigationVisible}
+      noBorder
       onClick={() => dispatch(CountryReportActions.setNavigationVisible())}
-      type="button"
-    >
-      <Icon name="menu-left" />
-    </button>
+      size={ButtonSize.l}
+      type={navigationVisible ? ButtonType.primary : ButtonType.transparent}
+    />
   )
 }
 

--- a/src/client/components/TablePaginated/Filters/Text/Text.scss
+++ b/src/client/components/TablePaginated/Filters/Text/Text.scss
@@ -15,26 +15,10 @@
   }
 
   button.clear-button {
-    background-color: #ffffff;
-    border: none;
-    height: $spacing-xs;
-    padding: 0;
     position: absolute;
     right: $spacing-xxxs;
     top: 50%;
     transform: translateY(-50%);
-    width: $spacing-xs;
-
-    svg {
-      height: 14px;
-      width: 14px;
-    }
-
-    &:hover {
-      svg {
-        color: $ui-destructive;
-      }
-    }
   }
 
   &.active {

--- a/src/client/components/TablePaginated/Filters/Text/Text.tsx
+++ b/src/client/components/TablePaginated/Filters/Text/Text.tsx
@@ -8,7 +8,7 @@ import { TablePaginatedFilterType } from 'meta/tablePaginated/filters/filter'
 import { useAppDispatch } from 'client/store/hooks'
 import { TablePaginatedActions } from 'client/store/tablePaginated/actions'
 import { useTablePaginatedFilterValue } from 'client/store/tablePaginated/hooks/tablePaginated'
-import Icon from 'client/components/Icon'
+import Button, { ButtonSize, ButtonType } from 'client/components/Buttons/Button'
 import InputText from 'client/components/Inputs/InputText'
 import { TablePaginatedFilter } from 'client/components/TablePaginated/types'
 
@@ -41,9 +41,14 @@ const Text: React.FC<Props> = (props) => {
     <div className={classNames('table-paginated-filter-input', { active: !Objects.isEmpty(filterValue) })}>
       <InputText onChange={handleChange} placeholder={label} value={filterValue ?? ''} />
       {!Objects.isEmpty(filterValue) && (
-        <button className="clear-button icon" onClick={handleClearInput} type="button">
-          <Icon name="remove" />
-        </button>
+        <Button
+          className="clear-button icon"
+          iconName="remove"
+          inverse
+          onClick={handleClearInput}
+          size={ButtonSize.m}
+          type={ButtonType.anonymous}
+        />
       )}
     </div>
   )

--- a/src/client/components/TablePaginated/Header/OrderBy/OrderBy.tsx
+++ b/src/client/components/TablePaginated/Header/OrderBy/OrderBy.tsx
@@ -1,13 +1,11 @@
 import React, { ReactElement, useCallback } from 'react'
 
-import classNames from 'classnames'
-
 import { TablePaginatedOrderBy, TablePaginatedOrderByDirection } from 'meta/tablePaginated/orderBy'
 
 import { useAppDispatch } from 'client/store/hooks'
 import { TablePaginatedActions } from 'client/store/tablePaginated/actions'
 import { useTablePaginatedOrderBy } from 'client/store/tablePaginated/hooks/tablePaginated'
-import Icon from 'client/components/Icon'
+import Button, { ButtonSize, ButtonType } from 'client/components/Buttons/Button'
 import { Column } from 'client/components/TablePaginated/types'
 
 type Props<Datum> = {
@@ -36,9 +34,16 @@ const OrderBy = <Datum extends object>(props: Props<Datum>): ReactElement => {
   }, [active, activeAsc, dispatch, orderByProperty, path])
 
   return (
-    <button className={classNames('btn-sort', { active })} onClick={onClick} type="button">
-      <Icon name={iconName} />
-    </button>
+    <Button
+      bgTransparent
+      className="table-paginated__btn-sort"
+      iconName={iconName}
+      inverse
+      noBorder
+      onClick={onClick}
+      size={ButtonSize.m}
+      type={active ? ButtonType.primary : ButtonType.anonymous}
+    />
   )
 }
 

--- a/src/client/components/TablePaginated/TablePaginated.scss
+++ b/src/client/components/TablePaginated/TablePaginated.scss
@@ -10,8 +10,8 @@
 .table-paginated-datagrid {
   .data-cell {
     border: none;
-    text-align: left;
     padding: $spacing-xxs;
+    text-align: left;
     word-break: break-word;
 
     &.withBorder {
@@ -20,34 +20,14 @@
   }
 
   .data-cell.header {
+    align-items: center;
     background-color: $ui-bg;
-    font-size: $font-m;
-    padding: $spacing-xxs;
-    text-align: left;
-    overflow-wrap: break-word;
-    border: none;
     border-bottom: 1px solid color.adjust($ui-border, $lightness: -15%, $space: hsl);
     display: flex;
+    font-size: $font-m;
     justify-content: start;
-    align-items: center;
-
-    button.btn-sort {
-      border: unset;
-      background: unset;
-      padding: unset;
-      margin: 0 0 0 $spacing-xxs;
-      display: flex;
-      align-items: center;
-
-      svg {
-        color: $text-body;
-      }
-
-      &.active {
-        svg {
-          color: $ui-accent;
-        }
-      }
-    }
+    overflow-wrap: break-word;
+    padding: $spacing-xxs;
+    text-align: left;
   }
 }

--- a/src/client/pages/Section/Title/CSVAllTables/CSVAllTables.tsx
+++ b/src/client/pages/Section/Title/CSVAllTables/CSVAllTables.tsx
@@ -3,8 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Promises } from 'utils/promises'
 
 import { useIsPrintRoute } from 'client/hooks/routes'
-import { ButtonSize, useButtonClassName } from 'client/components/Buttons/Button'
-import Icon from 'client/components/Icon'
+import Button from 'client/components/Buttons/Button'
 
 type Props = {
   disabled?: boolean
@@ -16,13 +15,6 @@ const CSVAllTables: React.FC<Props> = (props) => {
   const [isDownloading, setIsDownloading] = useState(false)
   const { t } = useTranslation()
   const { print } = useIsPrintRoute()
-
-  const className = useButtonClassName({
-    disabled: disabled || isDownloading,
-    iconName: 'hit-down',
-    size: ButtonSize.s,
-    className: 'btn-csv-download-all',
-  })
 
   const handleClick = async (): Promise<void> => {
     setIsDownloading(true)
@@ -50,10 +42,12 @@ const CSVAllTables: React.FC<Props> = (props) => {
   if (print) return null
 
   return (
-    <button className={className} onClick={handleClick} type="button">
-      <Icon className="icon-white" name="hit-down" />
-      {t('common.csvAllTables')}
-    </button>
+    <Button
+      disabled={disabled || isDownloading}
+      iconName="hit-down"
+      label={t('common.csvAllTables')}
+      onClick={handleClick}
+    />
   )
 }
 

--- a/src/client/styles/buttons.scss
+++ b/src/client/styles/buttons.scss
@@ -48,10 +48,6 @@ button:hover {
   @include mixin-button-base($font-s, 3px 9px);
 }
 
-.btn-xs {
-  @include mixin-button-base($font-xs, 1px 4px);
-}
-
 .btn-primary {
   background-color: $ui-accent;
   color: white;
@@ -63,47 +59,6 @@ button:hover {
 
   &:active {
     box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.1);
-  }
-}
-
-.btn-secondary {
-  background-color: $ui-bg;
-  border-color: $ui-border;
-  color: $text-mute;
-
-  &:hover {
-    background-color: color.adjust($ui-bg, $lightness: -4%, $space: hsl);
-    border-color: color.adjust($ui-border, $lightness: -4%, $space: hsl);
-    color: $text-mute;
-  }
-
-  &:active {
-    box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.1);
-  }
-}
-
-.btn-destructive {
-  background-color: $ui-destructive;
-  color: white;
-
-  &:hover {
-    background-color: color.adjust($ui-destructive, $lightness: -4%, $space: hsl);
-    color: white;
-  }
-
-  &:active {
-    box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.1);
-  }
-}
-
-.btn-link {
-  background: transparent;
-  color: color.adjust($ui-accent, $lightness: -2%, $space: hsl);
-  font-weight: 400;
-
-  &:hover {
-    color: color.adjust($ui-accent, $lightness: -4%, $space: hsl);
-    text-decoration: underline;
   }
 }
 

--- a/src/i18n/resources/ar/other.json
+++ b/src/i18n/resources/ar/other.json
@@ -456,7 +456,6 @@
     "placeholder": "اختر..."
   },
   "navigation": {
-    "cancel": "إلغاء",
     "changeStatusTextPlaceholder": "إضافة رسالة اختيارية",
     "doNotNotifyUsers": "عدم إرسال إشعار إلى المستخدمين",
     "hideAll": "إخفاء الكل",

--- a/src/i18n/resources/en/other.json
+++ b/src/i18n/resources/en/other.json
@@ -456,7 +456,6 @@
     "placeholder": "Choose…"
   },
   "navigation": {
-    "cancel": "Cancel",
     "changeStatusTextPlaceholder": "Add an optional message",
     "doNotNotifyUsers": "Don't notify users",
     "hideAll": "Hide all",

--- a/src/i18n/resources/es/other.json
+++ b/src/i18n/resources/es/other.json
@@ -456,7 +456,6 @@
     "placeholder": "Elegir…"
   },
   "navigation": {
-    "cancel": "Cancelar",
     "changeStatusTextPlaceholder": "Añadir un mensaje opcional",
     "doNotNotifyUsers": "No notificar a los usuarios",
     "hideAll": "Esconder todo",

--- a/src/i18n/resources/fr/other.json
+++ b/src/i18n/resources/fr/other.json
@@ -456,7 +456,6 @@
     "placeholder": "Choisir…"
   },
   "navigation": {
-    "cancel": "Annuler",
     "changeStatusTextPlaceholder": "Ajouter un message facultatif",
     "doNotNotifyUsers": "Ne pas notifier les utilisateurs",
     "hideAll": "Masquer tout",

--- a/src/i18n/resources/ru/other.json
+++ b/src/i18n/resources/ru/other.json
@@ -456,7 +456,6 @@
     "placeholder": "Выбрать…"
   },
   "navigation": {
-    "cancel": "Отмена",
     "changeStatusTextPlaceholder": "Добавить комментарий по выбору",
     "doNotNotifyUsers": "Не уведомлять пользователей",
     "hideAll": "Скрыть все",

--- a/src/i18n/resources/zh/other.json
+++ b/src/i18n/resources/zh/other.json
@@ -456,7 +456,6 @@
     "placeholder": "选择…"
   },
   "navigation": {
-    "cancel": "取消",
     "changeStatusTextPlaceholder": "添加可选消息",
     "doNotNotifyUsers": "不通知用户",
     "hideAll": "隐藏所有",


### PR DESCRIPTION
- [x] **Completed components folder** 
- [x] **Add ButtonType.secondary** 

________________________
- [x] **Add from repository** 
<img width="709" height="276" alt="image" src="https://github.com/user-attachments/assets/2242e032-5812-49c3-914a-3dcc3301e735" />

________________________
- [x] **Form**
<img width="722" height="185" alt="image" src="https://github.com/user-attachments/assets/ae90adaa-22a7-46a9-b715-174888109509" />

________________________
- [x] **Select**
<img width="576" height="62" alt="image" src="https://github.com/user-attachments/assets/4f35e265-3aaa-4b81-a64b-b8e63e94d26b" />

________________________
- [x] **Header**
<img width="281" height="103" alt="image" src="https://github.com/user-attachments/assets/25ad6922-5088-47ef-9712-3a6c17278385" />

________________________
- [x] **Language selector mobile**
<img width="370" height="50" alt="image" src="https://github.com/user-attachments/assets/62fafa4f-b5b7-46e9-a88c-4ef99edbf7a7" />

________________________
- [x] **Link data**
<img width="267" height="64" alt="image" src="https://github.com/user-attachments/assets/18b84bc5-5f31-47ac-9481-c6d750fa327f" />


________________________
- [x] **Status confirm**
<img width="232" height="90" alt="image" src="https://github.com/user-attachments/assets/abf396a1-4e3d-4d3c-a810-48ebfaaa1b30" />


________________________
- [x] **Table paginated**
<img width="281" height="98" alt="image" src="https://github.com/user-attachments/assets/7bb8af42-aa16-4d78-8886-b65a4280c115" />