### PR TITLE
5057 - AreaSelector: Fix styling

### DIFF
--- a/src/client/components/PageLayout/Toolbar/AreaSelect/Group/Group.scss
+++ b/src/client/components/PageLayout/Toolbar/AreaSelect/Group/Group.scss
@@ -10,8 +10,13 @@
   &.isAdmin {
     background-color: white;
     position: sticky;
-    top: $spacing-s; //  csv download
+    top: 0;
   }
+}
+
+// only when the area selector has the csv download button, apply top: 24px to sticky header
+:has(.area-select__country-download) .area-select__group-heading.isAdmin {
+  top: $spacing-s;
 }
 
 button.area-select__show-more {


### PR DESCRIPTION
<img width="833" height="282" alt="Screenshot 2026-02-19 at 9 59 04" src="https://github.com/user-attachments/assets/5c5091f6-714f-4266-9ac6-2a21871b77c4" />

<img width="792" height="760" alt="Screenshot 2026-02-19 at 9 59 22" src="https://github.com/user-attachments/assets/58f8ea37-cfaf-4af9-b535-0fe0803536a9" />
