### PR TITLE
5758 - Navigation: Data errors - New Validation cache types - 1

### DIFF
--- a/src/meta/assessment/metaCache/index.ts
+++ b/src/meta/assessment/metaCache/index.ts
@@ -28,16 +28,7 @@ export type VariablesCache = Record<TableName, Record<VariableName, VariableCach
 export type TableDependencyRecord = Record<VariableName, Array<VariableCache>>
 export type DependencyRecord = Record<TableName, TableDependencyRecord>
 
-export type ValidationTargetCache = {
-  colName: ColName
-  tableName: TableName
-  variableName: VariableName
-}
-
-export type ValidationTargetsBySource = Record<
-  TableName,
-  Record<VariableName, Record<ColName, Array<ValidationTargetCache>>>
->
+export type ValidationTargetsBySource = Record<TableName, Record<VariableName, Record<ColName, Array<VariableCache>>>>
 
 export type DependencyCache = {
   dependencies: DependencyRecord

--- a/src/meta/assessment/metaCache/index.ts
+++ b/src/meta/assessment/metaCache/index.ts
@@ -28,14 +28,30 @@ export type VariablesCache = Record<TableName, Record<VariableName, VariableCach
 export type TableDependencyRecord = Record<VariableName, Array<VariableCache>>
 export type DependencyRecord = Record<TableName, TableDependencyRecord>
 
+export type ValidationTargetCache = {
+  colName: ColName
+  tableName: TableName
+  variableName: VariableName
+}
+
+export type ValidationTargetsBySource = Record<
+  TableName,
+  Record<VariableName, Record<ColName, Array<ValidationTargetCache>>>
+>
+
 export type DependencyCache = {
   dependencies: DependencyRecord
   dependants: DependencyRecord
 }
 
+export type ValidationDependencyCache = {
+  dependencies: DependencyRecord
+  dependants: ValidationTargetsBySource
+}
+
 export interface AssessmentMetaCache {
   calculations: DependencyCache
-  validations: DependencyCache
+  validations: ValidationDependencyCache
   enablers?: DependencyCache
   variablesByTable: VariablesCache
 }

--- a/src/meta/assessment/metaCaches/index.ts
+++ b/src/meta/assessment/metaCaches/index.ts
@@ -60,7 +60,8 @@ const getMetaCache = (props: CycleProps): AssessmentMetaCache => {
 
 const getCalculations = (props: CycleProps): DependencyCache => getMetaCache(props).calculations
 
-const getValidations = (props: CycleProps): DependencyCache => getMetaCache(props).validations
+const getValidations = (props: CycleProps): DependencyCache =>
+  getMetaCache(props).validations as unknown as DependencyCache // TODO: delete this cast after implementing new validation graph
 
 const getEnablers = (props: CycleProps): DependencyCache => getMetaCache(props).enablers
 

--- a/src/server/controller/cycleData/validations/context/contextFactory.ts
+++ b/src/server/controller/cycleData/validations/context/contextFactory.ts
@@ -1,6 +1,7 @@
+import { ColName } from 'meta/assessment/col'
 import { VariableCache } from 'meta/assessment/metaCache'
 import { AssessmentMetaCaches } from 'meta/assessment/metaCaches'
-import { RowCacheKey } from 'meta/assessment/rowCache'
+import { RowCache, RowCacheKey } from 'meta/assessment/rowCache'
 import { RowCaches } from 'meta/assessment/rowCaches'
 import { TableName } from 'meta/assessment/table'
 import { NodeUpdate, NodeUpdates } from 'meta/data/nodeUpdates'
@@ -52,6 +53,44 @@ export class ContextFactory extends BaseContextBuilder {
     const cycleName = variable.cycleName ?? this.props.cycle.name
 
     return assessmentName === this.props.assessment.props.name && cycleName === this.props.cycle.name
+  }
+
+  async #getRow(variable: VariableCache): Promise<RowCache | undefined> {
+    const rowKey = RowCaches.getKey(variable)
+
+    const rows = await RowRedisRepository.getRows({ assessment: this.props.assessment, rowKeys: [rowKey] })
+
+    return rows[rowKey]
+  }
+
+  async #expandVariable(variable: VariableCache): Promise<Array<VariableCache>> {
+    const assessmentName = variable.assessmentName ?? this.props.assessment.props.name
+    const cycleName = variable.cycleName ?? this.props.cycle.name
+
+    if (!Objects.isEmpty(variable.colName)) {
+      return [{ ...variable, assessmentName, cycleName, colName: variable.colName }]
+    }
+
+    const row = await this.#getRow(variable)
+    const colNames =
+      row?.cols?.reduce<Array<ColName>>((acc, col) => {
+        const colName = col.props.colName as ColName | undefined
+
+        if (Objects.isEmpty(colName)) {
+          return acc
+        }
+
+        acc.push(colName)
+
+        return acc
+      }, []) ?? []
+
+    return colNames.map((colName) => ({
+      ...variable,
+      assessmentName,
+      cycleName,
+      colName,
+    }))
   }
 
   async #addToQueue(variable: VariableCache): Promise<void> {
