### PR TITLE
5547 - Reviewer Links Verification process - Add Links.getVerificationSummary BE

### DIFF
--- a/src/meta/api/endpoint/cycleData.ts
+++ b/src/meta/api/endpoint/cycleData.ts
@@ -25,6 +25,7 @@ export const CycleData = {
     many: (): string => apiPath('cycle-data', 'links'),
     one: (): string => apiPath('cycle-data', 'links', 'link'),
     verify: (): string => apiPath('cycle-data', 'links', 'verify'),
+    verifySummary: (): string => apiPath('cycle-data', 'links', 'verify', 'summary'),
     verifyStatus: (): string => apiPath('cycle-data', 'links', 'verify', 'status'),
   },
 

--- a/src/meta/cycleData/links/link.ts
+++ b/src/meta/cycleData/links/link.ts
@@ -57,3 +57,10 @@ export type LinkToVisit = {
 }
 
 export type VisitedLink = LinkToVisit & LinkVisit
+
+export type LinksVerificationSummary = {
+  invalidCount: number
+  invalidUnapprovedCount: number
+  lastExecutedAt?: string
+  neverRan: boolean
+}

--- a/src/server/api/cycleData/index.ts
+++ b/src/server/api/cycleData/index.ts
@@ -13,6 +13,7 @@ import { getManyLinks } from 'server/api/cycleData/links/getManyLinks'
 import { updateLink } from 'server/api/cycleData/links/updateLink'
 import { verifyLinks } from 'server/api/cycleData/links/verifyLinks'
 import { verifyStatus } from 'server/api/cycleData/links/verifyStatus'
+import { verifySummary } from 'server/api/cycleData/links/verifySummary'
 import { AuthMiddleware } from 'server/middleware/auth'
 
 import { getActivities } from './activities/getActivities'
@@ -158,6 +159,7 @@ export const CycleDataApi = {
     express.get(ApiEndPoint.CycleData.Links.export(), AuthMiddleware.requireVerifyLinks, exportLinks)
     express.patch(ApiEndPoint.CycleData.Links.one(), AuthMiddleware.requireVerifyLinks, updateLink)
     express.post(ApiEndPoint.CycleData.Links.verify(), AuthMiddleware.requireVerifyLinks, verifyLinks)
+    express.get(ApiEndPoint.CycleData.Links.verifySummary(), AuthMiddleware.requireVerifyLinks, verifySummary)
     express.get(ApiEndPoint.CycleData.Links.verifyStatus(), AuthMiddleware.requireVerifyLinks, verifyStatus)
 
     // Activities

--- a/src/server/api/cycleData/links/verifySummary.ts
+++ b/src/server/api/cycleData/links/verifySummary.ts
@@ -1,0 +1,21 @@
+import { Response } from 'express'
+
+import { CycleRequest } from 'meta/api/request/cycle'
+import { AreaCode } from 'meta/area/areaCode'
+
+import { CycleDataController } from 'server/controller/cycleData'
+import Requests from 'server/utils/requests'
+
+type Request = CycleRequest<{ countryIso?: AreaCode }>
+
+export const verifySummary = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { assessment, country, cycle } = req.context
+    const { countryIso } = country ?? {}
+
+    const summary = await CycleDataController.Links.getVerificationSummary({ assessment, countryIso, cycle })
+    Requests.sendOk(res, summary)
+  } catch (e) {
+    Requests.sendErr(res, e)
+  }
+}

