### PR TITLE
5758 - Navigation: Data errors - Validations ContextFactory

### DIFF
--- a/src/server/controller/cycleData/validations/context/baseContextBuilder.ts
+++ b/src/server/controller/cycleData/validations/context/baseContextBuilder.ts
@@ -1,0 +1,9 @@
+import { ContextBuilderProps } from './contextBuilderProps'
+
+export abstract class BaseContextBuilder {
+  protected readonly props: ContextBuilderProps
+
+  protected constructor(props: ContextBuilderProps) {
+    this.props = props
+  }
+}

--- a/src/server/controller/cycleData/validations/context/context.ts
+++ b/src/server/controller/cycleData/validations/context/context.ts
@@ -1,0 +1,66 @@
+import { CountryIso } from 'meta/area/countryIso'
+import { Assessment, RecordAssessments } from 'meta/assessment/assessment'
+import { Cycle } from 'meta/assessment/cycle'
+import { TableName } from 'meta/assessment/table'
+import { NodeUpdates } from 'meta/data/nodeUpdates'
+import { RecordAssessmentData } from 'meta/data/recordData'
+
+type ConstructorProps = {
+  assessment: Assessment
+  assessments: RecordAssessments
+  countryIso: CountryIso
+  cycle: Cycle
+  data: RecordAssessmentData
+  externalNodeUpdates: Array<NodeUpdates>
+  tableNames: Array<TableName>
+}
+
+export class Context {
+  readonly #assessment: Assessment
+  readonly #assessments: RecordAssessments
+  readonly #countryIso: CountryIso
+  readonly #cycle: Cycle
+  readonly #data: RecordAssessmentData
+  readonly #externalNodeUpdates: Array<NodeUpdates>
+  readonly #tableNames: Array<TableName>
+
+  constructor(props: ConstructorProps) {
+    const { assessment, assessments, countryIso, cycle, data, externalNodeUpdates, tableNames } = props
+
+    this.#assessment = assessment
+    this.#assessments = assessments
+    this.#countryIso = countryIso
+    this.#cycle = cycle
+    this.#data = data
+    this.#externalNodeUpdates = externalNodeUpdates
+    this.#tableNames = tableNames
+  }
+
+  get assessment(): Assessment {
+    return this.#assessment
+  }
+
+  get assessments(): RecordAssessments {
+    return this.#assessments
+  }
+
+  get countryIso(): CountryIso {
+    return this.#countryIso
+  }
+
+  get cycle(): Cycle {
+    return this.#cycle
+  }
+
+  get data(): RecordAssessmentData {
+    return this.#data
+  }
+
+  get externalNodeUpdates(): Array<NodeUpdates> {
+    return this.#externalNodeUpdates
+  }
+
+  get tableNames(): Array<TableName> {
+    return this.#tableNames
+  }
+}

--- a/src/server/controller/cycleData/validations/context/contextBuilderProps.ts
+++ b/src/server/controller/cycleData/validations/context/contextBuilderProps.ts
@@ -1,0 +1,9 @@
+import { CountryIso } from 'meta/area/countryIso'
+import { Assessment } from 'meta/assessment/assessment'
+import { Cycle } from 'meta/assessment/cycle'
+
+export type ContextBuilderProps = {
+  assessment: Assessment
+  countryIso: CountryIso
+  cycle: Cycle
+}

