### PR TITLE
5491 - Admin links job on separate Heroku dyno - Add VerifyLinksJob

### DIFF
--- a/src/server/controller/cycleData/links/getAllLinksToVisit.ts
+++ b/src/server/controller/cycleData/links/getAllLinksToVisit.ts
@@ -1,5 +1,5 @@
 import { CountryIso } from 'meta/area/countryIso'
-import { Assessment } from 'meta/assessment/assessment'
+import { Assessment, AssessmentNames } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import { OriginalDataPointCommentKey } from 'meta/assessment/originalDataPoint'
 import { SectionNames } from 'meta/assessment/section'
@@ -90,6 +90,8 @@ const _getDescriptionTextLinks = async (props: Props): Promise<Array<LinkToVisit
 
 const _getOriginalDataPointLinks = async (props: Props): Promise<Array<LinkToVisit>> => {
   const { assessment, cycle } = props
+  if (assessment.props.name === AssessmentNames.panEuropean) return []
+
   const assessmentName = assessment.props.name
   const cycleName = cycle.name
   const [odpsByDescriptionsLinks, odpsByReferenceLinks] = await Promise.all([

--- a/src/server/controller/cycleData/links/visitCycleLinks/queueFactory.ts
+++ b/src/server/controller/cycleData/links/visitCycleLinks/queueFactory.ts
@@ -1,17 +1,15 @@
-import { Job, Queue, QueueOptions, Worker } from 'bullmq'
+import { Job, Queue, QueueOptions } from 'bullmq'
 import IORedis from 'ioredis'
 
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 
 import { ProcessEnv } from 'server/utils'
-import { Logger } from 'server/utils/logger'
 
 import { VisitCycleLinksProps } from './props'
-import { WorkerFactory } from './workerFactory'
 
-const queues: Record<string, Queue<VisitCycleLinksProps>> = {}
-const workers: Record<string, Worker<VisitCycleLinksProps>> = {}
+const queueName = 'verifyLinks'
+let queue: Queue<VisitCycleLinksProps> | undefined
 
 const connection = new IORedis(ProcessEnv.redisQueueUrl)
 connection.options.maxRetriesPerRequest = null
@@ -26,35 +24,29 @@ const opts: QueueOptions = {
   streams: { events: { maxLen: 1 } },
 }
 
-const getInstance = (props: Props): Queue<VisitCycleLinksProps> => {
-  const { assessment, cycle } = props
-
-  const key = `visitCycleLinks/${assessment.props.name}/${cycle.name}`
-  let queue = queues[key]
-
+const getInstance = (): Queue<VisitCycleLinksProps> => {
   if (queue) return queue
 
-  workers[key] = WorkerFactory.newInstance({ key })
-
-  queue = new Queue<VisitCycleLinksProps>(key, opts)
-  queues[key] = queue
-
+  queue = new Queue<VisitCycleLinksProps>(queueName, opts)
   return queue
 }
 
-const getActiveJobs = async (props: Props): Promise<Array<Job<VisitCycleLinksProps>>> => {
-  const queue = getInstance(props)
+const getActiveJobs = async (_props: Props): Promise<Array<Job<VisitCycleLinksProps>>> => {
+  const queue = getInstance()
   const activeJobs: Array<Job<VisitCycleLinksProps>> = await queue.getActive()
   return activeJobs
 }
 
-process.on('SIGTERM', async () => {
-  await Promise.all(Object.values(workers).map((worker) => worker.close()))
-  Logger.debug('[visitCycleLinks] all workers closed')
-})
+const getJobId = (props: Props): string => {
+  const { assessment, cycle } = props
+
+  return `verifyLinks/${assessment.props.name}/${cycle.name}`
+}
 
 export const VisitCycleLinksQueueFactory = {
   connection,
   getActiveJobs,
   getInstance,
+  getJobId,
+  queueName,
 }

--- a/src/server/controller/cycleData/links/visitCycleLinks/visitCycleLinks.ts
+++ b/src/server/controller/cycleData/links/visitCycleLinks/visitCycleLinks.ts
@@ -1,6 +1,7 @@
 import { Job, JobsOptions } from 'bullmq'
 
 import { Logger } from 'server/utils/logger'
+import { VerifyLinksJob } from 'server/worker/tasks/verifyLinksJob'
 
 import { VisitCycleLinksProps } from './props'
 import { VisitCycleLinksQueueFactory } from './queueFactory'
@@ -21,6 +22,12 @@ export const visitCycleLinks = async (props: VisitCycleLinksProps): Promise<Job<
 
   if (isVerificationInProgress) return undefined
 
-  const queue = VisitCycleLinksQueueFactory.getInstance({ assessment, cycle })
-  return queue.add('visitCycleLinks', props, jobOptions)
+  const queue = VisitCycleLinksQueueFactory.getInstance()
+  const jobId = VisitCycleLinksQueueFactory.getJobId({ assessment, cycle })
+  const job = await queue.add('verifyLinks', props, { ...jobOptions, jobId })
+
+  const verifyLinksJob = new VerifyLinksJob({ assessment, cycle })
+  await verifyLinksJob.setQueued(job.id?.toString())
+
+  return job
 }

--- a/src/server/controller/cycleData/links/visitCycleLinks/workerFactory.ts
+++ b/src/server/controller/cycleData/links/visitCycleLinks/workerFactory.ts
@@ -12,17 +12,20 @@ import { SocketServer } from 'server/service/socket'
 import { ProcessEnv } from 'server/utils'
 import { Logger } from 'server/utils/logger'
 
-import { VisitCycleLinksProps } from './props'
+import { VisitCycleLinksJob, VisitCycleLinksProps } from './props'
 import workerProcessor from './worker'
 
 const connection = new IORedis(ProcessEnv.redisQueueUrl)
 connection.options.maxRetriesPerRequest = null
 
+const jobTimeoutMs = 10 * 60 * 1000
+
 const workerOptions: WorkerOptions = {
   concurrency: 1,
   connection,
-  lockDuration: 60_000,
+  lockDuration: jobTimeoutMs,
   maxStalledCount: 0,
+  skipLockRenewal: true,
 }
 
 type EmitEventProps = {
@@ -30,6 +33,8 @@ type EmitEventProps = {
   cycle: Cycle
   event: keyof WorkerListener
 }
+
+type VisitCycleLinksProcessor = string | ((job: VisitCycleLinksJob) => Promise<void>)
 
 const _emitEvent = (props: EmitEventProps): void => {
   const { assessment, cycle, event } = props
@@ -40,10 +45,10 @@ const _emitEvent = (props: EmitEventProps): void => {
   SocketServer.emit(linksVerificationEvent, { event })
 }
 
-const newInstance = (props: { key: string }): Worker<VisitCycleLinksProps> => {
-  const { key } = props
+const newInstance = (props: { key: string; processor?: VisitCycleLinksProcessor }): Worker<VisitCycleLinksProps> => {
+  const { key, processor } = props
 
-  const worker = new Worker<VisitCycleLinksProps>(key, workerProcessor, workerOptions)
+  const worker = new Worker<VisitCycleLinksProps>(key, processor ?? workerProcessor, workerOptions)
 
   worker.on('error', (error) => {
     Logger.error(`[visitCycleLinks-worker] job error ${error}`)

--- a/src/server/controller/cycleData/links/visitCycleLinks/workerFactory.ts
+++ b/src/server/controller/cycleData/links/visitCycleLinks/workerFactory.ts
@@ -34,6 +34,7 @@ type EmitEventProps = {
   event: keyof WorkerListener
 }
 
+// BullMQ accepts either a processor function (dev) or a path to compiled JS (prod).
 type VisitCycleLinksProcessor = string | ((job: VisitCycleLinksJob) => Promise<void>)
 
 const _emitEvent = (props: EmitEventProps): void => {

--- a/src/server/worker/tasks/verifyLinks.ts
+++ b/src/server/worker/tasks/verifyLinks.ts
@@ -8,12 +8,29 @@ import { Logger } from 'server/utils/logger'
 import { VerifyLinksJob } from 'server/worker/tasks/verifyLinksJob'
 import { VerifyLinksWorkerPresence } from 'server/worker/tasks/verifyLinksWorkerPresence'
 
-// One minute idle time before shutdown
+/**
+ * The plan:
+ * - Queue verify-links jobs in the main web process and keep them using Redis, then
+ *   spin up a dedicated Heroku dyno to consume them.
+ * - Only one dyno should run at a time. If one is already active, new requests are
+ *   just added to the queue.
+ * - The worker runs with concurrency=1, so the jobs are run sequentially. There will
+ *   be a single queue for all link jobs, regardless of assessment/cycle. Then the
+ *   worker shuts itself down after the queue stays empty for a brief idle grace period.
+ * - The job status is stored in Redis keyed by assessment/cycle so the admin status
+ *   endpoint can report queued/running/success/failed per assessment/cycle. That's
+ *   also necessary so we can disable the Verify Links button per assessment. (We will
+ *   add a countryIso to the key in the future).
+ */
+
+// Idle grace period to keep dyno alive briefly for possible new incoming jobs.
 const idleGraceMs = 60 * 1000
+// Interval time to check if the process is idle and can be shut down.
 const idleCheckIntervalMs = 15 * 1000
 
 const isMainProcess = require.main === module
 
+// Exit on idle option, set to false for dev so the local server can keep running.
 type StartOptions = {
   exitOnIdle?: boolean
 }
@@ -30,10 +47,12 @@ export const startVerifyLinksWorker = async (options: StartOptions = {}): Promis
 
   const queue = VisitCycleLinksQueueFactory.getInstance()
 
+  // Init SocketServer only for the worker dyno so it can emit events.
   if (exitOnIdle) {
     await SocketServer.init(http.createServer())
   }
 
+  // Mark this worker as active in Redis so new requests won’t start another dyno.
   await VerifyLinksWorkerPresence.refreshWorkerLock(workerId)
 
   const worker = WorkerFactory.newInstance({
@@ -74,6 +93,7 @@ export const startVerifyLinksWorker = async (options: StartOptions = {}): Promis
       const pendingJobs = counts.waiting + counts.active + counts.delayed
 
       if (pendingJobs === 0) {
+        // Queue is empty, so shutdown if the grace period has passed.
         if (!idleSince) idleSince = Date.now()
         const idleForMs = Date.now() - idleSince
         if (idleForMs >= idleGraceMs) {
@@ -87,6 +107,7 @@ export const startVerifyLinksWorker = async (options: StartOptions = {}): Promis
     }
   }
 
+  // Check idle periodically.
   idleIntervalRef.current = setInterval(() => {
     void checkIdle()
   }, idleCheckIntervalMs)

--- a/src/server/worker/tasks/verifyLinks.ts
+++ b/src/server/worker/tasks/verifyLinks.ts
@@ -1,0 +1,119 @@
+import http from 'http'
+
+import { VisitCycleLinksJob } from 'server/controller/cycleData/links/visitCycleLinks'
+import { VisitCycleLinksQueueFactory } from 'server/controller/cycleData/links/visitCycleLinks/queueFactory'
+import { WorkerFactory } from 'server/controller/cycleData/links/visitCycleLinks/workerFactory'
+import { SocketServer } from 'server/service/socket'
+import { Logger } from 'server/utils/logger'
+import { VerifyLinksJob } from 'server/worker/tasks/verifyLinksJob'
+import { VerifyLinksWorkerPresence } from 'server/worker/tasks/verifyLinksWorkerPresence'
+
+// One minute idle time before shutdown
+const idleGraceMs = 60 * 1000
+const idleCheckIntervalMs = 15 * 1000
+
+const isMainProcess = require.main === module
+
+type StartOptions = {
+  exitOnIdle?: boolean
+}
+
+const processor = async (job: VisitCycleLinksJob): Promise<void> => {
+  const { assessment, cycle } = job.data
+  const verifyLinksJob = new VerifyLinksJob({ assessment, cycle })
+  await verifyLinksJob.runFromQueue(job)
+}
+
+export const startVerifyLinksWorker = async (options: StartOptions = {}): Promise<void> => {
+  const exitOnIdle = options.exitOnIdle ?? isMainProcess
+  const workerId = `verify-links-${process.pid}-${Date.now()}`
+
+  const queue = VisitCycleLinksQueueFactory.getInstance()
+
+  if (exitOnIdle) {
+    await SocketServer.init(http.createServer())
+  }
+
+  await VerifyLinksWorkerPresence.refreshWorkerLock(workerId)
+
+  const worker = WorkerFactory.newInstance({
+    key: VisitCycleLinksQueueFactory.queueName,
+    processor,
+  })
+
+  let idleSince: number | null = null
+  let isCheckingIdle = false
+  let shuttingDown = false
+  const idleIntervalRef: { current?: NodeJS.Timeout } = {}
+
+  const shutdown = async (reason: string): Promise<void> => {
+    if (shuttingDown) return
+    shuttingDown = true
+
+    if (idleIntervalRef.current) {
+      clearInterval(idleIntervalRef.current)
+    }
+
+    await worker.close()
+    await VerifyLinksWorkerPresence.clearWorkerLock()
+
+    if (exitOnIdle) {
+      await queue.close()
+      await VerifyLinksWorkerPresence.disconnect()
+      Logger.info(`[verifyLinks-worker] shutdown (${reason})`)
+      process.exit(0)
+    }
+  }
+
+  const checkIdle = async (): Promise<void> => {
+    if (isCheckingIdle || shuttingDown) return
+    isCheckingIdle = true
+
+    try {
+      const counts = await queue.getJobCounts('waiting', 'active', 'delayed')
+      const pendingJobs = counts.waiting + counts.active + counts.delayed
+
+      if (pendingJobs === 0) {
+        if (!idleSince) idleSince = Date.now()
+        const idleForMs = Date.now() - idleSince
+        if (idleForMs >= idleGraceMs) {
+          await shutdown('idle')
+        }
+      } else {
+        idleSince = null
+      }
+    } finally {
+      isCheckingIdle = false
+    }
+  }
+
+  idleIntervalRef.current = setInterval(() => {
+    void checkIdle()
+  }, idleCheckIntervalMs)
+
+  worker.on('active', () => {
+    idleSince = null
+  })
+  worker.on('completed', () => {
+    idleSince = null
+  })
+  worker.on('failed', () => {
+    idleSince = null
+  })
+
+  process.on('SIGTERM', () => {
+    void shutdown('SIGTERM')
+  })
+  process.on('SIGINT', () => {
+    void shutdown('SIGINT')
+  })
+
+  await checkIdle()
+}
+
+if (isMainProcess) {
+  startVerifyLinksWorker({ exitOnIdle: true }).catch((error) => {
+    Logger.error(`[verifyLinks-worker] failed to start: ${JSON.stringify(error)}`)
+    process.exit(1)
+  })
+}

--- a/src/server/worker/tasks/verifyLinksJob.ts
+++ b/src/server/worker/tasks/verifyLinksJob.ts
@@ -1,0 +1,72 @@
+import { Assessment } from 'meta/assessment/assessment'
+import { Cycle } from 'meta/assessment/cycle'
+
+import { VisitCycleLinksJob } from 'server/controller/cycleData/links/visitCycleLinks'
+import workerProcessor from 'server/controller/cycleData/links/visitCycleLinks/worker'
+import { Job } from 'server/worker/job/job'
+import { JobStatus } from 'server/worker/job/jobStatus'
+
+type VerifyLinksJobContext = {
+  assessment: Assessment
+  cycle: Cycle
+}
+
+const jobNamePrefix = 'VerifyLinks'
+
+export class VerifyLinksJob extends Job {
+  #queueJob?: VisitCycleLinksJob
+
+  public constructor(context: VerifyLinksJobContext) {
+    super(VerifyLinksJob.getJobName(context))
+  }
+
+  public static getJobName(context: VerifyLinksJobContext): string {
+    const { assessment, cycle } = context
+    return `${jobNamePrefix}/${assessment.props.name}/${cycle.name}`
+  }
+
+  public async runFromQueue(job: VisitCycleLinksJob): Promise<void> {
+    const jobId = job.id?.toString()
+    this.#queueJob = job
+
+    try {
+      await this.setRunning(jobId)
+      await this.execute()
+      await this.setSuccess(jobId)
+    } catch (error) {
+      await this.setFailed(error, jobId)
+      throw error
+    } finally {
+      this.#queueJob = undefined
+    }
+  }
+
+  public async setQueued(jobId?: string): Promise<void> {
+    await this.setStatus(JobStatus.queued, { jobId, queuedAt: new Date().toISOString() })
+  }
+
+  public async setRunning(jobId?: string): Promise<void> {
+    await this.setStatus(JobStatus.running, { jobId, startedAt: new Date().toISOString() })
+  }
+
+  public async setSuccess(jobId?: string): Promise<void> {
+    await this.setStatus(JobStatus.success, { jobId, finishedAt: new Date().toISOString() })
+  }
+
+  public async setFailed(error: unknown, jobId?: string): Promise<void> {
+    const errorMessage = error instanceof Error ? error.message : JSON.stringify(error)
+    await this.setStatus(JobStatus.failed, {
+      error: errorMessage,
+      finishedAt: new Date().toISOString(),
+      jobId,
+    })
+  }
+
+  protected async execute(): Promise<void> {
+    if (!this.#queueJob) {
+      throw new Error('VerifyLinksJob.execute requires a BullMQ job payload')
+    }
+
+    await workerProcessor(this.#queueJob)
+  }
+}

--- a/src/server/worker/tasks/verifyLinksWorkerPresence.ts
+++ b/src/server/worker/tasks/verifyLinksWorkerPresence.ts
@@ -1,0 +1,41 @@
+import IORedis from 'ioredis'
+
+import { ProcessEnv } from 'server/utils'
+
+const workerPresenceKey = 'verifyLinks:worker:active'
+const workerPresenceTtlMs = 10 * 60 * 1000
+const redis = new IORedis(ProcessEnv.redisQueueUrl)
+redis.options.maxRetriesPerRequest = null
+
+const isWorkerActive = async (): Promise<boolean> => {
+  const value = await redis.get(workerPresenceKey)
+  return Boolean(value)
+}
+
+const tryAcquireWorkerLock = async (value: string): Promise<boolean> => {
+  const result = await redis.set(workerPresenceKey, value, 'PX', workerPresenceTtlMs, 'NX')
+  return result === 'OK'
+}
+
+const refreshWorkerLock = async (value: string): Promise<void> => {
+  await redis.set(workerPresenceKey, value, 'PX', workerPresenceTtlMs)
+}
+
+const clearWorkerLock = async (): Promise<void> => {
+  await redis.del(workerPresenceKey)
+}
+
+const disconnect = async (): Promise<void> => {
+  await redis.quit()
+}
+
+export const VerifyLinksWorkerPresence = {
+  clearWorkerLock,
+  disconnect,
+  isWorkerActive,
+  redis,
+  refreshWorkerLock,
+  tryAcquireWorkerLock,
+  workerPresenceKey,
+  workerPresenceTtlMs,
+}


### PR DESCRIPTION
The plan:
- Queue verify‑links jobs in the main web process and keep them using Redis, then spin up a dedicated Heroku dyno to consume them.
- Only one dyno should run at a time. If one is already active, new requests are just added to the queue.
- The worker runs with concurrency=1, so the jobs are run sequentially. There will be a single queue for *all* link jobs, regardless of assessment/cycle. Then the worker shuts itself down after the queue stays empty for a brief idle grace period.
- The job status is stored in Redis keyed by assessment/cycle so the admin status endpoint can report queued/running/success/failed per assessment/cycle. That's also necessary so we can disable the Verify Links button per assessment.  (We will add a countryIso to the key in the future). 