--- a/src/server/controller/cycleData/links/getVerificationSummary.ts
+++ b/src/server/controller/cycleData/links/getVerificationSummary.ts
@@ -1,0 +1,39 @@
+import { CountryIso } from 'meta/area/countryIso'
+import { Assessment } from 'meta/assessment/assessment'
+import { Cycle } from 'meta/assessment/cycle'
+import { LinksVerificationSummary } from 'meta/cycleData/links/link'
+
+import { LinkRepository } from 'server/db/repository/assessmentCycle/links'
+import { ActivityLogRepository } from 'server/db/repository/public/activityLog'
+import { JobStatus } from 'server/worker/job/jobStatus'
+import { VerifyLinksJob } from 'server/worker/tasks/verifyLinks/verifyLinksJob'
+
+type Props = {
+  assessment: Assessment
+  countryIso?: CountryIso
+  cycle: Cycle
+}
+
+export const getVerificationSummary = async (props: Props): Promise<LinksVerificationSummary> => {
+  const { assessment, countryIso, cycle } = props
+
+  const verifyLinksJob = new VerifyLinksJob({ assessment, countryIso, cycle })
+  const [summary, activityLog, jobStatus] = await Promise.all([
+    LinkRepository.getVerificationSummary({ assessment, countryIso, cycle }),
+    ActivityLogRepository.getLastLinksCheckCompleteTime({ assessment, countryIso, cycle }),
+    verifyLinksJob.getStatus(),
+  ])
+
+  const lastJobFinishedAt = jobStatus?.status === JobStatus.success ? jobStatus.finishedAt : undefined
+  const lastActivityLogCompleteTime = activityLog?.lastCompletedAt ?? undefined
+  const lastVisitedAt = summary.lastVisitedAt ? new Date(Number(summary.lastVisitedAt)).toISOString() : undefined
+  const lastExecutedAt = lastJobFinishedAt ?? lastActivityLogCompleteTime ?? lastVisitedAt
+  const neverRan = !lastExecutedAt
+
+  return {
+    invalidCount: summary.invalidCount ?? 0,
+    invalidUnapprovedCount: summary.invalidUnapprovedCount ?? 0,
+    lastExecutedAt,
+    neverRan,
+  }
+}

--- a/src/server/controller/cycleData/links/index.ts
+++ b/src/server/controller/cycleData/links/index.ts
@@ -4,6 +4,7 @@ import { visitCycleLinks } from 'server/worker/tasks/verifyLinks/visitCycleLinks
 import { getActiveVerifyJob } from './getActiveVerifyJob'
 import { getAllLinksToVisit } from './getAllLinksToVisit'
 import { getManyExport } from './getManyExport'
