### PR TITLE
5767 - Repository: Intermediate PR: FormField File and minor tweaks

### DIFF
--- a/src/client/components/Form/Buttons/Buttons.tsx
+++ b/src/client/components/Form/Buttons/Buttons.tsx
@@ -7,7 +7,7 @@ import Flex from 'client/components/Layout/Flex'
 import Cancel from './Cancel'
 import Submit from './Submit'
 
-type ButtonsProps = Pick<FormProps, 'disabled' | 'hideCancel'> & {
+type ButtonsProps = Pick<FormProps, 'disabled' | 'hideCancel' | 'isDirtyOverride'> & {
   isDirty?: boolean
   isSubmitting?: boolean
   onCancel: () => void
@@ -15,12 +15,17 @@ type ButtonsProps = Pick<FormProps, 'disabled' | 'hideCancel'> & {
 }
 
 const Buttons: React.FC<ButtonsProps> = (props) => {
-  const { disabled, hideCancel, isDirty, isSubmitting, labels, onCancel } = props
+  const { disabled, hideCancel, isDirty, isDirtyOverride, isSubmitting, labels, onCancel } = props
 
   return (
     <Flex className="form-button-container" gap={'32'} justifyContent={'center'}>
       <Cancel disabled={disabled} hideCancel={hideCancel} onClick={onCancel} />
-      <Submit disabled={disabled} isDirty={isDirty} isSubmitting={isSubmitting} label={labels?.submit} />
+      <Submit
+        disabled={disabled}
+        isDirty={isDirtyOverride ?? isDirty}
+        isSubmitting={isSubmitting}
+        label={labels?.submit}
+      />
     </Flex>
   )
 }

--- a/src/client/components/Form/Form.tsx
+++ b/src/client/components/Form/Form.tsx
@@ -32,6 +32,7 @@ const Form: React.FC<FormProps> = (props) => {
     disabled,
     formDefinition,
     hideCancel,
+    isDirtyOverride,
     method = 'post',
     onCancel,
     onSuccess,
@@ -94,6 +95,7 @@ const Form: React.FC<FormProps> = (props) => {
           disabled={disabled}
           hideCancel={hideCancel}
           isDirty={isDirty}
+          isDirtyOverride={isDirtyOverride}
           isSubmitting={isSubmitting}
           labels={labels}
           onCancel={onCancel}

--- a/src/client/components/Form/FormFields/FileField/FileField.tsx
+++ b/src/client/components/Form/FormFields/FileField/FileField.tsx
@@ -9,18 +9,23 @@ import FormField from 'client/components/Form/FormFields/FormField'
 import { FieldProps } from '../types'
 
 const FileField: React.FC<FieldProps> = (props) => {
-  const { fieldDefinition, register, setValue, trigger } = props
-  const { name } = fieldDefinition
+  const { fieldDefinition, register, setValue, trigger, watch } = props
+  const { name, nameField } = fieldDefinition
 
   const [files, setFiles] = useState<Array<FileSummary>>()
 
   const onChange = useCallback<FileUploadOnChange>(
     (uploadedFiles) => {
+      const file = uploadedFiles.at(0)
       setFiles(uploadedFiles)
-      setValue(name, uploadedFiles.at(0)?.uuid ?? '')
+      setValue(name, file?.uuid ?? '')
+      // If nameField is empty, populate the given name field with file name
+      if (nameField && !watch(nameField) && file?.name) {
+        setValue(nameField as never, file.name as never)
+      }
       trigger(name)
     },
-    [name, setValue, trigger]
+    [name, nameField, setValue, trigger, watch]
   )
 
   return (

--- a/src/client/components/Form/FormFields/FileField/FileField.tsx
+++ b/src/client/components/Form/FormFields/FileField/FileField.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback, useState } from 'react'
+
+import { FileSummary } from 'meta/file/file'
+
+import FileUpload from 'client/components/FileUpload'
+import { FileUploadOnChange } from 'client/components/FileUpload/types'
+import FormField from 'client/components/Form/FormFields/FormField'
+
+import { FieldProps } from '../types'
+
+const FileField: React.FC<FieldProps> = (props) => {
+  const { fieldDefinition, register, setValue, trigger } = props
+  const { name } = fieldDefinition
+
+  const [files, setFiles] = useState<Array<FileSummary>>()
+
+  const onChange = useCallback<FileUploadOnChange>(
+    (uploadedFiles) => {
+      setFiles(uploadedFiles)
+      setValue(name, uploadedFiles.at(0)?.uuid ?? '')
+      trigger(name)
+    },
+    [name, setValue, trigger]
+  )
+
+  return (
+    <FormField
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+      renderInput={() => (
+        <>
+          {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+          <input type="hidden" {...register(name)} />
+          <FileUpload onChange={onChange} value={files} />
+        </>
+      )}
+    />
+  )
+}
+
+export default FileField

--- a/src/client/components/Form/FormFields/FileField/index.ts
+++ b/src/client/components/Form/FormFields/FileField/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FileField'

--- a/src/client/components/Form/FormFields/FormFields.tsx
+++ b/src/client/components/Form/FormFields/FormFields.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import AvatarField from 'client/components/Form/FormFields/AvatarField'
 import CheckboxField from 'client/components/Form/FormFields/CheckboxField'
 import CountryField from 'client/components/Form/FormFields/CountryField'
+import FileField from 'client/components/Form/FormFields/FileField'
 import HiddenField from 'client/components/Form/FormFields/HiddenField'
 import LanguageField from 'client/components/Form/FormFields/LanguageField'
 import PasswordField from 'client/components/Form/FormFields/PasswordField'
@@ -19,6 +20,7 @@ export const FormFields: Record<FormFieldType, React.FC<FieldProps>> = {
   [FormFieldType.avatar]: AvatarField,
   [FormFieldType.checkbox]: CheckboxField,
   [FormFieldType.country]: CountryField,
+  [FormFieldType.file]: FileField,
   [FormFieldType.hidden]: HiddenField,
   [FormFieldType.language]: LanguageField,
   [FormFieldType.password]: PasswordField,

--- a/src/client/components/Form/types.ts
+++ b/src/client/components/Form/types.ts
@@ -7,6 +7,7 @@ export enum FormFieldType {
   avatar = 'avatar',
   checkbox = 'checkbox',
   country = 'country',
+  file = 'file',
   hidden = 'hidden',
   language = 'language',
   password = 'password',

--- a/src/client/components/Form/types.ts
+++ b/src/client/components/Form/types.ts
@@ -31,6 +31,7 @@ export type FieldDefinition<FIELD_VALUES = FieldValues> = {
   isMulti?: boolean
   label: string
   name: string
+  nameField?: string
   options?: Array<Option>
   placeholder?: string
   required?: boolean
@@ -59,6 +60,7 @@ export type FormProps<FIELD_VALUES = FieldValues> = {
   disabled?: boolean
   formDefinition: FormDefinition<FIELD_VALUES>
   hideCancel?: boolean
+  isDirtyOverride?: boolean
   method?: ReactHookFormProps<unknown>['method']
   onCancel?: () => void
   onSuccess?: (values: FIELD_VALUES, response: Response) => void | Promise<void>

--- a/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/RepositoryListItem.scss
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/RepositoryListItem.scss
@@ -6,6 +6,7 @@
   grid-column: 1 / -1;
   grid-template-columns: subgrid;
   min-height: 32px;
+  padding-right: $spacing-xxs;
 
   &:nth-child(even) {
     background-color: $ui-bg-light;

--- a/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/RepositoryListItem.tsx
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/RepositoryListItem/RepositoryListItem.tsx
@@ -2,6 +2,7 @@ import './RepositoryListItem.scss'
 import React from 'react'
 
 import { RepositoryItemTree } from 'meta/cycleData/repository/item'
+import { RepositoryItems } from 'meta/cycleData/repository/items'
 
 import { useRepositoryListContext } from '../context'
 import type { Props as FolderProps } from './Folder/props'
@@ -23,7 +24,7 @@ const RepositoryListItem: React.FC<Props> = (props) => {
   const { collapsed } = useRepositoryListContext()
 
   const isCollapsed = collapsed[item.uuid]
-  const Component = Components[item.folderName ? 'folder' : 'item']
+  const Component = Components[RepositoryItems.isFolder(item) ? 'folder' : 'item']
 
   return (
     <>

--- a/src/client/pages/CountryHome/Repository/RepositoryList/hooks/_useFilterFn.ts
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/hooks/_useFilterFn.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 
 import { RepositoryItemTree } from 'meta/cycleData/repository/item'
+import { RepositoryItems } from 'meta/cycleData/repository/items'
 import { Lang } from 'meta/lang'
 import { Objects } from 'utils/objects'
 
@@ -14,7 +15,7 @@ const _filterByPredicate = (
   predicate: (item: RepositoryItemTree) => boolean
 ): Array<RepositoryItemTree> =>
   items.reduce<Array<RepositoryItemTree>>((acc, item) => {
-    if (!item.folderName) {
+    if (!RepositoryItems.isFolder(item)) {
       if (predicate(item)) acc.push(item)
       return acc
     }
@@ -39,7 +40,7 @@ const _getFilterBoolSelect = (
 const _filterByName = (items: Array<RepositoryItemTree>, filter: string, language: Lang): Array<RepositoryItemTree> => {
   const lower = filter.toLowerCase()
   return items.reduce<Array<RepositoryItemTree>>((acc, item) => {
-    if (!item.folderName) {
+    if (!RepositoryItems.isFolder(item)) {
       if (_getNameTranslation(item, language).toLowerCase().includes(lower)) acc.push(item)
       return acc
     }

--- a/src/client/pages/CountryHome/Repository/RepositoryList/hooks/_useSortFn.ts
+++ b/src/client/pages/CountryHome/Repository/RepositoryList/hooks/_useSortFn.ts
@@ -1,4 +1,5 @@
 import { RepositoryItemTree } from 'meta/cycleData/repository/item'
+import { RepositoryItems } from 'meta/cycleData/repository/items'
 import { Lang } from 'meta/lang'
 import { TablePaginatedOrderByDirection } from 'meta/tablePaginated/orderBy'
 import { Objects } from 'utils/objects'
@@ -31,8 +32,8 @@ const _compareFn =
   (property: SortProperty, direction: TablePaginatedOrderByDirection, language: Lang): CompareFN =>
   (a: RepositoryItemTree, b: RepositoryItemTree): number => {
     // Folders first
-    if (a.folderName && !b.folderName) return -1
-    if (!a.folderName && b.folderName) return 1
+    if (RepositoryItems.isFolder(a) && !RepositoryItems.isFolder(b)) return -1
+    if (!RepositoryItems.isFolder(a) && RepositoryItems.isFolder(b)) return 1
 
     // Direction
     const multiplier = direction === TablePaginatedOrderByDirection.asc ? 1 : -1

--- a/src/meta/cycleData/repository/itemValidation.ts
+++ b/src/meta/cycleData/repository/itemValidation.ts
@@ -1,5 +1,6 @@
 export type RepositoryItemValidation = {
-  name?: string
   fileUuid?: string
+  folderName?: string
   link?: string
+  name?: string
 }

--- a/src/meta/cycleData/repository/itemValidator.ts
+++ b/src/meta/cycleData/repository/itemValidator.ts
@@ -2,17 +2,15 @@ import { RepositoryItem } from 'meta/cycleData/repository/item'
 import { RepositoryItemValidation } from 'meta/cycleData/repository/itemValidation'
 
 const validate = (repositoryItem: Partial<RepositoryItem>): RepositoryItemValidation | undefined => {
-  const {
-    fileUuid,
-    link,
-    props: {
-      translation: { en: name },
-    },
-  } = repositoryItem || {}
+  const { fileUuid, folderName, link, props } = repositoryItem || {}
+  const name = props?.translation?.en
 
-  if (!name) {
-    return { name: 'validation.repositoryItem.nameIsRequired' }
+  if (folderName !== undefined) {
+    if (!folderName) return { folderName: 'validation.repositoryItem.nameIsRequired' }
+    return undefined
   }
+
+  if (!name) return { name: 'validation.repositoryItem.nameIsRequired' }
 
   if (!fileUuid && !link) {
     return {

--- a/src/meta/cycleData/repository/itemValidator.ts
+++ b/src/meta/cycleData/repository/itemValidator.ts
@@ -1,11 +1,12 @@
 import { RepositoryItem } from 'meta/cycleData/repository/item'
+import { RepositoryItems } from 'meta/cycleData/repository/items'
 import { RepositoryItemValidation } from 'meta/cycleData/repository/itemValidation'
 
 const validate = (repositoryItem: Partial<RepositoryItem>): RepositoryItemValidation | undefined => {
   const { fileUuid, folderName, link, props } = repositoryItem || {}
   const name = props?.translation?.en
 
-  if (folderName !== undefined) {
+  if (RepositoryItems.isFolder(repositoryItem)) {
     if (!folderName) return { folderName: 'validation.repositoryItem.nameIsRequired' }
     return undefined
   }

--- a/src/meta/cycleData/repository/items.ts
+++ b/src/meta/cycleData/repository/items.ts
@@ -17,6 +17,8 @@ const getURL = (props: GetFileURLProps): string => {
   return `${ApiEndPoint.CycleData.Repository.File.one(datum.uuid)}?${queryParams.toString()}`
 }
 
+const isFolder = (item: Pick<RepositoryItem, 'folderName'>): boolean => typeof item.folderName === 'string'
+
 const isGlobal = (props: { repositoryItem: RepositoryItem }): boolean => {
   const { repositoryItem } = props
   return !repositoryItem.countryIso
@@ -24,5 +26,6 @@ const isGlobal = (props: { repositoryItem: RepositoryItem }): boolean => {
 
 export const RepositoryItems = {
   getURL,
+  isFolder,
   isGlobal,
 }

--- a/src/server/api/cycleData/index.ts
+++ b/src/server/api/cycleData/index.ts
@@ -1,6 +1,7 @@
 import { Express } from 'express'
 // @ts-ignore
 import queue from 'express-queue'
+import multer from 'multer'
 
 import { ApiEndPoint } from 'meta/api/endpoint'
 
@@ -15,6 +16,7 @@ import { verifyLinks } from 'server/api/cycleData/links/verifyLinks'
 import { verifyStatus } from 'server/api/cycleData/links/verifyStatus'
 import { verifySummary } from 'server/api/cycleData/links/verifySummary'
 import { AuthMiddleware } from 'server/middleware/auth'
+import { FormDataBodyMiddleware } from 'server/middleware/formDataBodyMiddleware'
 
 import { getActivities } from './activities/getActivities'
 import { getActivitiesCount } from './activities/getActivitiesCount'
@@ -179,7 +181,13 @@ export const CycleDataApi = {
     express.delete(ApiEndPoint.CycleData.Contacts.one(), AuthMiddleware.requireEditDescriptions, removeContact)
 
     // repository
-    express.post(ApiEndPoint.CycleData.Repository.one(), AuthMiddleware.requireEditRepositoryItem, createRepositoryItem)
+    express.post(
+      ApiEndPoint.CycleData.Repository.one(),
+      multer().none(),
+      FormDataBodyMiddleware.parseBody,
+      AuthMiddleware.requireEditRepositoryItem,
+      createRepositoryItem
+    )
     express.get(
       ApiEndPoint.CycleData.Repository.File.one(),
       AuthMiddleware.requireViewRepositoryItem,
@@ -195,6 +203,8 @@ export const CycleDataApi = {
     express.get(ApiEndPoint.CycleData.Repository.tree(), AuthMiddleware.requireView, getManyRepositoryTree)
     express.patch(
       ApiEndPoint.CycleData.Repository.one(),
+      multer().none(),
+      FormDataBodyMiddleware.parseBody,
       AuthMiddleware.requireEditRepositoryItem,
       updateRepositoryItem
     )

--- a/src/server/db/repository/assessmentCycle/repository/create.ts
+++ b/src/server/db/repository/assessmentCycle/repository/create.ts
@@ -16,20 +16,22 @@ type Props = {
 
 export const create = async (props: Props, client: BaseProtocol = DB): Promise<RepositoryItem> => {
   const { assessment, cycle, repositoryItem } = props
-  const { countryIso, description, fileUuid, link, parentUuid, props: _props } = repositoryItem
+  const { countryIso, description, fileUuid, folderName, link, parentUuid, props: _props = {} } = repositoryItem
 
-  if (fileUuid && link) throw new Error('Cannot create both file and link')
-  if (!fileUuid && !link) throw new Error('No file or link provided')
+  if (!folderName) {
+    if (fileUuid && link) throw new Error('Cannot create both file and link')
+    if (!fileUuid && !link) throw new Error('No file or link provided')
+  }
 
   const schemaCycle = Schemas.getNameCycle(assessment, cycle)
 
   return client.one<RepositoryItem>(
     `
-      insert into ${schemaCycle}.repository (country_iso, description, file_uuid, link, parent_uuid, props)
-      values ($1, $2, $3, $4, $5, $6)
+      insert into ${schemaCycle}.repository (country_iso, description, file_uuid, folder_name, link, parent_uuid, props)
+      values ($(countryIso), $(description), $(fileUuid), $(folderName), $(link), $(parentUuid), $(props))
       returning *
     `,
-    [countryIso, description, fileUuid, link, parentUuid, _props],
+    { countryIso, description, fileUuid, folderName, link, parentUuid, props: _props },
     (row) => Objects.camelize(row)
   )
 }

--- a/src/server/db/repository/assessmentCycle/repository/create.ts
+++ b/src/server/db/repository/assessmentCycle/repository/create.ts
@@ -2,6 +2,7 @@ import { AreaCode } from 'meta/area/areaCode'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import { RepositoryItem } from 'meta/cycleData/repository/item'
+import { RepositoryItems } from 'meta/cycleData/repository/items'
 import { Objects } from 'utils/objects'
 
 import { BaseProtocol, DB } from 'server/db/db'
@@ -18,7 +19,7 @@ export const create = async (props: Props, client: BaseProtocol = DB): Promise<R
   const { assessment, cycle, repositoryItem } = props
   const { countryIso, description, fileUuid, folderName, link, parentUuid, props: _props = {} } = repositoryItem
 
-  if (!folderName) {
+  if (!RepositoryItems.isFolder(repositoryItem)) {
     if (fileUuid && link) throw new Error('Cannot create both file and link')
     if (!fileUuid && !link) throw new Error('No file or link provided')
   }
@@ -31,7 +32,15 @@ export const create = async (props: Props, client: BaseProtocol = DB): Promise<R
       values ($(countryIso), $(description), $(fileUuid), $(folderName), $(link), $(parentUuid), $(props))
       returning *
     `,
-    { countryIso, description, fileUuid, folderName, link, parentUuid, props: _props },
+    {
+      countryIso,
+      description: description || null,
+      fileUuid: fileUuid || null,
+      folderName: folderName ?? null,
+      link: link || null,
+      parentUuid: parentUuid || null,
+      props: _props,
+    },
     (row) => Objects.camelize(row)
   )
 }

--- a/src/server/db/repository/assessmentCycle/repository/update.ts
+++ b/src/server/db/repository/assessmentCycle/repository/update.ts
@@ -14,24 +14,27 @@ type Props = {
 
 export const update = async (props: Props, client: BaseProtocol = DB): Promise<RepositoryItem> => {
   const { assessment, cycle, repositoryItem } = props
-  const { description, fileUuid, link, props: _props, uuid } = repositoryItem
+  const { description, fileUuid, folderName, link, props: _props = {}, uuid } = repositoryItem
 
-  if (fileUuid && link) throw new Error('Cannot create both file and link')
-  if (!fileUuid && !link) throw new Error('No file or link provided')
+  if (!folderName) {
+    if (fileUuid && link) throw new Error('Cannot create both file and link')
+    if (!fileUuid && !link) throw new Error('No file or link provided')
+  }
 
   const schemaCycle = Schemas.getNameCycle(assessment, cycle)
 
   return client.one<RepositoryItem>(
     `
       update ${schemaCycle}.repository
-      set description = $1
-        , file_uuid = $2
-        , link = $3
-        , props = $4
-      where uuid = $5
+      set description = $(description)
+        , file_uuid = $(fileUuid)
+        , folder_name = $(folderName)
+        , link = $(link)
+        , props = $(props)
+      where uuid = $(uuid)
       returning *
     `,
-    [description, fileUuid, link, _props, uuid],
+    { description, fileUuid, folderName, link, props: _props, uuid },
     (row) => Objects.camelize(row)
   )
 }

--- a/src/server/db/repository/assessmentCycle/repository/update.ts
+++ b/src/server/db/repository/assessmentCycle/repository/update.ts
@@ -1,6 +1,7 @@
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import { RepositoryItem } from 'meta/cycleData/repository/item'
+import { RepositoryItems } from 'meta/cycleData/repository/items'
 import { Objects } from 'utils/objects'
 
 import { BaseProtocol, DB } from 'server/db/db'
@@ -16,7 +17,7 @@ export const update = async (props: Props, client: BaseProtocol = DB): Promise<R
   const { assessment, cycle, repositoryItem } = props
   const { description, fileUuid, folderName, link, props: _props = {}, uuid } = repositoryItem
 
-  if (!folderName) {
+  if (!RepositoryItems.isFolder(repositoryItem)) {
     if (fileUuid && link) throw new Error('Cannot create both file and link')
     if (!fileUuid && !link) throw new Error('No file or link provided')
   }
@@ -34,7 +35,14 @@ export const update = async (props: Props, client: BaseProtocol = DB): Promise<R
       where uuid = $(uuid)
       returning *
     `,
-    { description, fileUuid, folderName, link, props: _props, uuid },
+    {
+      description: description || null,
+      fileUuid: fileUuid || null,
+      folderName: folderName ?? null,
+      link: link || null,
+      props: _props,
+      uuid,
+    },
     (row) => Objects.camelize(row)
   )
 }


### PR DESCRIPTION
User interface changes:
Only fix button position slightly:

<img width="647" height="302" alt="image" src="https://github.com/user-attachments/assets/d85c2f89-a672-46a8-a7f2-3cd088121722" />


Note:
- Intermediate PR to avoid too large PR

Scope of this PR:
  - Support overriding `isDirty` prop for form (to handle enabling and disabling of button)
  - Add `FormField.File` component
- RepositoryItems.isFolder
- Add `folder_name` writing to db
- Support FormData in BE

Next PR:
- Add, remove and edit files and folders using our Form component