--- a/src/server/controller/cycleData/validations/context/contextFactory.ts
+++ b/src/server/controller/cycleData/validations/context/contextFactory.ts
@@ -1,0 +1,174 @@
+import { VariableCache } from 'meta/assessment/metaCache'
+import { AssessmentMetaCaches } from 'meta/assessment/metaCaches'
+import { TableName } from 'meta/assessment/table'
+import { NodeUpdate, NodeUpdates } from 'meta/data/nodeUpdates'
+import { Promises } from 'utils/promises'
+
+import { BaseContextBuilder } from './baseContextBuilder'
+import { ContextBuilderProps } from './contextBuilderProps'
+
+type Props = Pick<ContextBuilderProps, 'assessment' | 'cycle'> & {
+  nodeUpdates: NodeUpdates
+}
+
+type Returned = {
+  externalNodeUpdates: Array<NodeUpdates>
+  tableNames: Array<TableName>
+}
+
+export class ContextFactory extends BaseContextBuilder {
+  readonly #externalNodeUpdatesByCycle: Map<string, NodeUpdates>
+  readonly #nodeUpdates: NodeUpdates
+  readonly #queue: Array<VariableCache>
+  readonly #tableNames: Set<TableName>
+  readonly #visitedVariables: Set<string>
+
+  private constructor(props: Props) {
+    super({ assessment: props.assessment, countryIso: props.nodeUpdates.countryIso, cycle: props.cycle })
+
+    const { assessmentName, cycleName, nodes } = props.nodeUpdates
+
+    this.#externalNodeUpdatesByCycle = new Map<string, NodeUpdates>()
+    this.#nodeUpdates = props.nodeUpdates
+    this.#queue = nodes.map((node) => ({
+      assessmentName,
+      cycleName,
+      colName: node.colName,
+      tableName: node.tableName,
+      variableName: node.variableName,
+    }))
+    this.#tableNames = new Set<TableName>()
+    this.#visitedVariables = new Set<string>()
+  }
+
+  #getVariableKey(variable: VariableCache): string {
+    const assessmentName = variable.assessmentName ?? this.props.assessment.props.name
+    const cycleName = variable.cycleName ?? this.props.cycle.name
+
+    return [assessmentName, cycleName, variable.tableName, variable.variableName, variable.colName].join(':')
+  }
+
+  #getNodeUpdateKey(node: NodeUpdate, assessmentName: string, cycleName: string): string {
+    return [assessmentName, cycleName, node.tableName, node.variableName, node.colName].join(':')
+  }
+
+  #isCurrentTarget(variable: VariableCache): boolean {
+    const assessmentName = variable.assessmentName ?? this.props.assessment.props.name
+    const cycleName = variable.cycleName ?? this.props.cycle.name
+
+    return assessmentName === this.props.assessment.props.name && cycleName === this.props.cycle.name
+  }
+
+  #isQueued(variable: VariableCache): boolean {
+    const variableKey = this.#getVariableKey(variable)
+
+    return this.#queue.some((queuedVariable) => this.#getVariableKey(queuedVariable) === variableKey)
+  }
+
+  #addToQueue(variable: VariableCache): void {
+    const variableKey = this.#getVariableKey(variable)
+
+    // Skip variables that were already processed or are already scheduled
+    if (!this.#visitedVariables.has(variableKey) && !this.#isQueued(variable)) {
+      this.#queue.push(variable)
+    }
+  }
+
+  async #addTable(tableName: TableName): Promise<void> {
+    if (this.#tableNames.has(tableName)) return
+    this.#tableNames.add(tableName)
+  }
+
+  #addExternalNodeUpdate(variable: VariableCache): void {
+    const assessmentName = variable.assessmentName ?? this.props.assessment.props.name
+    const cycleName = variable.cycleName ?? this.props.cycle.name
+    const key = `${assessmentName}:${cycleName}`
+    const existing = this.#externalNodeUpdatesByCycle.get(key)
+    const externalNode: NodeUpdate = {
+      colName: variable.colName,
+      tableName: variable.tableName,
+      value: { raw: undefined },
+      variableName: variable.variableName,
+    }
+    const externalNodeKey = this.#getNodeUpdateKey(externalNode, assessmentName, cycleName)
+
+    if (!existing) {
+      // External validation dependants are rescheduled through updateDependencies in the target cycle
+      this.#externalNodeUpdatesByCycle.set(key, {
+        assessmentName,
+        countryIso: this.#nodeUpdates.countryIso,
+        cycleName,
+        nodes: [externalNode],
+      })
+
+      return
+    }
+
+    if (!existing.nodes.find((node) => this.#getNodeUpdateKey(node, assessmentName, cycleName) === externalNodeKey)) {
+      existing.nodes.push(externalNode)
+    }
+  }
+
+  async #addDependantsToQueue(variable: VariableCache): Promise<void> {
+    const { assessment, cycle } = this.props
+    const dependants = [
+      ...AssessmentMetaCaches.getCalculationsDependants({
+        assessment,
+        cycle,
+        tableName: variable.tableName,
+        variableName: variable.variableName,
+      }),
+      ...AssessmentMetaCaches.getValidationsDependants({
+        assessment,
+        cycle,
+        tableName: variable.tableName,
+        variableName: variable.variableName,
+      }),
+    ]
+
+    await Promises.each(dependants, async (dependant) => {
+      const candidate: VariableCache = {
+        assessmentName: dependant.assessmentName ?? assessment.props.name,
+        cycleName: dependant.cycleName ?? cycle.name,
+        colName: dependant.colName ?? variable.colName,
+        tableName: dependant.tableName,
+        variableName: dependant.variableName,
+      }
+
+      if (!this.#isCurrentTarget(candidate)) {
+        this.#addExternalNodeUpdate(candidate)
+        return
+      }
+
+      this.#addToQueue(candidate)
+    })
+  }
+
+  async #initQueue(): Promise<void> {
+    // Traverse the dependant graph starting from the changed source nodes
+    await Promises.each(this.#queue, async (variable) => {
+      const variableKey = this.#getVariableKey(variable)
+      if (this.#visitedVariables.has(variableKey)) {
+        return
+      }
+
+      this.#visitedVariables.add(variableKey)
+      await this.#addTable(variable.tableName)
+      await this.#addDependantsToQueue(variable)
+    })
+  }
+
+  #getTargets(): Returned {
+    return {
+      externalNodeUpdates: Array.from(this.#externalNodeUpdatesByCycle.values()),
+      tableNames: Array.from(this.#tableNames),
+    }
+  }
+
+  static async collect(props: Props): Promise<Returned> {
+    const factory = new ContextFactory(props)
+    await factory.#initQueue()
+
+    return factory.#getTargets()
+  }
+}


### PR DESCRIPTION
In a similar fashion as `controller/cycleData/updateDependencies/context/context.ts`, we will have `validations/context/context.ts`, which will produce the affected tables and external node updates through a dependant chain, so we can validate through it.

Later I will add `dataContextBuilder.ts`, which will get the actual table data we can use to validate.