+import { getVerificationSummary } from './getVerificationSummary'
 import { update } from './update'
 
 export const Links = {
@@ -12,6 +13,7 @@ export const Links = {
   getCount: LinkRepository.getCount,
   getMany: LinkRepository.getMany,
   getManyExport,
+  getVerificationSummary,
   update,
   verify: visitCycleLinks,
 }

--- a/src/server/db/repository/assessmentCycle/links/getVerificationSummary.ts
+++ b/src/server/db/repository/assessmentCycle/links/getVerificationSummary.ts
@@ -1,0 +1,46 @@
+import { CountryIso } from 'meta/area/countryIso'
+import { Assessment } from 'meta/assessment/assessment'
+import { Cycle } from 'meta/assessment/cycle'
+import { Objects } from 'utils/objects'
+
+import { BaseProtocol, DB } from 'server/db/db'
+import { Schemas } from 'server/db/schemas'
+
+type Props = {
+  assessment: Assessment
+  countryIso?: CountryIso
+  cycle: Cycle
+}
+
+type Returned = {
+  invalidCount?: number
+  invalidUnapprovedCount?: number
+  lastVisitedAt?: string
+}
+
+export const getVerificationSummary = async (props: Props, client: BaseProtocol = DB): Promise<Returned> => {
+  const { assessment, countryIso, cycle } = props
+  const schemaCycle = Schemas.getNameCycle(assessment, cycle)
+
+  const params = { countryIso }
+  const whereConditions = [
+    `(props->>'deleted')::boolean is distinct from true`,
+    countryIso && `country_iso = $(countryIso)`,
+  ].filter(Boolean)
+
+  return client.one(
+    `
+      select
+        max((visits -> (jsonb_array_length(visits) - 1) ->> 'timestamp')::bigint) as last_visited_at,
+        (count(*) filter (where (visits -> (jsonb_array_length(visits) - 1) ->> 'code') <> 'success'))::int as invalid_count,
+        (count(*) filter (
+          where (visits -> (jsonb_array_length(visits) - 1) ->> 'code') <> 'success'
+            and (props ->> 'approved')::boolean is distinct from true
+        ))::int as invalid_unapproved_count
+      from ${schemaCycle}.link
+      where ${whereConditions.join(' and ')}
+    `,
+    params,
+    (row) => Objects.camelize(row)
+  )
+}

--- a/src/server/db/repository/assessmentCycle/links/index.ts
+++ b/src/server/db/repository/assessmentCycle/links/index.ts
@@ -1,5 +1,6 @@
 import { getCount } from 'server/db/repository/assessmentCycle/links/getCount'
 import { buildGetManyQuery, getMany } from 'server/db/repository/assessmentCycle/links/getMany'
+import { getVerificationSummary } from 'server/db/repository/assessmentCycle/links/getVerificationSummary'
 import { markDeletedMany } from 'server/db/repository/assessmentCycle/links/markDeletedMany'
 import { update } from 'server/db/repository/assessmentCycle/links/update'
 import { upsertMany } from 'server/db/repository/assessmentCycle/links/upsertMany'
@@ -8,6 +9,7 @@ export const LinkRepository = {
   buildGetManyQuery,
   getCount,
   getMany,
+  getVerificationSummary,
   markDeletedMany,
   update,
   upsertMany,

--- a/src/server/db/repository/public/activityLog/getLastLinksCheckCompleteTime.ts
+++ b/src/server/db/repository/public/activityLog/getLastLinksCheckCompleteTime.ts
@@ -1,0 +1,47 @@
+import { CountryIso } from 'meta/area/countryIso'
+import { ActivityLogMessage } from 'meta/assessment/activityLog'
+import { Assessment } from 'meta/assessment/assessment'
+import { Cycle } from 'meta/assessment/cycle'
+import { SectionNames } from 'meta/routes/sectionNames'
+import { Objects } from 'utils/objects'
+
+import { BaseProtocol, DB } from 'server/db/db'
+
+type Props = {
+  assessment: Assessment
+  countryIso?: CountryIso
+  cycle: Cycle
+}
+
+type Returned = { lastCompletedAt: string | null }
+
+export const getLastLinksCheckCompleteTime = async (
+  props: Props,
+  client: BaseProtocol = DB
+): Promise<Returned | null> => {
+  const { assessment, countryIso, cycle } = props
+
+  const whereConditions = [
+    `assessment_uuid = $(assessmentUuid)`,
+    `cycle_uuid = $(cycleUuid)`,
+    `message = $(message)`,
+    `section = $(section)`,
+    countryIso && `country_iso = $(countryIso)`,
+  ].filter(Boolean)
+
+  return client.oneOrNone<Returned | null>(
+    `
+      select max(time) as last_completed_at
+      from public.activity_log
+      where ${whereConditions.join(' and ')}
+    `,
+    {
+      assessmentUuid: assessment.uuid,
+      countryIso,
+      cycleUuid: cycle.uuid,
+      message: ActivityLogMessage.linksCheckComplete,
+      section: SectionNames.Admin.links,
+    },
+    Objects.camelize
+  )
+}

--- a/src/server/db/repository/public/activityLog/index.ts
+++ b/src/server/db/repository/public/activityLog/index.ts
@@ -1,10 +1,12 @@
 import { getCount } from 'server/db/repository/public/activityLog/getCount'
+import { getLastLinksCheckCompleteTime } from 'server/db/repository/public/activityLog/getLastLinksCheckCompleteTime'
 import { getMany } from 'server/db/repository/public/activityLog/getMany'
 import { insertActivityLog } from 'server/db/repository/public/activityLog/insertActivityLog'
 import { massiveInsert } from 'server/db/repository/public/activityLog/massiveInsert'
 
 export const ActivityLogRepository = {
   getCount,
+  getLastLinksCheckCompleteTime,
   getMany,
   insertActivityLog,
   massiveInsert,


### PR DESCRIPTION
Adding `getVerificationSummary` so we can use it to display the last execution date and later to block country status change:
> if jobs has never been executed or there are non approved invalid links, the status cannot change