### PR TITLE
5758 - Navigation: Data errors - All cols validations

### DIFF
--- a/src/meta/assessment/metaCache/index.ts
+++ b/src/meta/assessment/metaCache/index.ts
@@ -36,6 +36,9 @@ export type DependencyCache = {
   dependants: DependencyRecord
 }
 
+// Used by validation dependencies that read across all columns, such as maxForestArea().
+export const AllColumnsDependencyKey = '*'
+
 export type ValidationDependencyCache = {
   dependencies: DependencyRecord
   dependants: FullDependencyRecord

--- a/src/meta/assessment/metaCaches/index.ts
+++ b/src/meta/assessment/metaCaches/index.ts
@@ -30,6 +30,9 @@ type VariableProps = TableProps & {
 type ColProps = VariableProps & {
   colName: ColName
 }
+type ValidationsDependantsProps = ColProps & {
+  includeAllColumnsDependants: boolean
+}
 
 type DependencyTableCacheProps = Pick<VariableProps, 'tableName'> & { dependencyCache: DependencyCache }
 type DependencyCacheProps = Pick<VariableProps, 'variableName'> & DependencyTableCacheProps
@@ -88,20 +91,19 @@ const getTableValidationsDependants = (props: TableProps): ValidationTableDepend
   const { assessment, cycle, tableName } = props
   return getValidations({ assessment, cycle }).dependants[tableName] ?? {}
 }
-const getValidationsDependantsAtCol = (props: ColProps): VariableCacheList =>
-  getTableValidationsDependants(props)[props.variableName]?.[props.colName] ?? []
 
-const getValidationsDependants = (props: ColProps): VariableCacheList => {
-  const { colName } = props
-  const columnDependants = getValidationsDependantsAtCol(props)
+const getValidationsDependants = (props: ValidationsDependantsProps): VariableCacheList => {
+  const { colName, includeAllColumnsDependants, variableName } = props
+  const dependantsByCol = getTableValidationsDependants(props)[variableName] ?? {}
+  const columnDependants = dependantsByCol[colName] ?? []
 
   // Avoid adding the all-columns dependencies twice.
-  if (colName === AllColumnsDependencyKey) {
+  if (!includeAllColumnsDependants || colName === AllColumnsDependencyKey) {
     return columnDependants
   }
 
   // maxForestArea() and maxLandArea() depend on the source variable across all columns.
-  const allColumnsDependants = getValidationsDependantsAtCol({ ...props, colName: AllColumnsDependencyKey })
+  const allColumnsDependants = dependantsByCol[AllColumnsDependencyKey] ?? []
 
   return [...columnDependants, ...allColumnsDependants]
 }
@@ -163,8 +165,6 @@ export const AssessmentMetaCaches = {
   getVariablesByTables,
   getEnablersDependants,
   getEnablersDependencies,
-  getValidationsDependantsAtCol,
   getTableCalculationsDependencies,
-  getTableValidationsDependants,
   getTableValidationsDependencies,
 }

--- a/src/meta/assessment/metaCaches/index.ts
+++ b/src/meta/assessment/metaCaches/index.ts
@@ -88,18 +88,20 @@ const getTableValidationsDependants = (props: TableProps): ValidationTableDepend
   const { assessment, cycle, tableName } = props
   return getValidations({ assessment, cycle }).dependants[tableName] ?? {}
 }
+const getValidationsDependantsAtCol = (props: ColProps): VariableCacheList =>
+  getTableValidationsDependants(props)[props.variableName]?.[props.colName] ?? []
+
 const getValidationsDependants = (props: ColProps): VariableCacheList => {
-  const { colName, variableName } = props
-  const dependantsByCol = getTableValidationsDependants(props)?.[variableName] ?? {}
+  const { colName } = props
+  const columnDependants = getValidationsDependantsAtCol(props)
 
   // Avoid adding the all-columns dependencies twice.
   if (colName === AllColumnsDependencyKey) {
-    return dependantsByCol[colName] ?? []
+    return columnDependants
   }
 
-  const columnDependants = dependantsByCol[colName] ?? []
   // maxForestArea() and maxLandArea() depend on the source variable across all columns.
-  const allColumnsDependants = dependantsByCol[AllColumnsDependencyKey] ?? []
+  const allColumnsDependants = getValidationsDependantsAtCol({ ...props, colName: AllColumnsDependencyKey })
 
   return [...columnDependants, ...allColumnsDependants]
 }
@@ -161,6 +163,7 @@ export const AssessmentMetaCaches = {
   getVariablesByTables,
   getEnablersDependants,
   getEnablersDependencies,
+  getValidationsDependantsAtCol,
   getTableCalculationsDependencies,
   getTableValidationsDependants,
   getTableValidationsDependencies,

--- a/src/meta/assessment/metaCaches/index.ts
+++ b/src/meta/assessment/metaCaches/index.ts
@@ -3,6 +3,7 @@ import { Assessment } from 'meta/assessment/assessment'
 import { ColName } from 'meta/assessment/col'
 import { Cycle } from 'meta/assessment/cycle'
 import {
+  AllColumnsDependencyKey,
   AssessmentMetaCache,
   DependencyCache,
   DependencyRecord,
@@ -87,8 +88,21 @@ const getTableValidationsDependants = (props: TableProps): ValidationTableDepend
   const { assessment, cycle, tableName } = props
   return getValidations({ assessment, cycle }).dependants[tableName] ?? {}
 }
-const getValidationsDependants = (props: ColProps): VariableCacheList =>
-  getTableValidationsDependants(props)?.[props.variableName]?.[props.colName] ?? []
+const getValidationsDependants = (props: ColProps): VariableCacheList => {
+  const { colName, variableName } = props
+  const dependantsByCol = getTableValidationsDependants(props)?.[variableName] ?? {}
+
+  // Avoid adding the all-columns dependencies twice.
+  if (colName === AllColumnsDependencyKey) {
+    return dependantsByCol[colName] ?? []
+  }
+
+  const columnDependants = dependantsByCol[colName] ?? []
+  // maxForestArea() and maxLandArea() depend on the source variable across all columns.
+  const allColumnsDependants = dependantsByCol[AllColumnsDependencyKey] ?? []
+
+  return [...columnDependants, ...allColumnsDependants]
+}
 
 const getTableValidationsDependencies = (props: TableProps): TableDependencyRecord => {
   const { assessment, cycle, tableName } = props
@@ -148,5 +162,6 @@ export const AssessmentMetaCaches = {
   getEnablersDependants,
   getEnablersDependencies,
   getTableCalculationsDependencies,
+  getTableValidationsDependants,
   getTableValidationsDependencies,
 }

--- a/src/server/cache/repository/metaCache/generateMetaCache/dependencyEvaluator/evalDependencies/call.ts
+++ b/src/server/cache/repository/metaCache/generateMetaCache/dependencyEvaluator/evalDependencies/call.ts
@@ -2,7 +2,7 @@ import { ExpressionContext } from 'lib/expressionEvaluator/context'
 import type { CallExpression, ExpressionNode, IdentifierExpression } from 'lib/expressionEvaluator/node'
 import { ExpressionNodeEvaluator, ExpressionNodeType } from 'lib/expressionEvaluator/node'
 
-import { customDepenendencies } from 'server/cache/repository/metaCache/generateMetaCache/dependencyEvaluator/evalDependencies/customDepenendencies'
+import { customDependencies } from 'server/cache/repository/metaCache/generateMetaCache/dependencyEvaluator/evalDependencies/customDependencies'
 
 export class CallEvaluator<C extends ExpressionContext> extends ExpressionNodeEvaluator<C, CallExpression> {
   evaluate(expressionNode: CallExpression): any {
@@ -10,10 +10,10 @@ export class CallEvaluator<C extends ExpressionContext> extends ExpressionNodeEv
     const identifier = callee as unknown as IdentifierExpression
 
     // custom dependencies
-    if (Object.keys(customDepenendencies).includes(identifier?.name)) {
+    if (Object.keys(customDependencies).includes(identifier?.name)) {
       const name = (callee as unknown as IdentifierExpression)?.name
 
-      return this.evaluator.evaluateNode(customDepenendencies[name], this.context)
+      return this.evaluator.evaluateNode(customDependencies[name], this.context)
     }
 
     return `${this.evaluator.evaluateNode(

--- a/src/server/cache/repository/metaCache/generateMetaCache/dependencyEvaluator/evalDependencies/customDependencies.ts
+++ b/src/server/cache/repository/metaCache/generateMetaCache/dependencyEvaluator/evalDependencies/customDependencies.ts
@@ -1,6 +1,6 @@
 import { ExpressionNodeType, IdentifierExpression, MemberExpression } from 'lib/expressionEvaluator/node'
 
-export const customDepenendencies: Record<string, MemberExpression> = {
+export const customDependencies: Record<string, MemberExpression> = {
   maxForestArea: {
     type: 'MemberExpression' as ExpressionNodeType.Member,
     computed: false,

--- a/src/server/cache/repository/metaCache/generateMetaCache/dependencyEvaluator/evalDependencies/customDependencies.ts
+++ b/src/server/cache/repository/metaCache/generateMetaCache/dependencyEvaluator/evalDependencies/customDependencies.ts
@@ -1,28 +1,54 @@
-import { ExpressionNodeType, IdentifierExpression, MemberExpression } from 'lib/expressionEvaluator/node'
+import { AllColumnsDependencyKey } from 'meta/assessment/metaCache'
+import { TableNames } from 'meta/assessment/table'
+
+import {
+  ExpressionNodeType,
+  IdentifierExpression,
+  LiteralExpression,
+  MemberExpression,
+} from 'lib/expressionEvaluator/node'
 
 export const customDependencies: Record<string, MemberExpression> = {
   maxForestArea: {
     type: 'MemberExpression' as ExpressionNodeType.Member,
-    computed: false,
+    computed: true,
     object: {
-      type: 'Identifier' as ExpressionNodeType.Identifier,
-      name: 'extentOfForest',
-    } as IdentifierExpression,
+      type: 'MemberExpression' as ExpressionNodeType.Member,
+      computed: false,
+      object: {
+        type: 'Identifier' as ExpressionNodeType.Identifier,
+        name: TableNames.extentOfForest,
+      } as IdentifierExpression,
+      property: {
+        type: 'Identifier' as ExpressionNodeType.Identifier,
+        name: 'forestArea',
+      } as IdentifierExpression,
+    } as MemberExpression,
     property: {
-      type: 'Identifier' as ExpressionNodeType.Identifier,
-      name: 'forestArea',
-    } as IdentifierExpression,
+      type: 'Literal' as ExpressionNodeType.Literal,
+      raw: `'${AllColumnsDependencyKey}'`,
+      value: AllColumnsDependencyKey,
+    } as LiteralExpression,
   },
   maxLandArea: {
     type: 'MemberExpression' as ExpressionNodeType.Member,
-    computed: false,
+    computed: true,
     object: {
-      type: 'Identifier' as ExpressionNodeType.Identifier,
-      name: 'extentOfForest',
-    } as IdentifierExpression,
+      type: 'MemberExpression' as ExpressionNodeType.Member,
+      computed: false,
+      object: {
+        type: 'Identifier' as ExpressionNodeType.Identifier,
+        name: TableNames.extentOfForest,
+      } as IdentifierExpression,
+      property: {
+        type: 'Identifier' as ExpressionNodeType.Identifier,
+        name: 'totalLandArea',
+      } as IdentifierExpression,
+    } as MemberExpression,
     property: {
-      type: 'Identifier' as ExpressionNodeType.Identifier,
-      name: 'totalLandArea',
-    } as IdentifierExpression,
+      type: 'Literal' as ExpressionNodeType.Literal,
+      raw: `'${AllColumnsDependencyKey}'`,
+      value: AllColumnsDependencyKey,
+    } as LiteralExpression,
   },
 }

--- a/src/server/cache/repository/metaCache/generateMetaCache/dependencyEvaluator/evalDependencies/member.ts
+++ b/src/server/cache/repository/metaCache/generateMetaCache/dependencyEvaluator/evalDependencies/member.ts
@@ -63,8 +63,7 @@ export class MemberEvaluator extends ExpressionNodeEvaluator<Context, MemberExpr
         // Prevent validating nodes from other asessments/cycles
         if (assessment.props.name !== assessmentName || cycle.name !== cycleName) return
 
-        dependants =
-          AssessmentMetaCaches.getTableValidationsDependants(propsDependants)?.[variable.variableName]?.[colName] ?? []
+        dependants = AssessmentMetaCaches.getValidationsDependantsAtCol({ ...propsDependants, colName })
       }
       const external = assessmentName !== assessment.props.name
       const dependant: VariableCache = {

--- a/src/server/cache/repository/metaCache/generateMetaCache/dependencyEvaluator/evalDependencies/member.ts
+++ b/src/server/cache/repository/metaCache/generateMetaCache/dependencyEvaluator/evalDependencies/member.ts
@@ -63,7 +63,8 @@ export class MemberEvaluator extends ExpressionNodeEvaluator<Context, MemberExpr
         // Prevent validating nodes from other asessments/cycles
         if (assessment.props.name !== assessmentName || cycle.name !== cycleName) return
 
-        dependants = AssessmentMetaCaches.getValidationsDependants({ ...propsDependants, colName })
+        dependants =
+          AssessmentMetaCaches.getTableValidationsDependants(propsDependants)?.[variable.variableName]?.[colName] ?? []
       }
       const external = assessmentName !== assessment.props.name
       const dependant: VariableCache = {

--- a/src/server/cache/repository/metaCache/generateMetaCache/dependencyEvaluator/evalDependencies/member.ts
+++ b/src/server/cache/repository/metaCache/generateMetaCache/dependencyEvaluator/evalDependencies/member.ts
@@ -63,7 +63,11 @@ export class MemberEvaluator extends ExpressionNodeEvaluator<Context, MemberExpr
         // Prevent validating nodes from other asessments/cycles
         if (assessment.props.name !== assessmentName || cycle.name !== cycleName) return
 
-        dependants = AssessmentMetaCaches.getValidationsDependantsAtCol({ ...propsDependants, colName })
+        dependants = AssessmentMetaCaches.getValidationsDependants({
+          ...propsDependants,
+          colName,
+          includeAllColumnsDependants: false, // Graph generation must read only this column's dependants.
+        })
       }
       const external = assessmentName !== assessment.props.name
       const dependant: VariableCache = {

--- a/src/server/controller/cycleData/validations/context/contextFactory.ts
+++ b/src/server/controller/cycleData/validations/context/contextFactory.ts
@@ -59,6 +59,7 @@ export class ContextFactory extends BaseContextBuilder {
       assessment,
       cycle,
       colName: variable.colName,
+      includeAllColumnsDependants: true,
       tableName: variable.tableName,
       variableName: variable.variableName,
     })


### PR DESCRIPTION
Fixing validations for `maxForestArea()` and `maxLandArea()` by storing them as all-column validation dependencies in the meta cache.

Previously, these helpers were normal column-scoped dependencies, so editing `extentOfForest.forestArea['2025']` would not revalidate targets that used `maxForestArea()` in other years. e.g `disturbances.insects['2005']`. Now we store those helpers under an all-columns dependency (`*`), and validation lookup includes both exact column and all-column dependants.

Changes:

- Add `AllColumnsDependencyKey = '*'`
- Store `maxForestArea()` under `extentOfForest.forestArea['*']`
- Store `maxLandArea()` under `extentOfForest.totalLandArea['*']`
- Include `*` dependants during validation lookup
- Rename `customDepenendencies` to `customDependencies`


TODO in different PR: Test