### PR TITLE
5386: Client/styles cleanup: buttons pages [part 1]

### DIFF
--- a/src/client/components/AreaSelector/CountryList/CountryListDownload/CountryListDownload.tsx
+++ b/src/client/components/AreaSelector/CountryList/CountryListDownload/CountryListDownload.tsx
@@ -51,7 +51,7 @@ const CountryListDownload: React.FC = () => {
   return (
     <div className="country-selection-list__download">
       <CSVLink className={className} data={data} filename="FRA-Countries.csv" headers={headers} target="_blank">
-        <Icon className="icon-white" name="hit-down" />
+        <Icon name="hit-down" />
         CSV
       </CSVLink>
     </div>

--- a/src/client/components/AreaSelector/CountryList/CountryListRoleSection/CountryListRoleSection.tsx
+++ b/src/client/components/AreaSelector/CountryList/CountryListRoleSection/CountryListRoleSection.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-
 import classNames from 'classnames'
 import { TFunction } from 'i18next'
 
@@ -18,6 +17,7 @@ import { useIsAreaSelectorExpanded } from 'client/store/ui/areaSelector/hooks/ar
 import { useUser } from 'client/store/user/hooks/user'
 import { checkMatch } from 'client/components/AreaSelector/CountryList/checkMatch'
 import CountryListRow from 'client/components/AreaSelector/CountryList/CountryListRow'
+import Button from 'client/components/Buttons/Button'
 
 import { useToggleMode } from './hooks/useToggleMode'
 
@@ -67,16 +67,16 @@ const CountryListRoleSection: React.FC<Props> = (props: Props) => {
           {!expanded && <div>{t('common.updated')}</div>}
 
           {admin && (
-            <button
-              className="btn btn-s btn-transparent country-selection-list__btn-show-more"
+            <Button
+              className="country-selection-list__btn-show-more"
+              inverse
+              label={expanded ? t('common.showLess') : t('common.showMore')}
+              noBorder
               onClick={(event): void => {
                 event.stopPropagation()
                 toggleMode()
               }}
-              type="button"
-            >
-              {expanded ? t('common.showLess') : t('common.showMore')}
-            </button>
+            />
           )}
         </div>
       )}

--- a/src/client/components/AreaSelector/CountryList/countryList.scss
+++ b/src/client/components/AreaSelector/CountryList/countryList.scss
@@ -101,17 +101,9 @@
 }
 
 button.country-selection-list__btn-show-more {
-  align-items: center;
-  color: $ui-accent;
-  display: flex;
-  font-size: $font-xxs;
-  font-weight: bold;
-  height: $spacing-m;
   margin-left: $spacing-xs;
-  padding: unset;
   position: absolute;
   right: $spacing-xs;
-  text-transform: uppercase;
   top: 0;
 }
 

--- a/src/client/components/ButtonTableExport/ButtonTableExport.tsx
+++ b/src/client/components/ButtonTableExport/ButtonTableExport.tsx
@@ -39,7 +39,7 @@ const ButtonTableExport: React.FC<Props> = (props: Props) => {
       }}
       target="_blank"
     >
-      <Icon className="icon-white" name="hit-down" />
+      <Icon name="hit-down" />
       CSV
     </CSVLink>
   )

