### PR TITLE
5758 - Navigation: Data errors - Add validations DataContextBuilder

### DIFF
--- a/src/server/controller/cycleData/validations/context/contextFactory.ts
+++ b/src/server/controller/cycleData/validations/context/contextFactory.ts
@@ -1,11 +1,15 @@
+import { RecordAssessments } from 'meta/assessment/assessment'
 import { VariableCache } from 'meta/assessment/metaCache'
 import { AssessmentMetaCaches } from 'meta/assessment/metaCaches'
 import { TableName } from 'meta/assessment/table'
 import { NodeUpdate, NodeUpdates } from 'meta/data/nodeUpdates'
+import { RecordAssessmentData } from 'meta/data/recordData'
 import { Promises } from 'utils/promises'
 
 import { BaseContextBuilder } from './baseContextBuilder'
+import { Context } from './context'
 import { ContextBuilderProps } from './contextBuilderProps'
+import { DataContextBuilder } from './dataContextBuilder'
 
 type Props = Pick<ContextBuilderProps, 'assessment' | 'cycle'> & {
   nodeUpdates: NodeUpdates
@@ -17,16 +21,21 @@ type Returned = {
 }
 
 export class ContextFactory extends BaseContextBuilder {
+  readonly #dataContextBuilder?: DataContextBuilder
   readonly #externalNodeUpdatesByCycle: Map<string, NodeUpdates>
   readonly #nodeUpdates: NodeUpdates
   readonly #queue: Array<VariableCache>
   readonly #tableNames: Set<TableName>
   readonly #visitedVariables: Set<string>
 
-  private constructor(props: Props) {
+  private constructor(props: Props, withDataContext: boolean) {
     super({ assessment: props.assessment, countryIso: props.nodeUpdates.countryIso, cycle: props.cycle })
 
     const { assessmentName, cycleName, nodes } = props.nodeUpdates
+
+    if (withDataContext) {
+      this.#dataContextBuilder = new DataContextBuilder(this.props)
+    }
 
     this.#externalNodeUpdatesByCycle = new Map<string, NodeUpdates>()
     this.#nodeUpdates = props.nodeUpdates
@@ -76,7 +85,13 @@ export class ContextFactory extends BaseContextBuilder {
 
   async #addTable(tableName: TableName): Promise<void> {
     if (this.#tableNames.has(tableName)) return
+
+    // Keep track of affected local tables and optionally preload their validation deps
     this.#tableNames.add(tableName)
+
+    if (this.#dataContextBuilder) {
+      await this.#dataContextBuilder.addTable(tableName)
+    }
   }
 
   #addExternalNodeUpdate(variable: VariableCache): void {
@@ -165,10 +180,45 @@ export class ContextFactory extends BaseContextBuilder {
     }
   }
 
+  async #getDataContext(): Promise<{ assessments: RecordAssessments; data: RecordAssessmentData }> {
+    const { assessment } = this.props
+    if (this.#dataContextBuilder) {
+      return this.#dataContextBuilder.getData()
+    }
+
+    return {
+      assessments: { [assessment.props.name]: assessment },
+      data: {} as RecordAssessmentData,
+    }
+  }
+
+  async #createContext(): Promise<Context> {
+    const { assessment, countryIso, cycle } = this.props
+    const { assessments, data } = await this.#getDataContext()
+
+    // collect() only needs targets, while newInstance() also materializes the fetched validation data
+    return new Context({
+      assessment,
+      assessments,
+      countryIso,
+      cycle,
+      data,
+      externalNodeUpdates: Array.from(this.#externalNodeUpdatesByCycle.values()),
+      tableNames: Array.from(this.#tableNames),
+    })
+  }
+
   static async collect(props: Props): Promise<Returned> {
-    const factory = new ContextFactory(props)
+    const factory = new ContextFactory(props, false)
     await factory.#initQueue()
 
     return factory.#getTargets()
+  }
+
+  static async newInstance(props: Props): Promise<Context> {
+    const factory = new ContextFactory(props, true)
+    await factory.#initQueue()
+
+    return factory.#createContext()
   }
 }

--- a/src/server/controller/cycleData/validations/context/dataContextBuilder.ts
+++ b/src/server/controller/cycleData/validations/context/dataContextBuilder.ts
@@ -1,0 +1,133 @@
+import { Assessment, AssessmentName, RecordAssessments } from 'meta/assessment/assessment'
+import { Assessments } from 'meta/assessment/assessments'
+import { Cycle, CycleName } from 'meta/assessment/cycle'
+import { VariableCache } from 'meta/assessment/metaCache'
+import { AssessmentMetaCaches } from 'meta/assessment/metaCaches'
+import { TableName } from 'meta/assessment/table'
+import { RecordAssessmentData } from 'meta/data/recordData'
+import { RecordAssessmentDatas } from 'meta/data/recordDatas'
+import { Objects } from 'utils/objects'
+import { Promises } from 'utils/promises'
+
+import { AssessmentController } from 'server/controller/assessment'
+import { getTableData } from 'server/controller/cycleData/getTableData'
+
+import { BaseContextBuilder } from './baseContextBuilder'
+import { ContextBuilderProps } from './contextBuilderProps'
+
+type Returned = {
+  assessments: RecordAssessments
+  data: RecordAssessmentData
+}
+
+type TablesFetch = {
+  assessment: Assessment
+  cycle: Cycle
+  tableNames: Set<TableName>
+}
+
+export class DataContextBuilder extends BaseContextBuilder {
+  readonly #assessments: RecordAssessments
+  readonly #tables: Record<AssessmentName, Record<CycleName, TablesFetch>>
+
+  constructor(props: ContextBuilderProps) {
+    super(props)
+
+    const { assessment, cycle } = this.props
+
+    // init assessments
+    this.#assessments = { [assessment.props.name]: assessment }
+
+    // init tables to fetch
+    this.#tables = {
+      [assessment.props.name]: {
+        [cycle.name]: {
+          assessment,
+          cycle,
+          tableNames: new Set<TableName>(),
+        },
+      },
+    }
+  }
+
+  async #ensureAssessment(assessmentName: AssessmentName): Promise<Assessment> {
+    if (!this.#assessments[assessmentName]) {
+      this.#assessments[assessmentName] = await AssessmentController.getOne({ assessmentName, metaCache: true })
+    }
+
+    return this.#assessments[assessmentName]
+  }
+
+  async #ensureTablesFetch(assessmentName: AssessmentName, cycleName: CycleName): Promise<TablesFetch> {
+    if (!this.#tables[assessmentName]?.[cycleName]) {
+      // Validation dependencies may point to another assessment/cycle
+      const assessment = await this.#ensureAssessment(assessmentName)
+      const cycle = Assessments.getCycle({ assessment, cycleName })
+
+      Objects.setInPath({
+        obj: this.#tables,
+        path: [assessmentName, cycleName],
+        value: { assessment, cycle, tableNames: new Set<TableName>() },
+      })
+    }
+
+    return this.#tables[assessmentName][cycleName]
+  }
+
+  async #addDependency(props: Pick<VariableCache, 'assessmentName' | 'cycleName' | 'tableName'>): Promise<void> {
+    const assessmentName = props.assessmentName ?? this.props.assessment.props.name
+    const cycleName = props.cycleName ?? this.props.cycle.name
+    const tablesFetch = await this.#ensureTablesFetch(assessmentName, cycleName)
+
+    tablesFetch.tableNames.add(props.tableName)
+  }
+
+  async addTable(tableName: TableName): Promise<void> {
+    // Add the requested table itself before its validation dependencies
+    await this.#addDependency({ tableName })
+
+    const dependencies = AssessmentMetaCaches.getTableValidationsDependencies({
+      assessment: this.props.assessment,
+      cycle: this.props.cycle,
+      tableName,
+    })
+
+    // Validation formulas can read from other local or external tables
+    await Promises.each(Object.values(dependencies).flat(), async (dependency) => {
+      await this.#addDependency(dependency)
+    })
+  }
+
+  async registerRequestedTables(tableNames: Array<TableName>): Promise<void> {
+    await Promises.each(tableNames, async (tableName) => {
+      await this.addTable(tableName)
+    })
+  }
+
+  async getData(): Promise<Returned> {
+    const { countryIso } = this.props
+    let data: RecordAssessmentData = {}
+
+    await Promises.each(Object.values(this.#tables), async (cycles) => {
+      await Promises.each(Object.values(cycles), async (tablesFetch) => {
+        const tableNames = Array.from(tablesFetch.tableNames)
+
+        if (tableNames.length === 0) {
+          return
+        }
+
+        const cycleData = await getTableData({
+          assessment: tablesFetch.assessment,
+          countryISOs: [countryIso],
+          cycle: tablesFetch.cycle,
+          mergeOdp: true,
+          tableNames,
+        })
+
+        data = RecordAssessmentDatas.mergeData({ newTableData: cycleData, tableData: data })
+      })
+    })
+
+    return { assessments: this.#assessments, data }
+  }
+}


### PR DESCRIPTION
Adding `DataContextBuilder`, which can be optionally instantiated from `ContextFactory`.
Now `ContextFactory` supports either getting the tables to validate only, or getting both the tables and the data required to validate them.
The idea is that from `scheduleUpdateDependencies.ts` we only need to know which tables must be validated, so we can invalidate the cache, and no table data is needed there.
From the worker, we will need both the affected tables and the data, so we can run the actual validations.




