### PR TITLE
5767 - Repository: Filter by linked, unlinked public and private

### DIFF
--- a/src/client/pages/CountryHome/Repository/RepositoryList/Filters/Filters.scss
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/Filters/Filters.scss
@@ -18,9 +18,5 @@
   .filter-multiselect__tooltip-trigger,
   .table-paginated-filter-input {
     height: 30px;
-
-    div.select__control {
-      min-height: 30px;
-    }
   }
 }

--- a/src/client/pages/CountryHome/Repository/RepositoryList/Filters/Filters.scss
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/Filters/Filters.scss
@@ -15,7 +15,12 @@
     width: 1px;
   }
 
+  .filter-multiselect__tooltip-trigger,
   .table-paginated-filter-input {
     height: 30px;
+
+    div.select__control {
+      min-height: 30px;
+    }
   }
 }

--- a/src/client/pages/CountryHome/Repository/RepositoryList/Filters/Filters.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/Filters/Filters.tsx
@@ -7,6 +7,7 @@ import { TablePaginatedFilterType } from 'meta/tablePaginated/filters/filter'
 
 import Hr from 'client/components/Hr'
 import Icon from 'client/components/Icon'
+import Switch from 'client/components/TablePaginated/Filters/Switch'
 import Text from 'client/components/TablePaginated/Filters/Text'
 import ButtonAdd from 'client/pages/CountryHome/Repository/ButtonAdd'
 import ButtonDownloadAll from 'client/pages/CountryHome/Repository/ButtonDownloadAll'
@@ -29,9 +30,10 @@ const Filters: React.FC<Props> = (props) => {
       <Hr vertical />
       <Icon name="filter" />
       <Text fieldName="name" label={t('common.name')} path={path} type={TablePaginatedFilterType.TEXT} />
-      {/* TODO: Add ADDED */}
-      {/* TODO: Add LINKED */}
-      {/* TODO: Add ACCESS */}
+      <Switch fieldName="linked" label={t('common.linked')} path={path} type={TablePaginatedFilterType.SWITCH} />
+      <Switch fieldName="unlinked" label={t('common.unlinked')} path={path} type={TablePaginatedFilterType.SWITCH} />
+      <Switch fieldName="public" label={t('common.public')} path={path} type={TablePaginatedFilterType.SWITCH} />
+      <Switch fieldName="private" label={t('common.private')} path={path} type={TablePaginatedFilterType.SWITCH} />
     </div>
   )
 }

--- a/src/client/pages/CountryHome/Repository/RepositoryList/Filters/Filters.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/Filters/Filters.tsx
@@ -7,7 +7,7 @@ import { TablePaginatedFilterType } from 'meta/tablePaginated/filters/filter'
 
 import Hr from 'client/components/Hr'
 import Icon from 'client/components/Icon'
-import Switch from 'client/components/TablePaginated/Filters/Switch'
+import MultiSelect from 'client/components/TablePaginated/Filters/MultiSelect'
 import Text from 'client/components/TablePaginated/Filters/Text'
 import ButtonAdd from 'client/pages/CountryHome/Repository/ButtonAdd'
 import ButtonDownloadAll from 'client/pages/CountryHome/Repository/ButtonDownloadAll'
@@ -30,10 +30,28 @@ const Filters: React.FC<Props> = (props) => {
       <Hr vertical />
       <Icon name="filter" />
       <Text fieldName="name" label={t('common.name')} path={path} type={TablePaginatedFilterType.TEXT} />
-      <Switch fieldName="linked" label={t('common.linked')} path={path} type={TablePaginatedFilterType.SWITCH} />
-      <Switch fieldName="unlinked" label={t('common.unlinked')} path={path} type={TablePaginatedFilterType.SWITCH} />
-      <Switch fieldName="public" label={t('common.public')} path={path} type={TablePaginatedFilterType.SWITCH} />
-      <Switch fieldName="private" label={t('common.private')} path={path} type={TablePaginatedFilterType.SWITCH} />
+      <MultiSelect
+        fieldName="linked"
+        label={t('common.linked')}
+        multiLabelSummaryKey="common.linked"
+        options={[
+          { label: t('common.linked'), value: 'linked' },
+          { label: t('common.unlinked'), value: 'unlinked' },
+        ]}
+        path={path}
+        type={TablePaginatedFilterType.MULTI_SELECT}
+      />
+      <MultiSelect
+        fieldName="access"
+        label={t('common.access')}
+        multiLabelSummaryKey="common.access"
+        options={[
+          { label: t('common.public'), value: 'public' },
+          { label: t('common.private'), value: 'private' },
+        ]}
+        path={path}
+        type={TablePaginatedFilterType.MULTI_SELECT}
+      />
     </div>
   )
 }