@@ -109,25 +148,23 @@ export class ContextFactory extends BaseContextBuilder {
     })
 
     await Promises.each(dependants, async (dependant) => {
-      const candidate: VariableCache = {
+      const candidates = await this.#expandVariable({
         assessmentName: dependant.assessmentName ?? assessment.props.name,
         cycleName: dependant.cycleName ?? cycle.name,
-        colName: dependant.colName ?? variable.colName,
+        colName: dependant.colName,
         tableName: dependant.tableName,
         variableName: dependant.variableName,
-      }
+      })
 
-      if (Objects.isEmpty(candidate.colName)) {
-        return
-      }
+      await Promises.each(candidates, async (candidate) => {
+        if (!this.#isCurrentTarget(candidate)) {
+          // External validation dependants are rescheduled through updateDependencies in the target cycle.
+          this.#addExternalNodeUpdate(candidate)
+          return
+        }
 
-      if (!this.#isCurrentTarget(candidate)) {
-        // External validation dependants are rescheduled through updateDependencies in the target cycle.
-        this.#addExternalNodeUpdate(candidate)
-        return
-      }
-
-      await this.#addToQueue(candidate)
+        await this.#addToQueue(candidate)
+      })
     })
   }
 

--- a/src/server/controller/cycleData/validations/context/contextFactory.ts
+++ b/src/server/controller/cycleData/validations/context/contextFactory.ts
@@ -1,7 +1,6 @@
-import { ColName } from 'meta/assessment/col'
 import { VariableCache } from 'meta/assessment/metaCache'
 import { AssessmentMetaCaches } from 'meta/assessment/metaCaches'
-import { RowCache, RowCacheKey } from 'meta/assessment/rowCache'
+import { RowCacheKey } from 'meta/assessment/rowCache'
 import { RowCaches } from 'meta/assessment/rowCaches'
 import { TableName } from 'meta/assessment/table'
 import { NodeUpdate, NodeUpdates } from 'meta/data/nodeUpdates'
@@ -53,44 +52,6 @@ export class ContextFactory extends BaseContextBuilder {
     const cycleName = variable.cycleName ?? this.props.cycle.name
 
     return assessmentName === this.props.assessment.props.name && cycleName === this.props.cycle.name
-  }
-
-  async #getRow(variable: VariableCache): Promise<RowCache | undefined> {
-    const rowKey = RowCaches.getKey(variable)
-
-    const rows = await RowRedisRepository.getRows({ assessment: this.props.assessment, rowKeys: [rowKey] })
-
-    return rows[rowKey]
-  }
-
-  async #expandVariable(variable: VariableCache): Promise<Array<VariableCache>> {
-    const assessmentName = variable.assessmentName ?? this.props.assessment.props.name
-    const cycleName = variable.cycleName ?? this.props.cycle.name
-
-    if (!Objects.isEmpty(variable.colName)) {
-      return [{ ...variable, assessmentName, cycleName, colName: variable.colName }]
-    }
-
-    const row = await this.#getRow(variable)
-    const colNames =
-      row?.cols?.reduce<Array<ColName>>((acc, col) => {
-        const colName = col.props.colName as ColName | undefined
-
-        if (Objects.isEmpty(colName)) {
-          return acc
-        }
-
-        acc.push(colName)
-
-        return acc
-      }, []) ?? []
-
-    return colNames.map((colName) => ({
-      ...variable,
-      assessmentName,
-      cycleName,
-      colName,
-    }))
   }
 
   async #addToQueue(variable: VariableCache): Promise<void> {
