### PR TITLE
5799 - Pan-European - Hide 2.5 indicator in data export

### DIFF
--- a/src/tools/migrations/steps/steps/20260327150039-step-paneuropean-hide-2-5-from-data-export.ts
+++ b/src/tools/migrations/steps/steps/20260327150039-step-paneuropean-hide-2-5-from-data-export.ts
@@ -1,0 +1,37 @@
+import { AssessmentNames } from 'meta/assessment/assessment'
+import { CycleNames } from 'meta/assessment/cycle/names'
+import { Promises } from 'utils/promises'
+
+import { SectionRedisRepository } from 'server/cache/repository/section'
+import { AssessmentController } from 'server/controller/assessment'
+import { BaseProtocol } from 'server/db/db'
+import { SectionRepository } from 'server/db/repository/assessment/section'
+
+const assessmentName = AssessmentNames.panEuropean
+const cycleName = CycleNames._2025
+const sectionName = 'areaWithForestLandDegradation'
+
+export default async (client: BaseProtocol): Promise<void> => {
+  const { assessment, cycle } = await AssessmentController.getOneWithCycle({ assessmentName, cycleName }, client)
+  const subSection = await SectionRedisRepository.getSubSection({ assessment, cycle, sectionName })
+
+  await SectionRepository.updateSubSection(
+    {
+      assessment,
+      section: {
+        ...subSection,
+        props: {
+          ...subSection.props,
+          dataExport: false,
+        },
+      },
+    },
+    client
+  )
+
+  // dataExport is shared across cycles
+  await Promises.each(assessment.cycles, async (currentCycle) => {
+    await SectionRedisRepository.getMany({ assessment, cycle: currentCycle, force: true }, client)
+    await SectionRedisRepository.getManyMetadata({ assessment, cycle: currentCycle, force: true }, client)
+  })
+}


### PR DESCRIPTION
<img width="538" height="495" alt="image" src="https://github.com/user-attachments/assets/3af5aa9c-007d-4589-8e14-7919f3ebcf05" />

non-data export nav unchanged:
<img width="363" height="512" alt="image" src="https://github.com/user-attachments/assets/fbb4c4a0-7acd-447c-be36-dbcf1c6f707f" />
