### PR TITLE
5767 - Repository: Folder navigation with breadcrumbs

### DIFF
--- a/src/client/pages/CountryHome/Repository/ButtonAdd/ButtonAdd.tsx
+++ b/src/client/pages/CountryHome/Repository/ButtonAdd/ButtonAdd.tsx
@@ -10,14 +10,15 @@ import { useOpenPanel } from 'client/pages/CountryHome/Repository/hooks/useOpenP
 
 type Props = {
   isGlobal?: boolean
+  parentUuid?: string
 }
 
 const ButtonAdd: React.FC<Props> = (props: Props) => {
-  const { isGlobal } = props
+  const { isGlobal, parentUuid } = props
   const { countryIso } = useCountryRouteParams<CountryIso>()
   const { t } = useTranslation()
 
-  const openPanel = useOpenPanel({ countryIso: isGlobal ? undefined : countryIso })
+  const openPanel = useOpenPanel({ countryIso: isGlobal ? undefined : countryIso, parentUuid })
 
   const isGlobalRepositoryEditable = useIsGlobalRepositoryEditable()
   const isCountryRepositoryEditable = useIsCountryRepositoryEditable()

--- a/src/client/pages/CountryHome/Repository/RepositoryList/Breadcrumb/Breadcrumb.scss
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/Breadcrumb/Breadcrumb.scss
@@ -1,0 +1,21 @@
+@use 'src/client/style/partials' as *;
+
+.repository-list__breadcrumb {
+  align-items: center;
+  color: $text-mute;
+  display: flex;
+  font-size: $font-xs;
+  gap: $spacing-xxxs;
+  grid-column: 1 / -1;
+  padding: $spacing-xxxs $spacing-xxs;
+
+  button {
+    all: unset;
+    color: $ui-accent;
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/src/client/pages/CountryHome/Repository/RepositoryList/Breadcrumb/Breadcrumb.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/Breadcrumb/Breadcrumb.tsx
@@ -10,7 +10,7 @@ const Breadcrumb: React.FC = () => {
 
   return (
     <div className="repository-list__breadcrumb">
-      <button onClick={() => onNavigate(null)}>{t('landing.home')}</button>
+      <button onClick={() => onNavigate()}>{t('landing.home')}</button>
       {folderPath.map((folder) => (
         <React.Fragment key={folder.uuid}>
           {' / '}

--- a/src/client/pages/CountryHome/Repository/RepositoryList/Breadcrumb/Breadcrumb.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,30 @@
+import './Breadcrumb.scss'
+import React from 'react'
+
+import { RepositoryItemTree } from 'meta/cycleData/repository/item'
+import { Objects } from 'utils/objects'
+
+type Props = {
+  folderPath: Array<RepositoryItemTree>
+  onNavigate: (index: number) => void
+}
+
+const Breadcrumb: React.FC<Props> = (props) => {
+  const { folderPath, onNavigate } = props
+
+  if (Objects.isEmpty(folderPath)) return null
+
+  return (
+    <div className="repository-list__breadcrumb">
+      <button onClick={() => onNavigate(-1)}>…</button>
+      {folderPath.map((folder, i) => (
+        <React.Fragment key={folder.uuid}>
+          {' / '}
+          <button onClick={() => onNavigate(i)}>{folder.folderName}</button>
+        </React.Fragment>
+      ))}
+    </div>
+  )
+}
+
+export default Breadcrumb

--- a/src/client/pages/CountryHome/Repository/RepositoryList/Breadcrumb/Breadcrumb.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/Breadcrumb/Breadcrumb.tsx
@@ -1,26 +1,20 @@
 import './Breadcrumb.scss'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
-import { RepositoryItemTree } from 'meta/cycleData/repository/item'
-import { Objects } from 'utils/objects'
+import { useRepositoryListContext } from '../context'
 
-type Props = {
-  folderPath: Array<RepositoryItemTree>
-  onNavigate: (index: number) => void
-}
-
-const Breadcrumb: React.FC<Props> = (props) => {
-  const { folderPath, onNavigate } = props
-
-  if (Objects.isEmpty(folderPath)) return null
+const Breadcrumb: React.FC = () => {
+  const { folderPath, onNavigate } = useRepositoryListContext()
+  const { t } = useTranslation()
 
   return (
     <div className="repository-list__breadcrumb">
-      <button onClick={() => onNavigate(-1)}>…</button>
-      {folderPath.map((folder, i) => (
+      <button onClick={() => onNavigate(null)}>{t('landing.home')}</button>
+      {folderPath.map((folder) => (
         <React.Fragment key={folder.uuid}>
           {' / '}
-          <button onClick={() => onNavigate(i)}>{folder.folderName}</button>
+          <button onClick={() => onNavigate(folder.uuid)}>{folder.folderName}</button>
         </React.Fragment>
       ))}
     </div>

--- a/src/client/pages/CountryHome/Repository/RepositoryList/Breadcrumb/index.ts
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/Breadcrumb/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Breadcrumb'

--- a/src/client/pages/CountryHome/Repository/RepositoryList/Filters/Filters.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/Filters/Filters.tsx
@@ -14,10 +14,11 @@ import ButtonDownloadAll from 'client/pages/CountryHome/Repository/ButtonDownloa
 
 type Props = {
   isGlobal?: boolean
+  parentUuid?: string
 }
 
 const Filters: React.FC<Props> = (props) => {
-  const { isGlobal = false } = props
+  const { isGlobal = false, parentUuid } = props
   const { t } = useTranslation()
   const path = `${ApiEndPoint.CycleData.Repository.tree()}?global=${isGlobal}`
 
@@ -26,7 +27,7 @@ const Filters: React.FC<Props> = (props) => {
       <ButtonDownloadAll isGlobal={isGlobal} />
       {/* TODO: Add Button ADD FILE */}
       {/* TODO: Add Button ADD FOLDER */}
-      <ButtonAdd isGlobal={isGlobal} />
+      <ButtonAdd isGlobal={isGlobal} parentUuid={parentUuid} />
       <Hr vertical />
       <Icon name="filter" />
       <Text fieldName="name" label={t('common.name')} path={path} type={TablePaginatedFilterType.TEXT} />

--- a/src/client/pages/CountryHome/Repository/RepositoryList/Filters/Filters.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/Filters/Filters.tsx
@@ -12,14 +12,16 @@ import Text from 'client/components/TablePaginated/Filters/Text'
 import ButtonAdd from 'client/pages/CountryHome/Repository/ButtonAdd'
 import ButtonDownloadAll from 'client/pages/CountryHome/Repository/ButtonDownloadAll'
 
+import { useRepositoryListContext } from '../context'
+
 type Props = {
   isGlobal?: boolean
-  parentUuid?: string
 }
 
 const Filters: React.FC<Props> = (props) => {
-  const { isGlobal = false, parentUuid } = props
+  const { isGlobal = false } = props
   const { t } = useTranslation()
+  const { parentUuid } = useRepositoryListContext()
   const path = `${ApiEndPoint.CycleData.Repository.tree()}?global=${isGlobal}`
 
   return (

--- a/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryList.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryList.tsx
@@ -23,6 +23,7 @@ const RepositoryList: React.FC<Props> = (props) => {
   return (
     <div className="repository-list">
       <Filters isGlobal={isGlobal} />
+      <Filters isGlobal={isGlobal} parentUuid={parentUuid} />
       <Toolbar isGlobal={isGlobal} />
       {items.map((item) => (
         <RepositoryListItem key={item.uuid} collapsed={collapsed} item={item} onToggle={onToggle} />

--- a/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryList.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryList.tsx
@@ -3,9 +3,12 @@ import React from 'react'
 
 import RepositoryListItem from 'client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem'
 
+import { useFolderNavigation } from './hooks/useFolderNavigation'
 import { useGetItems } from './hooks/useGetItems'
 import { useItems } from './hooks/useItems'
 import { useOnToggle } from './hooks/useOnToggle'
+import Breadcrumb from './Breadcrumb'
+import { RepositoryListContext } from './context'
 import Filters from './Filters'
 import Toolbar from './Toolbar'
 
@@ -19,16 +22,19 @@ const RepositoryList: React.FC<Props> = (props) => {
   useGetItems(isGlobal)
   const items = useItems(isGlobal)
   const { collapsed, onToggle } = useOnToggle()
+  const { contextValue, visibleItems } = useFolderNavigation({ collapsed, items, onToggle })
 
   return (
-    <div className="repository-list">
-      <Filters isGlobal={isGlobal} />
-      <Filters isGlobal={isGlobal} parentUuid={parentUuid} />
-      <Toolbar isGlobal={isGlobal} />
-      {items.map((item) => (
-        <RepositoryListItem key={item.uuid} collapsed={collapsed} item={item} onToggle={onToggle} />
-      ))}
-    </div>
+    <RepositoryListContext.Provider value={contextValue}>
+      <div className="repository-list">
+        <Filters isGlobal={isGlobal} />
+        <Breadcrumb />
+        <Toolbar isGlobal={isGlobal} />
+        {visibleItems.map((item) => (
+          <RepositoryListItem key={item.uuid} item={item} />
+        ))}
+      </div>
+    </RepositoryListContext.Provider>
   )
 }
 

--- a/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/Folder/Folder.scss
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/Folder/Folder.scss
@@ -1,11 +1,17 @@
 @use 'src/client/style/partials' as *;
 
 .repository-folder {
-  all: unset;
   align-items: center;
-  cursor: pointer;
   display: flex;
   gap: $spacing-xxxs;
+
+  button {
+    all: unset;
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    gap: $spacing-xxxs;
+  }
 
   .icon_small-down {
     transform: rotate(-90deg);

--- a/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/Folder/Folder.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/Folder/Folder.tsx
@@ -4,20 +4,23 @@ import classNames from 'classnames'
 
 import Icon from 'client/components/Icon'
 
+import { useRepositoryListContext } from '../../context'
 import { FolderProps } from './props'
 
 const Folder: React.FC<FolderProps> = (props) => {
-  const { isCollapsed, onToggle, repositoryItem } = props
+  const { isCollapsed, repositoryItem } = props
+  const { onNavigate, onToggle } = useRepositoryListContext()
 
   return (
-    <button
-      className={classNames('repository-folder', { expanded: !isCollapsed })}
-      onClick={() => onToggle(repositoryItem.uuid)}
-    >
-      <Icon name="small-down" />
-      <Icon name="icon-folder" />
-      {repositoryItem.folderName}
-    </button>
+    <div className={classNames('repository-folder', { expanded: !isCollapsed })}>
+      <button onClick={() => onToggle(repositoryItem.uuid)}>
+        <Icon name="small-down" />
+      </button>
+      <button onClick={() => onNavigate(repositoryItem.uuid)}>
+        <Icon name="icon-folder" />
+        {repositoryItem.folderName}
+      </button>
+    </div>
   )
 }
 

--- a/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/Folder/props.ts
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/Folder/props.ts
@@ -2,6 +2,5 @@ import { RepositoryItemTree } from 'meta/cycleData/repository/item'
 
 export type FolderProps = {
   isCollapsed: boolean
-  onToggle: (uuid: string) => void
   repositoryItem: RepositoryItemTree
 }

--- a/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/FolderRow/FolderRow.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/FolderRow/FolderRow.tsx
@@ -9,15 +9,14 @@ export type Props = {
   depth: number
   isCollapsed: boolean
   item: RepositoryItemTree
-  onToggle: (uuid: string) => void
 }
 
 const FolderRow: React.FC<Props> = (props) => {
-  const { depth, isCollapsed, item, onToggle } = props
+  const { depth, isCollapsed, item } = props
 
   return (
     <div className="repository-list-item repository-list-item--folder" style={{ paddingLeft: depth * 20 }}>
-      <Folder isCollapsed={isCollapsed} onToggle={onToggle} repositoryItem={item} />
+      <Folder isCollapsed={isCollapsed} repositoryItem={item} />
     </div>
   )
 }

--- a/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/RepositoryListItem.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/RepositoryListItem.tsx
@@ -3,15 +3,14 @@ import React from 'react'
 
 import { RepositoryItemTree } from 'meta/cycleData/repository/item'
 
+import { useRepositoryListContext } from '../context'
 import type { Props as FolderRowProps } from './FolderRow/FolderRow'
 import FolderRow from './FolderRow'
 import ItemRow from './ItemRow'
 
 type Props = {
-  collapsed: Record<string, boolean>
   depth?: number
   item: RepositoryItemTree
-  onToggle: (uuid: string) => void
 }
 
 const Components: Record<string, React.FC<FolderRowProps>> = {
@@ -20,24 +19,17 @@ const Components: Record<string, React.FC<FolderRowProps>> = {
 }
 
 const RepositoryListItem: React.FC<Props> = (props) => {
-  const { collapsed, depth = 0, item, onToggle } = props
+  const { depth = 0, item } = props
+  const { collapsed } = useRepositoryListContext()
 
   const isCollapsed = collapsed[item.uuid]
   const Component = Components[item.folderName ? 'folder' : 'item']
 
   return (
     <>
-      <Component depth={depth} isCollapsed={isCollapsed} item={item} onToggle={onToggle} />
+      <Component depth={depth} isCollapsed={isCollapsed} item={item} />
       {!isCollapsed &&
-        item.children.map((child) => (
-          <RepositoryListItem
-            key={child.uuid}
-            collapsed={collapsed}
-            depth={depth + 1}
-            item={child}
-            onToggle={onToggle}
-          />
-        ))}
+        item.children.map((child) => <RepositoryListItem key={child.uuid} depth={depth + 1} item={child} />)}
     </>
   )
 }

--- a/src/client/pages/CountryHome/Repository/RepositoryList/context.ts
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/context.ts
@@ -5,7 +5,7 @@ import { RepositoryItemTree } from 'meta/cycleData/repository/item'
 export type RepositoryListContextValue = {
   collapsed: Record<string, boolean>
   folderPath: Array<RepositoryItemTree>
-  onNavigate: (uuid: string | null) => void
+  onNavigate: (uuid?: string) => void
   onToggle: (uuid: string) => void
   parentUuid: string | undefined
 }

--- a/src/client/pages/CountryHome/Repository/RepositoryList/context.ts
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/context.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react'
+
+import { RepositoryItemTree } from 'meta/cycleData/repository/item'
+
+export type RepositoryListContextValue = {
+  collapsed: Record<string, boolean>
+  folderPath: Array<RepositoryItemTree>
+  onNavigate: (uuid: string | null) => void
+  onToggle: (uuid: string) => void
+  parentUuid: string | undefined
+}
+
+export const RepositoryListContext = createContext<RepositoryListContextValue | undefined>(undefined)
+
+export const useRepositoryListContext = (): RepositoryListContextValue =>
+  useContext<RepositoryListContextValue>(RepositoryListContext)

--- a/src/client/pages/CountryHome/Repository/RepositoryList/hooks/getFolderPath.ts
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/hooks/getFolderPath.ts
@@ -12,7 +12,7 @@ export type FolderPath = {
  * @param uuid - target folder UUID
  * @returns path to the folder and the folder itself as currentFolder
  */
-export const getFolderPath = (items: Array<RepositoryItemTree>, uuid: string | null): FolderPath => {
+export const getFolderPath = (items: Array<RepositoryItemTree>, uuid: string | undefined): FolderPath => {
   if (!uuid) return { currentFolder: undefined, folderPath: [] }
 
   const folderPath = items.reduce<Array<RepositoryItemTree>>((found, item) => {

--- a/src/client/pages/CountryHome/Repository/RepositoryList/hooks/getFolderPath.ts
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/hooks/getFolderPath.ts
@@ -1,0 +1,26 @@
+import { RepositoryItemTree } from 'meta/cycleData/repository/item'
+import { Objects } from 'utils/objects'
+
+export type FolderPath = {
+  currentFolder: RepositoryItemTree | undefined
+  folderPath: Array<RepositoryItemTree>
+}
+
+/**
+ * Construct the full path to the folder for the given UUID
+ * @param items - items to search
+ * @param uuid - target folder UUID
+ * @returns path to the folder and the folder itself as currentFolder
+ */
+export const getFolderPath = (items: Array<RepositoryItemTree>, uuid: string | null): FolderPath => {
+  if (!uuid) return { currentFolder: undefined, folderPath: [] }
+
+  const folderPath = items.reduce<Array<RepositoryItemTree>>((found, item) => {
+    if (!Objects.isEmpty(found)) return found
+    if (item.uuid === uuid) return [item]
+    const childPath = getFolderPath(item.children, uuid).folderPath
+    return Objects.isEmpty(childPath) ? [] : [item, ...childPath]
+  }, [])
+
+  return { currentFolder: folderPath.at(-1), folderPath }
+}

--- a/src/client/pages/CountryHome/Repository/RepositoryList/hooks/useFolderNavigation.ts
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/hooks/useFolderNavigation.ts
@@ -1,0 +1,40 @@
+import { useCallback, useMemo, useState } from 'react'
+
+import { RepositoryItemTree } from 'meta/cycleData/repository/item'
+
+import { RepositoryListContextValue } from '../context'
+import { getFolderPath } from './getFolderPath'
+
+type Props = {
+  collapsed: Record<string, boolean>
+  items: Array<RepositoryItemTree>
+  onToggle: (uuid: string) => void
+}
+
+type Returned = {
+  contextValue: RepositoryListContextValue
+  visibleItems: Array<RepositoryItemTree>
+}
+
+export const useFolderNavigation = (props: Props): Returned => {
+  const { collapsed, items, onToggle } = props
+  const [folderTarget, setFolderTarget] = useState<string | null>(null)
+
+  const { currentFolder, folderPath } = useMemo(() => getFolderPath(items, folderTarget), [folderTarget, items])
+
+  const onNavigate = useCallback((uuid: string | null) => setFolderTarget(uuid), [])
+
+  const contextValue = useMemo<RepositoryListContextValue>(
+    () => ({
+      // Force the current folder to always appear expanded, even if contracted in parent view
+      collapsed: currentFolder ? { ...collapsed, [currentFolder.uuid]: false } : collapsed,
+      folderPath,
+      onNavigate,
+      onToggle,
+      parentUuid: currentFolder?.uuid,
+    }),
+    [collapsed, currentFolder, folderPath, onNavigate, onToggle]
+  )
+
+  return { contextValue, visibleItems: currentFolder ? [currentFolder] : items }
+}

--- a/src/client/pages/CountryHome/Repository/RepositoryList/hooks/useFolderNavigation.ts
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/hooks/useFolderNavigation.ts
@@ -18,11 +18,11 @@ type Returned = {
 
 export const useFolderNavigation = (props: Props): Returned => {
   const { collapsed, items, onToggle } = props
-  const [folderTarget, setFolderTarget] = useState<string | null>(null)
+  const [folderTarget, setFolderTarget] = useState<string | undefined>()
 
   const { currentFolder, folderPath } = useMemo(() => getFolderPath(items, folderTarget), [folderTarget, items])
 
-  const onNavigate = useCallback((uuid: string | null) => setFolderTarget(uuid), [])
+  const onNavigate = useCallback((uuid?: string) => setFolderTarget(uuid), [])
 
   const contextValue = useMemo<RepositoryListContextValue>(
     () => ({

--- a/src/client/pages/CountryHome/Repository/hooks/useOpenPanel.ts
+++ b/src/client/pages/CountryHome/Repository/hooks/useOpenPanel.ts
@@ -8,13 +8,17 @@ import { RepositoryActions } from 'client/store/repository/actions'
 
 type Returned = () => void
 
-const initialRepositoryItem = (countryIso?: CountryIso): Partial<RepositoryItem> => {
-  return { countryIso, props: { public: true, translation: { en: undefined } } }
+const initialRepositoryItem = (countryIso?: CountryIso, parentUuid?: string): Partial<RepositoryItem> => {
+  return { countryIso, parentUuid, props: { public: true, translation: { en: undefined } } }
 }
 
-export const useOpenPanel = (props: { repositoryItem?: RepositoryItem; countryIso?: CountryIso }): Returned => {
-  const { countryIso, repositoryItem } = props
-  const _repositoryItem = repositoryItem ?? initialRepositoryItem(countryIso)
+export const useOpenPanel = (props: {
+  repositoryItem?: RepositoryItem
+  countryIso?: CountryIso
+  parentUuid?: string
+}): Returned => {
+  const { countryIso, parentUuid, repositoryItem } = props
+  const _repositoryItem = repositoryItem ?? initialRepositoryItem(countryIso, parentUuid)
   const dispatch = useAppDispatch()
   return useCallback(() => {
     dispatch(RepositoryActions.setRepositoryItem(_repositoryItem))

--- a/src/server/db/repository/assessmentCycle/repository/create.ts
+++ b/src/server/db/repository/assessmentCycle/repository/create.ts
@@ -16,7 +16,7 @@ type Props = {
 
 export const create = async (props: Props, client: BaseProtocol = DB): Promise<RepositoryItem> => {
   const { assessment, cycle, repositoryItem } = props
-  const { countryIso, description, fileUuid, link, props: _props } = repositoryItem
+  const { countryIso, description, fileUuid, link, parentUuid, props: _props } = repositoryItem
 
   if (fileUuid && link) throw new Error('Cannot create both file and link')
   if (!fileUuid && !link) throw new Error('No file or link provided')
@@ -25,11 +25,11 @@ export const create = async (props: Props, client: BaseProtocol = DB): Promise<R
 
   return client.one<RepositoryItem>(
     `
-      insert into ${schemaCycle}.repository (country_iso, description, file_uuid, link, props)
-      values ($1, $2, $3, $4, $5)
+      insert into ${schemaCycle}.repository (country_iso, description, file_uuid, link, parent_uuid, props)
+      values ($1, $2, $3, $4, $5, $6)
       returning *
     `,
-    [countryIso, description, fileUuid, link, _props],
+    [countryIso, description, fileUuid, link, parentUuid, _props],
     (row) => Objects.camelize(row)
   )
 }


### PR DESCRIPTION

<img width="2140" height="621" alt="image" src="https://github.com/user-attachments/assets/4836a898-d48e-4417-8102-b9d115df8367" />

<img width="2149" height="378" alt="image" src="https://github.com/user-attachments/assets/2a51d85b-bce7-4a70-ad71-72fba8be1630" />


Scope of this PR:
- Folder navigation with breadcrumbs
- Create files under folders (parent_uuid passed)

Next PR:
- Finalize UI
  - Update the toolbar bar with back button
  - Style the toolbar
  - Order components (toolbar)

Still coming (for UI):
- use Form in the panel

Rest can be found in the main PR