--- a/src/client/pages/CountryHome/Repository/RepositoryList/hooks/_useFilterFn.ts
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/hooks/_useFilterFn.ts
@@ -9,6 +9,20 @@ import { useLanguage } from 'client/hooks/language'
 
 import { _getNameTranslation, ItemsFn } from './_utils'
 
+const _filterByPredicate = (
+  items: Array<RepositoryItemTree>,
+  predicate: (item: RepositoryItemTree) => boolean
+): Array<RepositoryItemTree> =>
+  items.reduce<Array<RepositoryItemTree>>((acc, item) => {
+    if (!item.folderName) {
+      if (predicate(item)) acc.push(item)
+      return acc
+    }
+    const filteredChildren = _filterByPredicate(item.children, predicate)
+    if (!Objects.isEmpty(filteredChildren)) acc.push({ ...item, children: filteredChildren })
+    return acc
+  }, [])
+
 const _filterByName = (items: Array<RepositoryItemTree>, filter: string, language: Lang): Array<RepositoryItemTree> => {
   const lower = filter.toLowerCase()
   return items.reduce<Array<RepositoryItemTree>>((acc, item) => {
@@ -26,13 +40,21 @@ const _filterByName = (items: Array<RepositoryItemTree>, filter: string, languag
 }
 
 export const useFilterFn = (path: string): ItemsFn => {
+  const linkedFilter = useTablePaginatedFilterValue<boolean>(path, 'linked')
   const nameFilter = useTablePaginatedFilterValue<string>(path, 'name')
+  const privateFilter = useTablePaginatedFilterValue<boolean>(path, 'private')
+  const publicFilter = useTablePaginatedFilterValue<boolean>(path, 'public')
+  const unlinkedFilter = useTablePaginatedFilterValue<boolean>(path, 'unlinked')
   const language = useLanguage()
 
   return useMemo(() => {
     const fns: Array<ItemsFn> = []
     if (nameFilter) fns.push((items) => _filterByName(items, nameFilter, language))
+    if (linkedFilter) fns.push((items) => _filterByPredicate(items, (item) => !!item.linked))
+    if (unlinkedFilter) fns.push((items) => _filterByPredicate(items, (item) => !item.linked))
+    if (publicFilter) fns.push((items) => _filterByPredicate(items, (item) => !!item.props?.public))
+    if (privateFilter) fns.push((items) => _filterByPredicate(items, (item) => !item.props?.public))
     if (Objects.isEmpty(fns)) return (items) => items
     return (items) => fns.reduce<Array<RepositoryItemTree>>((acc, fn) => fn(acc), items)
-  }, [language, nameFilter])
+  }, [language, linkedFilter, nameFilter, privateFilter, publicFilter, unlinkedFilter])
 }

--- a/src/client/pages/CountryHome/Repository/RepositoryList/hooks/_useFilterFn.ts
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/hooks/_useFilterFn.ts
@@ -23,6 +23,19 @@ const _filterByPredicate = (
     return acc
   }, [])
 
