### PR TITLE
5758 - Navigation: Data errors - Descriptions - 1

### DIFF
--- a/src/meta/assessment/nodeValueValidation/index.ts
+++ b/src/meta/assessment/nodeValueValidation/index.ts
@@ -1,14 +1,10 @@
+import { Validation, ValidationMessage } from 'meta/assessment/validation/validation'
 import { ValidatorName } from 'meta/expressionEvaluator/validatorName'
 
-export type NodeValueValidationMessageParam = string | number | Array<string> | Array<number>
-
-export interface NodeValueValidationMessage {
+export interface NodeValueValidationMessage extends ValidationMessage {
   name: ValidatorName
-  key: string
-  params?: Record<string, NodeValueValidationMessageParam>
 }
 
-export interface NodeValueValidation {
-  valid: boolean
+export interface NodeValueValidation extends Validation {
   messages?: Array<NodeValueValidationMessage>
 }

--- a/src/meta/assessment/validation/validation.ts
+++ b/src/meta/assessment/validation/validation.ts
@@ -1,0 +1,12 @@
+export type ValidationMessageParam = string | number | Array<string> | Array<number>
+
+export interface ValidationMessage {
+  name?: string
+  key: string
+  params?: Record<string, ValidationMessageParam>
+}
+
+export interface Validation {
+  valid: boolean
+  messages?: Array<ValidationMessage>
+}

--- a/src/meta/validations/messageParser/getMessage.ts
+++ b/src/meta/validations/messageParser/getMessage.ts
@@ -1,6 +1,6 @@
 import { TFunction } from 'i18next'
 
-import { NodeValueValidationMessage } from 'meta/assessment/nodeValueValidation'
+import { ValidationMessage } from 'meta/assessment/validation/validation'
 import { ValidatorName } from 'meta/expressionEvaluator/validatorName'
 import { Objects } from 'utils/objects'
 
@@ -8,7 +8,7 @@ import { parseSumEqualTo, SumEqualToParams } from './sumEqualTo'
 import { parseSumSubCategories, SumSubCategoriesParams } from './sumSubCategories'
 import { translateParams } from './utils'
 
-export const getMessage = (t: TFunction, message: NodeValueValidationMessage): string => {
+export const getMessage = (t: TFunction, message: ValidationMessage): string => {
   const { key, params } = message
 
   if (Objects.isEmpty(params)) {

--- a/src/meta/validations/messageParser/sumEqualTo.ts
+++ b/src/meta/validations/messageParser/sumEqualTo.ts
@@ -1,13 +1,13 @@
 import { TFunction } from 'i18next'
 
-import { NodeValueValidationMessageParam } from 'meta/assessment/nodeValueValidation'
+import { ValidationMessageParam } from 'meta/assessment/validation/validation'
 
 import { translateParam } from './utils'
 
 export type SumEqualToParams = {
-  categoriesSum: NodeValueValidationMessageParam
+  categoriesSum: ValidationMessageParam
   categoryLabelKeys: Array<string>
-  maxValue: NodeValueValidationMessageParam
+  maxValue: ValidationMessageParam
 }
 
 export const parseSumEqualTo = (t: TFunction, params: SumEqualToParams): Record<string, string> => {

--- a/src/meta/validations/messageParser/sumSubCategories.ts
+++ b/src/meta/validations/messageParser/sumSubCategories.ts
@@ -1,17 +1,17 @@
 import { TFunction } from 'i18next'
 
-import { NodeValueValidationMessageParam } from 'meta/assessment/nodeValueValidation'
+import { ValidationMessageParam } from 'meta/assessment/validation/validation'
 
 import { translateParam } from './utils'
 
 export type SumSubCategoriesParams = {
-  categoriesSum: NodeValueValidationMessageParam
+  categoriesSum: ValidationMessageParam
   categoryLabelKeys: Array<string>
   parentColLabelKey?: string
   parentLabelKey: string
   parentLabelParams?: string
   parentTableAnchor: string
-  parentValue: NodeValueValidationMessageParam
+  parentValue: ValidationMessageParam
 }
 
 export const parseSumSubCategories = (t: TFunction, params: SumSubCategoriesParams): Record<string, string> => {

--- a/src/meta/validations/messageParser/utils.ts
+++ b/src/meta/validations/messageParser/utils.ts
@@ -1,9 +1,9 @@
 import { TFunction } from 'i18next'
 
-import { NodeValueValidationMessageParam } from 'meta/assessment/nodeValueValidation'
+import { ValidationMessageParam } from 'meta/assessment/validation/validation'
 import { Objects } from 'utils/objects'
 
-export const translateParam = (t: TFunction, param: NodeValueValidationMessageParam): string => {
+export const translateParam = (t: TFunction, param: ValidationMessageParam): string => {
   if (Array.isArray(param)) {
     return `(${param.map((item) => translateParam(t, item)).join(', ')})`
   }
@@ -13,7 +13,7 @@ export const translateParam = (t: TFunction, param: NodeValueValidationMessagePa
 
 export const translateParams = (
   t: TFunction,
-  params?: Record<string, NodeValueValidationMessageParam>
+  params?: Record<string, ValidationMessageParam>
 ): Record<string, string> | undefined => {
   if (Objects.isEmpty(params)) {
     return undefined


### PR DESCRIPTION
Adding a general type in `src/meta/assessment/validation/validation.ts` because `NodeValueValidation` is too specific to be used for descriptions and for ODPs eventually. Better have a generic `Validation` and `ValidationMessage` that we can use across nodes, descriptions, odp. 