### PR TITLE
5758 - Navigation: Data errors - Prevent stale data

### DIFF
--- a/src/server/cache/repository/validation/clearCountryValidations.ts
+++ b/src/server/cache/repository/validation/clearCountryValidations.ts
@@ -1,0 +1,21 @@
+import { CountryIso } from 'meta/area/countryIso'
+import { Assessment } from 'meta/assessment/assessment'
+import { Cycle } from 'meta/assessment/cycle'
+
+import { getKeyCountry, Keys } from 'server/cache/repository/keys'
+import { RedisData } from 'server/cache/repository/redisData'
+
+type Props = {
+  assessment: Assessment
+  countryIso: CountryIso
+  cycle: Cycle
+}
+
+export const clearCountryValidations = async (props: Props): Promise<void> => {
+  const { assessment, countryIso, cycle } = props
+
+  const redis = RedisData.getInstance()
+  const key = getKeyCountry({ assessment, countryIso, cycle, key: Keys.Data.validations })
+
+  await redis.del(key)
+}

--- a/src/server/cache/repository/validation/index.ts
+++ b/src/server/cache/repository/validation/index.ts
@@ -1,7 +1,9 @@
+import { clearCountryValidations } from 'server/cache/repository/validation/clearCountryValidations'
 import { getTableValidations } from 'server/cache/repository/validation/getTableValidations'
 import { setTableValidations } from 'server/cache/repository/validation/setTableValidations'
 
 export const ValidationRedisRepository = {
+  clearCountryValidations,
   getTableValidations,
   setTableValidations,
 }

--- a/src/server/controller/cycleData/validations/country/validateCountryTables.ts
+++ b/src/server/controller/cycleData/validations/country/validateCountryTables.ts
@@ -1,5 +1,6 @@
 import { CountryIso } from 'meta/area/countryIso'
 import { AssessmentName } from 'meta/assessment/assessment'
+import { Assessments } from 'meta/assessment/assessments'
 import { CycleName } from 'meta/assessment/cycle'
 
 import { TableRedisRepository } from 'server/cache/repository/table'
@@ -19,10 +20,9 @@ type Props = {
 export const validateCountryTables = async (props: Props, client: BaseProtocol = DB): Promise<void> => {
   const { assessmentName, countryIso, cycleName } = props
 
-  const { assessment, cycle } = await AssessmentController.getOneWithCycle(
-    { assessmentName, cycleName, metaCache: true },
-    client
-  )
+  const assessment = await AssessmentController.getOne({ assessmentName, metaCache: true }, client)
+  const cycle = Assessments.getCycle({ assessment, cycleName })
+
   const [country, tables] = await Promise.all([
     AreaController.getCountry({ assessment, countryIso, cycle }, client),
     TableRedisRepository.getManyRecord({ assessment, cycle }),

--- a/src/server/controller/cycleData/validations/country/validateCountryTables.ts
+++ b/src/server/controller/cycleData/validations/country/validateCountryTables.ts
@@ -3,9 +3,9 @@ import { AssessmentName } from 'meta/assessment/assessment'
 import { Assessments } from 'meta/assessment/assessments'
 import { CycleName } from 'meta/assessment/cycle'
 
+import { AreaRedisRepository } from 'server/cache/repository/area'
 import { TableRedisRepository } from 'server/cache/repository/table'
 import { ValidationRedisRepository } from 'server/cache/repository/validation'
-import { AreaController } from 'server/controller/area'
 import { AssessmentController } from 'server/controller/assessment'
 import { updateValidations } from 'server/controller/cycleData/validations/updateValidations'
 import { BaseProtocol, DB } from 'server/db/db'
@@ -25,7 +25,7 @@ export const validateCountryTables = async (props: Props, client: BaseProtocol =
   const cycle = Assessments.getCycle({ assessment, cycleName })
 
   const [country, tables] = await Promise.all([
-    AreaController.getCountry({ assessment, countryIso, cycle }, client),
+    AreaRedisRepository.getOneCountry({ assessment, countryIso, cycle }, client),
     TableRedisRepository.getManyRecord({ assessment, cycle }),
   ])
   const nodeUpdates = buildTablesNodeUpdates({ assessment, country, cycle, tables })

--- a/src/server/controller/cycleData/validations/country/validateCountryTables.ts
+++ b/src/server/controller/cycleData/validations/country/validateCountryTables.ts
@@ -4,6 +4,7 @@ import { Assessments } from 'meta/assessment/assessments'
 import { CycleName } from 'meta/assessment/cycle'
 
 import { TableRedisRepository } from 'server/cache/repository/table'
+import { ValidationRedisRepository } from 'server/cache/repository/validation'
 import { AreaController } from 'server/controller/area'
 import { AssessmentController } from 'server/controller/assessment'
 import { updateValidations } from 'server/controller/cycleData/validations/updateValidations'
@@ -28,6 +29,8 @@ export const validateCountryTables = async (props: Props, client: BaseProtocol =
     TableRedisRepository.getManyRecord({ assessment, cycle }),
   ])
   const nodeUpdates = buildTablesNodeUpdates({ assessment, country, cycle, tables })
+
+  await ValidationRedisRepository.clearCountryValidations({ assessment, countryIso, cycle })
 
   await updateValidations({
     assessment,


### PR DESCRIPTION
Clearing the country validation cache before rebuilding it.

Why:

`validateAll` only queues cells that currently have `validateFns`. If a validator is removed from metadata, cells that used to have that validator are no longer queued, so their old validation results are never revisited or cleared. That can leave stale errors in Redis after a full rebuild.


## Example

Suppose an older metadata version has a validator on:

```ts
tableA.oldVariable["2025"]
```

That validator fails, so Redis stores an error for the country:

```json
{
  "tableA": {
    "2025": {
      "oldVariable": { "valid": false }
    }
  }
}
```

Later, metadata changes and `oldVariable` no longer has that validator, or the variable is removed entirely.

When `validateAll` runs again, `buildTablesNodeUpdates` only queues cells with current `validateFns`, so `oldVariable` is never validated again. Because it is never queued, `updateValidations` never removes the old Redis entry.

The result is stale validation state: the table can still appear invalid in the left navigation or submit-to-review warning.

Fix: clearing validations before rebuilding them in `validateCountryTables`. 