@@ -148,23 +109,25 @@ export class ContextFactory extends BaseContextBuilder {
     })
 
     await Promises.each(dependants, async (dependant) => {
-      const candidates = await this.#expandVariable({
+      const candidate: VariableCache = {
         assessmentName: dependant.assessmentName ?? assessment.props.name,
         cycleName: dependant.cycleName ?? cycle.name,
-        colName: dependant.colName,
+        colName: dependant.colName ?? variable.colName,
         tableName: dependant.tableName,
         variableName: dependant.variableName,
-      })
+      }
 
-      await Promises.each(candidates, async (candidate) => {
-        if (!this.#isCurrentTarget(candidate)) {
-          // External validation dependants are rescheduled through updateDependencies in the target cycle.
-          this.#addExternalNodeUpdate(candidate)
-          return
-        }
+      if (Objects.isEmpty(candidate.colName)) {
+        return
+      }
 
-        await this.#addToQueue(candidate)
-      })
+      if (!this.#isCurrentTarget(candidate)) {
+        // External validation dependants are rescheduled through updateDependencies in the target cycle.
+        this.#addExternalNodeUpdate(candidate)
+        return
+      }
+
+      await this.#addToQueue(candidate)
     })
   }
 

--- a/src/server/controller/cycleData/validations/context/dataContextBuilder.ts
+++ b/src/server/controller/cycleData/validations/context/dataContextBuilder.ts
@@ -1,4 +1,4 @@
-import { Assessment, AssessmentName, RecordAssessments } from 'meta/assessment/assessment'
+import { RecordAssessments } from 'meta/assessment/assessment'
 import { Assessments } from 'meta/assessment/assessments'
 import { Cycle, CycleName } from 'meta/assessment/cycle'
 import { VariableCache } from 'meta/assessment/metaCache'
@@ -6,10 +6,8 @@ import { AssessmentMetaCaches } from 'meta/assessment/metaCaches'
 import { TableName } from 'meta/assessment/table'
 import { RecordAssessmentData } from 'meta/data/recordData'
 import { RecordAssessmentDatas } from 'meta/data/recordDatas'
-import { Objects } from 'utils/objects'
 import { Promises } from 'utils/promises'
 
-import { AssessmentController } from 'server/controller/assessment'
 import { getTableData } from 'server/controller/cycleData/getTableData'
 
 import { BaseContextBuilder } from './baseContextBuilder'
@@ -21,14 +19,13 @@ type Returned = {
 }
 
 type TablesFetch = {
-  assessment: Assessment
   cycle: Cycle
   tableNames: Set<TableName>
 }
 
 export class DataContextBuilder extends BaseContextBuilder {
   readonly #assessments: RecordAssessments
-  readonly #tables: Record<AssessmentName, Record<CycleName, TablesFetch>>
+  readonly #tables: Record<CycleName, TablesFetch>
 
   constructor(props: ContextBuilderProps) {
     super(props)
@@ -40,44 +37,33 @@ export class DataContextBuilder extends BaseContextBuilder {
 
     // init tables to fetch
     this.#tables = {
-      [assessment.props.name]: {
-        [cycle.name]: {
-          assessment,
-          cycle,
-          tableNames: new Set<TableName>(),
-        },
+      [cycle.name]: {
+        cycle,
+        tableNames: new Set<TableName>(),
       },
     }
   }
 
-  async #ensureAssessment(assessmentName: AssessmentName): Promise<Assessment> {
-    if (!this.#assessments[assessmentName]) {
-      this.#assessments[assessmentName] = await AssessmentController.getOne({ assessmentName, metaCache: true })
+  async #ensureTablesFetch(cycleName: CycleName): Promise<TablesFetch> {
+    if (!this.#tables[cycleName]) {
+      this.#tables[cycleName] = {
+        cycle: Assessments.getCycle({ assessment: this.props.assessment, cycleName }),
+        tableNames: new Set<TableName>(),
+      }
     }
 
-    return this.#assessments[assessmentName]
-  }
-
-  async #ensureTablesFetch(assessmentName: AssessmentName, cycleName: CycleName): Promise<TablesFetch> {
-    if (!this.#tables[assessmentName]?.[cycleName]) {
-      // Validation dependencies may point to another assessment/cycle
-      const assessment = await this.#ensureAssessment(assessmentName)
-      const cycle = Assessments.getCycle({ assessment, cycleName })
-
-      Objects.setInPath({
-        obj: this.#tables,
-        path: [assessmentName, cycleName],
-        value: { assessment, cycle, tableNames: new Set<TableName>() },
-      })
-    }
-
-    return this.#tables[assessmentName][cycleName]
+    return this.#tables[cycleName]
   }
 
   async #addDependency(variable: Pick<VariableCache, 'assessmentName' | 'cycleName' | 'tableName'>): Promise<void> {
     const assessmentName = variable.assessmentName ?? this.props.assessment.props.name
     const cycleName = variable.cycleName ?? this.props.cycle.name
