### PR TITLE
5767 - Repository: Collapsable folders and split hook

### DIFF
--- a/src/client/pages/CountryHome/Repository/Folder/Folder.scss
+++ b/src/client/pages/CountryHome/Repository/Folder/Folder.scss
@@ -1,0 +1,20 @@
+@use 'src/client/style/partials' as *;
+
+.repository-folder {
+  all: unset;
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  gap: $spacing-xxxs;
+
+  .icon {
+    transform: rotate(-90deg);
+    transition: $ease-out;
+  }
+
+  &.expanded {
+    .icon {
+      transform: unset;
+    }
+  }
+}

--- a/src/client/pages/CountryHome/Repository/Folder/Folder.tsx
+++ b/src/client/pages/CountryHome/Repository/Folder/Folder.tsx
@@ -1,15 +1,23 @@
+import './Folder.scss'
 import React from 'react'
+import classNames from 'classnames'
 
-import { RepositoryItemTree } from 'meta/cycleData/repository/item'
+import Icon from 'client/components/Icon'
 
-type Props = {
-  repositoryItem: RepositoryItemTree
-}
+import { FolderProps } from './props'
 
-const Folder: React.FC<Props> = (props) => {
-  const { repositoryItem } = props
+const Folder: React.FC<FolderProps> = (props) => {
+  const { isCollapsed, onToggle, repositoryItem } = props
 
-  return <div>{repositoryItem.folderName}</div>
+  return (
+    <button
+      className={classNames('repository-folder', { expanded: !isCollapsed })}
+      onClick={() => onToggle(repositoryItem.uuid)}
+    >
+      <Icon name="small-down" />
+      {repositoryItem.folderName}
+    </button>
+  )
 }
 
 export default Folder

--- a/src/client/pages/CountryHome/Repository/Folder/props.ts
+++ b/src/client/pages/CountryHome/Repository/Folder/props.ts
@@ -1,0 +1,7 @@
+import { RepositoryItemTree } from 'meta/cycleData/repository/item'
+
+export type FolderProps = {
+  isCollapsed: boolean
+  onToggle: (uuid: string) => void
+  repositoryItem: RepositoryItemTree
+}

--- a/src/client/pages/CountryHome/Repository/Item/Item.tsx
+++ b/src/client/pages/CountryHome/Repository/Item/Item.tsx
@@ -1,10 +1,8 @@
 import 'client/pages/CountryHome/Repository/Item/Item.scss'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-
 import classNames from 'classnames'
 
-import { RepositoryItem } from 'meta/cycleData/repository/item'
 import { RepositoryItems } from 'meta/cycleData/repository/items'
 
 import { useIsCountryRepositoryEditable, useIsGlobalRepositoryEditable } from 'client/store/user/hooks/auth'
@@ -12,11 +10,9 @@ import Button, { ButtonSize } from 'client/components/Buttons/Button'
 import { useOpenPanel } from 'client/pages/CountryHome/Repository/hooks/useOpenPanel'
 import RepositoryLink from 'client/pages/CountryHome/Repository/RepositoryLink'
 
-type Props = {
-  repositoryItem: RepositoryItem
-}
+import { ItemProps } from './props'
 
-const Item: React.FC<Props> = (props) => {
+const Item: React.FC<ItemProps> = (props) => {
   const { repositoryItem } = props
 
   const { t } = useTranslation()

--- a/src/client/pages/CountryHome/Repository/Item/props.ts
+++ b/src/client/pages/CountryHome/Repository/Item/props.ts
@@ -1,0 +1,5 @@
+import { RepositoryItem } from 'meta/cycleData/repository/item'
+
+export type ItemProps = {
+  repositoryItem: RepositoryItem
+}

--- a/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryList.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryList.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { useItems } from 'client/pages/CountryHome/Repository/RepositoryList/hooks/useItems'
 import RepositoryListItem from 'client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem'
 
+import { useOnToggle } from './hooks/useOnToggle'
 type Props = {
   isGlobal?: boolean
 }
@@ -10,8 +11,11 @@ type Props = {
 const RepositoryList: React.FC<Props> = (props) => {
   const { isGlobal } = props
   const items = useItems(isGlobal)
+  const { collapsed, onToggle } = useOnToggle()
 
-  return items.map((item) => <RepositoryListItem key={item.uuid} item={item} />)
+  return items.map((item) => (
+    <RepositoryListItem key={item.uuid} collapsed={collapsed} item={item} onToggle={onToggle} />
+  ))
 }
 
 export default RepositoryList

--- a/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryList.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryList.tsx
@@ -1,15 +1,19 @@
 import React from 'react'
 
-import { useItems } from 'client/pages/CountryHome/Repository/RepositoryList/hooks/useItems'
 import RepositoryListItem from 'client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem'
 
+import { useGetItems } from './hooks/useGetItems'
+import { useItems } from './hooks/useItems'
 import { useOnToggle } from './hooks/useOnToggle'
+
 type Props = {
   isGlobal?: boolean
 }
 
 const RepositoryList: React.FC<Props> = (props) => {
   const { isGlobal } = props
+
+  useGetItems(isGlobal)
   const items = useItems(isGlobal)
   const { collapsed, onToggle } = useOnToggle()
 

--- a/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/RepositoryListItem.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/RepositoryListItem.tsx
@@ -3,31 +3,43 @@ import React from 'react'
 import { RepositoryItemTree } from 'meta/cycleData/repository/item'
 
 import Folder from 'client/pages/CountryHome/Repository/Folder'
+import type { FolderProps } from 'client/pages/CountryHome/Repository/Folder/props'
 import Item from 'client/pages/CountryHome/Repository/Item'
+import type { ItemProps } from 'client/pages/CountryHome/Repository/Item/props'
 
 type Props = {
+  collapsed: Record<string, boolean>
   depth?: number
   item: RepositoryItemTree
+  onToggle: (uuid: string) => void
 }
 
-const Components = {
+const Components: Record<string, React.FC<FolderProps | ItemProps>> = {
   folder: Folder,
   item: Item,
 }
 
 const RepositoryListItem: React.FC<Props> = (props) => {
-  const { depth = 0, item } = props
+  const { collapsed, depth = 0, item, onToggle } = props
 
   const Component = Components[item.folderName ? 'folder' : 'item']
+  const isCollapsed = collapsed[item.uuid]
 
   return (
     <>
-      <div style={{ paddingLeft: depth * 16 }}>
-        <Component repositoryItem={item} />
+      <div style={{ paddingLeft: depth * 20 }}>
+        <Component isCollapsed={isCollapsed} onToggle={onToggle} repositoryItem={item} />
       </div>
-      {item.children.map((child) => (
-        <RepositoryListItem key={child.uuid} depth={depth + 1} item={child} />
-      ))}
+      {!isCollapsed &&
+        item.children.map((child) => (
+          <RepositoryListItem
+            key={child.uuid}
+            collapsed={collapsed}
+            depth={depth + 1}
+            item={child}
+            onToggle={onToggle}
+          />
+        ))}
     </>
   )
 }

--- a/src/client/pages/CountryHome/Repository/RepositoryList/hooks/useGetItems.ts
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/hooks/useGetItems.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+
+import { ApiEndPoint } from 'meta/api/endpoint'
+
+import { useAppDispatch } from 'client/store/hooks'
+import { TablePaginatedActions } from 'client/store/tablePaginated/actions'
+import { useCountryRouteParams } from 'client/hooks/routeParams'
+
+export const useGetItems = (isGlobal = false): void => {
+  const { assessmentName, countryIso, cycleName } = useCountryRouteParams()
+  const dispatch = useAppDispatch()
+
+  const path = `${ApiEndPoint.CycleData.Repository.tree()}?global=${isGlobal}`
+
+  useEffect((): void => {
+    const limit: number = undefined
+    const page: number = undefined
+    dispatch(TablePaginatedActions.getData({ assessmentName, countryIso, cycleName, limit, page, path }))
+  }, [assessmentName, countryIso, cycleName, dispatch, path])
+}

--- a/src/client/pages/CountryHome/Repository/RepositoryList/hooks/useItems.ts
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/hooks/useItems.ts
@@ -1,28 +1,14 @@
-import { useEffect } from 'react'
-
 import { ApiEndPoint } from 'meta/api/endpoint'
 import { RepositoryItemTree } from 'meta/cycleData/repository/item'
 
-import { useAppDispatch, useInjectSlice } from 'client/store/hooks'
-import { TablePaginatedActions } from 'client/store/tablePaginated/actions'
+import { useInjectSlice } from 'client/store/hooks'
 import { useTablePaginatedData } from 'client/store/tablePaginated/hooks/tablePaginated'
 import { TablePaginatedSlice } from 'client/store/tablePaginated/slice'
-import { useCountryRouteParams } from 'client/hooks/routeParams'
 
 export const useItems = (isGlobal = false): Array<RepositoryItemTree> => {
-  const { assessmentName, countryIso, cycleName } = useCountryRouteParams()
-  const dispatch = useAppDispatch()
   useInjectSlice(TablePaginatedSlice)
 
-  const path = isGlobal
-    ? `${ApiEndPoint.CycleData.Repository.tree()}?global=true`
-    : ApiEndPoint.CycleData.Repository.tree()
-
-  useEffect((): void => {
-    const limit: number = undefined
-    const page: number = undefined
-    dispatch(TablePaginatedActions.getData({ assessmentName, countryIso, cycleName, limit, page, path }))
-  }, [assessmentName, countryIso, cycleName, dispatch, path])
+  const path = `${ApiEndPoint.CycleData.Repository.tree()}?global=${isGlobal}`
 
   return useTablePaginatedData<RepositoryItemTree>({ path }) ?? []
 }

--- a/src/client/pages/CountryHome/Repository/RepositoryList/hooks/useOnToggle.ts
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/hooks/useOnToggle.ts
@@ -1,0 +1,14 @@
+import { useState } from 'react'
+
+type Returned = {
+  collapsed: Record<string, boolean>
+  onToggle: (uuid: string) => void
+}
+
+export const useOnToggle = (): Returned => {
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
+
+  const onToggle = (uuid: string): void => setCollapsed((prev) => ({ ...prev, [uuid]: !prev[uuid] }))
+
+  return { collapsed, onToggle }
+}


### PR DESCRIPTION

https://github.com/user-attachments/assets/31945518-6101-4658-995a-2bffccd05c39

Current PR Scope:
- Functionality to collapse/expand folders (and remember sub folder state)
- Split hook

Next: created_at timestamp (and description?) (No migration (later))

Note: UI Clean up coming later