--- a/src/client/components/Buttons/Button/Button.tsx
+++ b/src/client/components/Buttons/Button/Button.tsx
@@ -37,7 +37,7 @@ const Button: React.FC<ButtonProps> = (props) => {
       onMouseLeave={onMouseLeave}
       type={htmlButtonType}
     >
-      {iconName && !icon && <Icon className="icon-white" name={iconName} />}
+      {iconName && !icon && <Icon name={iconName} />}
       {icon && icon}
       {label}
     </button>

--- a/src/client/components/Dashboard/ButtonDataExport/ButtonDataExport.tsx
+++ b/src/client/components/Dashboard/ButtonDataExport/ButtonDataExport.tsx
@@ -25,7 +25,7 @@ const ButtonDataExport: React.FC<ButtonDataExportProps> = (props) => {
   return (
     <div>
       <CSVLink className={className} data={data} filename={`${filename}.csv`} target="_blank">
-        <Icon className="icon-white" name="hit-down" />
+        <Icon name="hit-down" />
         CSV
       </CSVLink>
     </div>

--- a/src/client/components/DataGrid/ButtonGridExport/ButtonGridExport.tsx
+++ b/src/client/components/DataGrid/ButtonGridExport/ButtonGridExport.tsx
@@ -37,7 +37,7 @@ const ButtonGridExport: React.FC<Props> = (props) => {
 
   return (
     <CSVLink asyncOnClick className={className} data={data} filename={filename} onClick={onClick} target="_blank">
-      <Icon className="icon-white" name="hit-down" />
+      <Icon name="hit-down" />
       CSV
     </CSVLink>
   )

--- a/src/client/components/Navigation/NavAssessment/NavAssessment.tsx
+++ b/src/client/components/Navigation/NavAssessment/NavAssessment.tsx
@@ -53,7 +53,7 @@ const NavAssessment: React.FC = () => {
             to={Routes.CountryDataDownload.generatePath({ assessmentName, cycleName, countryIso })}
           >
             <div className="nav-section__order">
-              <Icon className="icon-white" name="hit-down" />
+              <Icon name="hit-down" />
             </div>
             <div className="nav-section__label">{t('dataDownload.dataDownload')}</div>
           </Link>

--- a/src/client/components/PageLayout/Toolbar/Options/LinkPrint/LinkPrint.tsx
+++ b/src/client/components/PageLayout/Toolbar/Options/LinkPrint/LinkPrint.tsx
@@ -42,8 +42,8 @@ const LinkPrint: React.FC = () => {
         target="_blank"
         to={pathTables}
       >
-        <Icon className="icon-white" name="small-print" />
-        <Icon className="icon-white" name="icon-table2" />
+        <Icon name="small-print" />
+        <Icon name="icon-table2" />
       </Link>
     </>
   )

--- a/src/client/components/TablePaginated/ExportButton/ExportButton.tsx
+++ b/src/client/components/TablePaginated/ExportButton/ExportButton.tsx
@@ -25,7 +25,7 @@ const ExportButton: React.FC<Props> = (props) => {
   return (
     <div className="table-paginated-export-button">
       <Link className={className} target="_blank" to={exportUrl}>
-        <Icon className="icon-white" name="hit-down" />
+        <Icon name="hit-down" />
         CSV
       </Link>
     </div>

--- a/src/client/pages/CountryHome/Collaborators/UserList/Invite/Invite.tsx
+++ b/src/client/pages/CountryHome/Collaborators/UserList/Invite/Invite.tsx
@@ -16,18 +16,13 @@ const Invite: React.FC = () => {
   const user = useUser()
   const { countryIso } = useCountryRouteParams()
   const cycle = useCycle()
-  const className = useButtonClassName({
-    className: 'btn-invite',
-    iconName: 'small-add',
-    label: 'L',
-    size: ButtonSize.s,
-  })
+  const className = useButtonClassName({ className: 'btn-invite', size: ButtonSize.s })
 
   if (!Users.getRolesAllowedToEdit({ user, countryIso, cycle }).length) return null
 
   return (
     <Link className={className} to={Routes.CountryHomeSectionInvite.path.relative}>
-      <Icon className="icon-white" name="small-add" /> {t('userManagement.addUser')}
+      <Icon name="small-add" /> {t('userManagement.addUser')}
     </Link>
   )
 }

--- a/src/client/pages/CountryHome/CountryHeader/ButtonDownloadDashboard/ButtonDownloadDashboard.tsx
+++ b/src/client/pages/CountryHome/CountryHeader/ButtonDownloadDashboard/ButtonDownloadDashboard.tsx
@@ -9,7 +9,7 @@ import { SectionNames } from 'meta/routes/sectionNames'
 
 import { useLanguage } from 'client/hooks/language'
 import { useCountryRouteParams } from 'client/hooks/routeParams'
-import { ButtonSize, useButtonClassName } from 'client/components/Buttons/Button'
+import { useButtonClassName } from 'client/components/Buttons/Button'
 import Icon from 'client/components/Icon'
 
 const sectionName = SectionNames.Country.Home.overview
@@ -19,7 +19,7 @@ const ButtonDownloadDashboard: React.FC = () => {
 
   const { assessmentName, countryIso, cycleName } = useCountryRouteParams()
   const lang = useLanguage()
-  const className = useButtonClassName({ iconName: 'icon-hit-down', label: 'L', size: ButtonSize.s })
+  const className = useButtonClassName({})
 
   const to = useMemo<string>(() => {
     return Files.Static.getStatisticalFactsheet({
@@ -43,8 +43,8 @@ const ButtonDownloadDashboard: React.FC = () => {
 
   return (
     <Link className={className} target="_top" to={to}>
-      <Icon className="icon-hit-down icon-white" name="hit-down" />
-      <Icon className="icon-white" name="icon-table2" />
+      <Icon className="icon-hit-down" name="hit-down" />
+      <Icon name="icon-table2" />
     </Link>
   )
 }

--- a/src/client/pages/CountryHome/FraHome/RecentActivity/EmptyActivities/EmptyActivities.tsx
+++ b/src/client/pages/CountryHome/FraHome/RecentActivity/EmptyActivities/EmptyActivities.tsx
@@ -5,17 +5,19 @@ import { Link } from 'react-router-dom'
 import { Routes } from 'meta/routes/routes'
 
 import { useCountryRouteParams } from 'client/hooks/routeParams'
+import { ButtonSize, useButtonClassName } from 'client/components/Buttons/Button'
 
 const EmptyActivities: React.FC = () => {
   const { t } = useTranslation()
-
   const { assessmentName, countryIso, cycleName } = useCountryRouteParams()
+  const linkClassName = useButtonClassName({ size: ButtonSize.m })
+
   return (
     <div className="landing__activity-empty">
       <img alt="tucan" height="72" src="/img/tucan.svg" />
       <p className="landing__activity-empty-title">{t('landing.recentActivity.noRecentActivityTitle')}</p>
       <p>{t('landing.recentActivity.noRecentActivityBody')}</p>
-      <Link className="btn-s btn-primary" to={Routes.Country.generatePath({ countryIso, assessmentName, cycleName })}>
+      <Link className={linkClassName} to={Routes.Country.generatePath({ countryIso, assessmentName, cycleName })}>
         {t('landing.recentActivity.getStarted')}
       </Link>
     </div>

--- a/src/client/pages/CountryHome/FraHome/RecentActivity/RecentActivityItem/RecentActivityItem.scss
+++ b/src/client/pages/CountryHome/FraHome/RecentActivity/RecentActivityItem/RecentActivityItem.scss
@@ -73,6 +73,8 @@
 
 .landing__activity-empty {
   color: $text-disabled;
+  display: grid;
+  justify-items: center;
   padding: $spacing-xl;
   text-align: center;
 }

--- a/src/client/pages/CountryHome/Repository/ButtonDownloadAll/ButtonDownloadAll.tsx
+++ b/src/client/pages/CountryHome/Repository/ButtonDownloadAll/ButtonDownloadAll.tsx
@@ -25,7 +25,7 @@ const ButtonDownloadAll: React.FC<Props> = (props: Props) => {
 
   return (
     <Link className={className} target="_blank" to={`${ApiEndPoint.CycleData.Repository.File.many()}?${queryParams}`}>
-      <Icon className="icon-white" name="hit-down" />
+      <Icon name="hit-down" />
       {label}
     </Link>
   )

--- a/src/client/pages/DataDownload/index.tsx
+++ b/src/client/pages/DataDownload/index.tsx
@@ -4,18 +4,26 @@ import { useTranslation } from 'react-i18next'
 
 import { ApiEndPoint } from 'meta/api/endpoint'
 import { Files } from 'meta/file/files'
+import { DataDownloadExt } from 'meta/file/static'
 
 import { useLanguage } from 'client/hooks/language'
 import { useCountryRouteParams } from 'client/hooks/routeParams'
+import { ButtonSize, useButtonClassName } from 'client/components/Buttons/Button'
 import Icon from 'client/components/Icon'
 import { DOMs } from 'client/utils/doms'
 
-import resources from './resources'
+import resources, { DataDownloadResource } from './resources'
 
 const DataDownload: React.FC = () => {
   const { t } = useTranslation()
-  const lang = useLanguage()
+  const language = useLanguage()
   const { assessmentName, countryIso, cycleName } = useCountryRouteParams()
+  const linkClassName = useButtonClassName({ size: ButtonSize.m })
+
+  const getHref = (resource: DataDownloadResource, ext: DataDownloadExt): string => {
+    const { name: file } = resource
+    return Files.Static.getDataDownload({ assessmentName, cycleName, countryIso, ext, file, language })
+  }
 
   useEffect(() => {
     DOMs.scrollTo()
@@ -31,8 +39,8 @@ const DataDownload: React.FC = () => {
 
       <div className="data-download">
         <div>{t('dataDownload.bulkDownload')}</div>
-        <a className="btn-s btn-primary" href={`${ApiEndPoint.File.bulkDownload()}?${baseParams}`}>
-          <Icon className="icon-white" name="hit-down" />
+        <a className={linkClassName} href={`${ApiEndPoint.File.bulkDownload()}?${baseParams}`}>
+          <Icon name="hit-down" />
           ZIP
         </a>
 
@@ -43,34 +51,14 @@ const DataDownload: React.FC = () => {
               {`${resource.idx}. `}
               {t(resource.labelKey)}
             </div>
-            <a
-              className="btn-s btn-primary"
-              href={Files.Static.getDataDownload({
-                assessmentName,
-                cycleName,
-                countryIso,
-                ext: 'ods',
-                file: resource.name,
-                language: lang,
-              })}
-            >
-              <Icon className="icon-white" name="hit-down" />
-              ODS
-            </a>
-            <a
-              className="btn-s btn-primary"
-              href={Files.Static.getDataDownload({
-                assessmentName,
-                cycleName,
-                countryIso,
-                ext: 'xlsx',
-                file: resource.name,
-                language: lang,
-              })}
-            >
-              <Icon className="icon-white" name="hit-down" />
-              XLS
-            </a>
+            {[DataDownloadExt.ods, DataDownloadExt.xlsx].map((ext) => {
+              return (
+                <a key={ext} className={linkClassName} href={getHref(resource, ext)}>
+                  <Icon name="hit-down" />
+                  {ext}
+                </a>
+              )
+            })}
           </React.Fragment>
         ))}
       </div>

--- a/src/client/pages/DataDownload/resources.ts
+++ b/src/client/pages/DataDownload/resources.ts
@@ -1,6 +1,12 @@
 import { DataDownloadFileName } from 'meta/file/static'
 
-const resources = [
+export type DataDownloadResource = {
+  idx: number
+  name: DataDownloadFileName
+  labelKey: string
+}
+
+const resources: Array<DataDownloadResource> = [
   {
     idx: 1,
     name: DataDownloadFileName.ForestExtentCharacteristicsAndChanges,

--- a/src/client/pages/Geo/ButtonCSVExport/ButtonCSVExport.tsx
+++ b/src/client/pages/Geo/ButtonCSVExport/ButtonCSVExport.tsx
@@ -24,7 +24,7 @@ const ButtonCSVExport: React.FC<Props> = (props) => {
       headers={csvData.headers}
       target="_blank"
     >
-      <Icon className="icon-white" name="hit-down" />
+      <Icon name="hit-down" />
       CSV
     </CSVLink>
   )

--- a/src/client/pages/OriginalDataPoint/components/NationalClasses/components/Prefill.tsx
+++ b/src/client/pages/OriginalDataPoint/components/NationalClasses/components/Prefill.tsx
@@ -51,7 +51,6 @@ export const Prefill: React.FC<Props> = (props) => {
         value={selectedPreviousYear}
       />
       <Button
-        className="btn-s btn-primary btn-copy-prev-values"
         disabled={copyDisabled || selectedPreviousYear === ''}
         label={t('nationalDataPoint.prefill')}
         onClick={onCopyClick}

--- a/src/client/pages/Print/Header/Header.tsx
+++ b/src/client/pages/Print/Header/Header.tsx
@@ -47,8 +47,8 @@ const Header: React.FC = () => {
       <div className="print-header__toolbar">
         {withDownload && (
           <a className={downloadClassName} href={downloadHref} rel="noreferrer" target="_blank">
-            <Icon className="icon-white" name="hit-down" />
-            <Icon className="icon-white" name="icon-files" />
+            <Icon name="hit-down" />
+            <Icon name="icon-files" />
           </a>
         )}
       </div>

--- a/src/client/pages/Section/DataTable/GenerateValues/GenerateValues.tsx
+++ b/src/client/pages/Section/DataTable/GenerateValues/GenerateValues.tsx
@@ -10,6 +10,7 @@ import { TableNames } from 'meta/assessment/table'
 import { RecordAssessmentData } from 'meta/data/recordData'
 
 import { useAssessmentCountry } from 'client/store/area/hooks/country'
+import Button from 'client/components/Buttons/Button'
 import Select, { Option, SelectSize } from 'client/components/Inputs/Select'
 
 import { useEstimationStatusListener } from './hooks/useEstimationStatusListener'
@@ -54,8 +55,8 @@ const GenerateValues: React.FC<Props> = (props) => {
   // ODPs cannot be hidden for table 1a
   if (!useOriginalDataPoint && tableName === TableNames.forestCharacteristics) return null
 
-  let buttonLabel = 'tableWithOdp.generateFraValues'
-  if (isEstimationPending || !buttonEnabled) buttonLabel = 'tableWithOdp.generatingFraValues'
+  const buttonLabel =
+    isEstimationPending || !buttonEnabled ? 'tableWithOdp.generatingFraValues' : 'tableWithOdp.generateFraValues'
 
   const options = methods.map<Option>((m) => {
     return { value: m.method, label: t(m.labelKey) }
@@ -72,9 +73,9 @@ const GenerateValues: React.FC<Props> = (props) => {
           value={method ?? ''}
         />
 
-        <button
-          className="btn-s btn-primary"
+        <Button
           disabled={isEstimationPending || !valid || !buttonEnabled}
+          label={t(buttonLabel)}
           onClick={(): void => {
             setButtonEnabled(false)
             generateValues()
@@ -82,10 +83,7 @@ const GenerateValues: React.FC<Props> = (props) => {
               setButtonEnabled(true)
             }, 4_000)
           }}
-          type="button"
-        >
-          {t(buttonLabel)}
-        </button>
+        />
 
         {!Objects.isEmpty(method) && <FieldsOption fields={fields} method={method} setFields={setFields} />}
       </div>

--- a/src/client/pages/Section/SectionHeader/ExtentOfForest/ExtentOfForest.tsx
+++ b/src/client/pages/Section/SectionHeader/ExtentOfForest/ExtentOfForest.tsx
@@ -19,7 +19,7 @@ const ExtentOfForest: React.FC = () => {
   const { assessmentName, countryIso, cycleName } = useCountryRouteParams<CountryIso>()
   const user = useUser()
   const disabled = !editEnabled
-  const className = useButtonClassName({ disabled, iconName: 'small-add', label: 'L', size: ButtonSize.m })
+  const className = useButtonClassName({ disabled, size: ButtonSize.m })
 
   if (!user) return null
 
@@ -30,7 +30,7 @@ const ExtentOfForest: React.FC = () => {
           className={className}
           to={Routes.OriginalDataPoint.generatePath({ assessmentName, cycleName, countryIso, sectionName, year: '-1' })}
         >
-          <Icon className="icon-white" name="small-add" />
+          <Icon name="small-add" />
           {t('nationalDataPoint.addNationalDataPoint')}
         </Link>
       </div>

--- a/src/client/pages/Tutorials/Tutorials.tsx
+++ b/src/client/pages/Tutorials/Tutorials.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useLanguage } from 'client/hooks/language'
+import { ButtonSize, useButtonClassName } from 'client/components/Buttons/Button'
 import Icon from 'client/components/Icon'
 import GuidelinesAndSpecifications from 'client/pages/Tutorials/GuidelinesAndSpecifications'
 
@@ -67,6 +68,7 @@ export const videoResources: Array<{
 const Tutorials: React.FC = () => {
   const { t } = useTranslation()
   const lang = useLanguage()
+  const linkClassName = useButtonClassName({ size: ButtonSize.m })
 
   return (
     <div>
@@ -85,12 +87,12 @@ const Tutorials: React.FC = () => {
               <div>{t(resource.labelKey)}</div>
 
               <a
-                className="btn-s btn-primary"
+                className={linkClassName}
                 href={resource.url[lang] ?? resource.url.en}
                 rel="noreferrer"
                 target="_blank"
               >
-                <Icon className="icon-white" name="video" />
+                <Icon name="video" />
                 {t('tutorial.watch')}
               </a>
             </React.Fragment>

--- a/src/client/styles/buttons.scss
+++ b/src/client/styles/buttons.scss
@@ -47,22 +47,3 @@ button:hover {
 .btn-s {
   @include mixin-button-base($font-s, 3px 9px);
 }
-
-.btn-primary {
-  background-color: $ui-accent;
-  color: white;
-
-  &:hover {
-    background-color: color.adjust($ui-accent, $lightness: -4%, $space: hsl);
-    color: white;
-  }
-
-  &:active {
-    box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.1);
-  }
-}
-
-.btn-transparent {
-  background-color: transparent;
-  border: none;
-}

--- a/src/meta/file/static.ts
+++ b/src/meta/file/static.ts
@@ -25,9 +25,14 @@ export enum DataDownloadFileName {
   PermanentForestEstate = '6 Permanent forest estate',
 }
 
+export enum DataDownloadExt {
+  ods = 'ods',
+  xlsx = 'xlsx',
+}
+
 interface DataDownloadProps extends BaseParams {
   file: DataDownloadFileName
-  ext: 'ods' | 'xlsx'
+  ext: DataDownloadExt
   language: Lang
 }
 


### PR DESCRIPTION
- [x] **Removed unnecessary icon-white className (icon color is inherited from Button type)**
- [x] **cleanup btn-primary btn-transparent classes**

____________________
- [x] **Country selector: show more/less**
<img width="441" height="48" alt="image" src="https://github.com/user-attachments/assets/7836658c-eafb-4cc0-940e-838a12102ea2" />

____________________
- [x] **Empty activities**
<img width="720" height="187" alt="image" src="https://github.com/user-attachments/assets/17b81092-d0d4-4648-89fe-ce2c88072fdd" />

____________________
- [x] **Data download**
<img width="807" height="347" alt="image" src="https://github.com/user-attachments/assets/59421b4f-33eb-47d8-bcc1-230cac006440" />

____________________
- [x] **Generate values**
<img width="348" height="51" alt="image" src="https://github.com/user-attachments/assets/65ee1bed-7789-4ead-9795-27978b0c9f41" />

____________________
- [x] **Tutorials**
<img width="1063" height="337" alt="image" src="https://github.com/user-attachments/assets/6e6f1344-949e-4994-9748-6bbb8f01428f" />