-    const tablesFetch = await this.#ensureTablesFetch(assessmentName, cycleName)
+
+    if (assessmentName !== this.props.assessment.props.name) {
+      throw new Error(`Cross-assessment validation dependencies are not supported: ${assessmentName}`)
+    }
+
+    const tablesFetch = await this.#ensureTablesFetch(cycleName)
 
     tablesFetch.tableNames.add(variable.tableName)
   }
@@ -116,28 +102,27 @@ export class DataContextBuilder extends BaseContextBuilder {
   }
 
   async getData(): Promise<Returned> {
-    const { countryIso } = this.props.country
+    const { assessment, country } = this.props
+    const { countryIso } = country
     let data: RecordAssessmentData = {}
 
-    await Promises.each(Object.values(this.#tables), async (cycles) => {
-      await Promises.each(Object.values(cycles), async (tablesFetch) => {
-        const tableNames = Array.from(tablesFetch.tableNames)
+    await Promises.each(Object.values(this.#tables), async (tablesFetch) => {
+      const tableNames = Array.from(tablesFetch.tableNames)
 
-        if (tableNames.length === 0) {
-          return
-        }
+      if (tableNames.length === 0) {
+        return
+      }
 
-        // Fetch the tables collected for this assessment/cycle
-        const cycleData = await getTableData({
-          assessment: tablesFetch.assessment,
-          countryISOs: [countryIso],
-          cycle: tablesFetch.cycle,
-          mergeOdp: true,
-          tableNames,
-        })
-
-        data = RecordAssessmentDatas.mergeData({ newTableData: cycleData, tableData: data })
+      // Fetch the tables collected for this assessment/cycle
+      const cycleData = await getTableData({
+        assessment,
+        countryISOs: [countryIso],
+        cycle: tablesFetch.cycle,
+        mergeOdp: true,
+        tableNames,
       })
+
+      data = RecordAssessmentDatas.mergeData({ newTableData: cycleData, tableData: data })
     })
 
     return { assessments: this.#assessments, data }


### PR DESCRIPTION
New PR scope:
- Removing cross-assessment dependencies handler because that doesn't exist for validations like they do for node updates.

- Introducing new type 
```ts
export type ValidationTargetsBySource = Record<
  TableName,
  Record<VariableName, Record<ColName, Array<ValidationTargetCache>>>
>
```

The idea is that the record itself is the validation source, and it contains an array of targets.
For example, for cell `extentOfForest`.`forestArea`.`2025`, the dependencies are
- `forestAreaChange`.`forestAreaNetChange`.`2020-2025`
- `forestAreaWithinProtectedAreas `.`forest_area_within_protected_areas `.`2025`, 
- and `forestAreaWithinProtectedAreas`.`forest_area_with_long_term_management_plan`.`2025`.

so the `ValidationTargetsBySource` object here would be:

```ts
{
  extentOfForest: {
    forestArea: {
      '2025': [
        {
          tableName: 'forestAreaChange',
          variableName: 'forestAreaNetChange',
          colName: '2020-2025',
        },
        {
          tableName: 'forestAreaWithinProtectedAreas',
          variableName: 'forest_area_within_protected_areas',
          colName: '2025',
        },
        {
          tableName: 'forestAreaWithinProtectedAreas',
          variableName: 'forest_area_with_long_term_management_plan',
          colName: '2025',
        },
      ],
    },
  },
}
```

The entire type is:
```ts
export type ValidationDependencyCache = {
  dependencies: DependencyRecord
  dependants: ValidationTargetsBySource
}
```

Dependencies are still kept as `DependencyRecord` because their current consumers only need to know what source variables/tables/cycles must be loaded, not which exact target cell triggered them.