+// Select filter for boolean values:
+// - If one value is selected: enable filter
+// - If (0,2) values are selected: dont filter
+const _getFilterBoolSelect = (
+  filter: Array<string> | undefined,
+  positiveValue: string,
+  getValue: (item: RepositoryItemTree) => boolean
+): ItemsFn | null => {
+  if (filter?.length !== 1) return null
+  const expected = filter[0] === positiveValue
+  return (items) => _filterByPredicate(items, (item) => getValue(item) === expected)
+}
+
 const _filterByName = (items: Array<RepositoryItemTree>, filter: string, language: Lang): Array<RepositoryItemTree> => {
   const lower = filter.toLowerCase()
   return items.reduce<Array<RepositoryItemTree>>((acc, item) => {
@@ -40,21 +53,19 @@ const _filterByName = (items: Array<RepositoryItemTree>, filter: string, languag
 }
 
 export const useFilterFn = (path: string): ItemsFn => {
-  const linkedFilter = useTablePaginatedFilterValue<boolean>(path, 'linked')
+  const accessFilter = useTablePaginatedFilterValue<Array<string>>(path, 'access')
+  const linkedFilter = useTablePaginatedFilterValue<Array<string>>(path, 'linked')
   const nameFilter = useTablePaginatedFilterValue<string>(path, 'name')
-  const privateFilter = useTablePaginatedFilterValue<boolean>(path, 'private')
-  const publicFilter = useTablePaginatedFilterValue<boolean>(path, 'public')
-  const unlinkedFilter = useTablePaginatedFilterValue<boolean>(path, 'unlinked')
   const language = useLanguage()
 
   return useMemo(() => {
     const fns: Array<ItemsFn> = []
     if (nameFilter) fns.push((items) => _filterByName(items, nameFilter, language))
-    if (linkedFilter) fns.push((items) => _filterByPredicate(items, (item) => !!item.linked))
-    if (unlinkedFilter) fns.push((items) => _filterByPredicate(items, (item) => !item.linked))
-    if (publicFilter) fns.push((items) => _filterByPredicate(items, (item) => !!item.props?.public))
-    if (privateFilter) fns.push((items) => _filterByPredicate(items, (item) => !item.props?.public))
+    const linkedFn = _getFilterBoolSelect(linkedFilter, 'linked', (item) => !!item.linked)
+    const accessFn = _getFilterBoolSelect(accessFilter, 'public', (item) => !!item.props?.public)
+    if (linkedFn) fns.push(linkedFn)
+    if (accessFn) fns.push(accessFn)
     if (Objects.isEmpty(fns)) return (items) => items
     return (items) => fns.reduce<Array<RepositoryItemTree>>((acc, fn) => fn(acc), items)
-  }, [language, linkedFilter, nameFilter, privateFilter, publicFilter, unlinkedFilter])
+  }, [accessFilter, language, linkedFilter, nameFilter])
 }

--- a/src/meta/assessment/assessments/index.ts
+++ b/src/meta/assessment/assessments/index.ts
@@ -1,9 +1,14 @@
-import { Dates } from 'utils/dates'
-
-import { Assessment, AssessmentName, RecordAssessments } from 'meta/assessment/assessment'
+import { Assessment, AssessmentName, AssessmentNames, RecordAssessments } from 'meta/assessment/assessment'
 import { Cycle, CycleName } from 'meta/assessment/cycle'
 import { Cycles } from 'meta/assessment/cycles'
 import { UUID } from 'meta/uuid/uuid'
+import { Dates } from 'utils/dates'
+
+/**
+ * Returns true if the given assessment has the ODP-feature layer
+ * @param assessment - Assessment
+ */
+const hasODPFeature = (assessment: Assessment): boolean => assessment.props.name === AssessmentNames.fra
 
 const getShortLabel = (assessmentName: AssessmentName): string => `${assessmentName}.labels.short`
 
@@ -74,4 +79,5 @@ export const Assessments = {
   getLastPublishedCycle,
   getRecordAssessments,
   getShortLabel,
+  hasODPFeature,
 }

--- a/src/server/db/repository/assessmentCycle/repository/getManyTree.ts
+++ b/src/server/db/repository/assessmentCycle/repository/getManyTree.ts
@@ -1,5 +1,6 @@
 import { AreaCode } from 'meta/area/areaCode'
 import { Assessment } from 'meta/assessment/assessment'
+import { Assessments } from 'meta/assessment/assessments'
 import { Cycle } from 'meta/assessment/cycle'
 import { RepositoryItemTree } from 'meta/cycleData/repository/item'
 import { Objects } from 'utils/objects'
@@ -20,6 +21,7 @@ export const getManyTree = async (props: Props, client: BaseProtocol = DB): Prom
 
   const condition = global ? 'country_iso is null' : 'country_iso = $1'
 
+  const hasODPFeature = Assessments.hasODPFeature(assessment)
   const linkedInOdp = (ref: string): string =>
     `exists(select 1 from ${schemaCycle}.original_data_point odp where odp.country_iso = tree.country_iso and odp.data_source_references ilike '%' || ${ref} || '%')`
   const linkedInDescriptions = (ref: string): string =>
@@ -47,10 +49,9 @@ export const getManyTree = async (props: Props, client: BaseProtocol = DB): Prom
         tree.*,
         -- For items (not folders): populate "linked"
         case when tree.folder_name is null then (
-             ${linkedInOdp('tree.uuid::text')}
-          or ${linkedInDescriptions('tree.uuid::text')}
+             ${linkedInDescriptions('tree.uuid::text')}
           or (tree.link is not null and ${linkedInDescriptions('tree.link')})
-          or (tree.link is not null and ${linkedInOdp('tree.link')})
+          ${hasODPFeature ? `or ${linkedInOdp('tree.uuid::text')} or (tree.link is not null and ${linkedInOdp('tree.link')})` : ''}
         ) end as linked
       from tree
       order by folder_name nulls last


### PR DESCRIPTION
<img width="2127" height="245" alt="image" src="https://github.com/user-attachments/assets/223d3b0d-826a-4c93-bb05-d222618ee009" />

Scope of current PR:
- Fix panEuropean repository (odp)
- implement all column filters (expect date created)

Next PR:
- Filter by file type