### PR TITLE
5758 - Navigation: Data errors - Descriptions - 5

### DIFF
--- a/src/server/controller/cycleData/links/getActiveVerifyJob.ts
+++ b/src/server/controller/cycleData/links/getActiveVerifyJob.ts
@@ -4,8 +4,8 @@ import { CountryIso } from 'meta/area/countryIso'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 
-import { VisitCycleLinksProps } from 'server/worker/tasks/verifyLinks/visitCycleLinks/props'
-import { VisitCycleLinksQueueFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory'
+import { VerifyAllLinksJobProps } from 'server/worker/tasks/verifyLinks/visitCycleLinks/props'
+import { VerifyLinksQueueFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory'
 
 type Props = {
   assessment: Assessment
@@ -13,6 +13,6 @@ type Props = {
   cycle: Cycle
 }
 
-export const getActiveVerifyJob = async (props: Props): Promise<Job<VisitCycleLinksProps> | null> => {
-  return VisitCycleLinksQueueFactory.getQueuedOrActiveJob(props)
+export const getActiveVerifyJob = async (props: Props): Promise<Job<VerifyAllLinksJobProps> | null> => {
+  return VerifyLinksQueueFactory.getQueuedOrActiveVerifyAllLinksJob(props)
 }

--- a/src/server/worker/cronJobs/notifyLinksInvalid.ts
+++ b/src/server/worker/cronJobs/notifyLinksInvalid.ts
@@ -10,7 +10,7 @@ import { MailService } from 'server/service'
 import { ProcessEnv } from 'server/utils'
 import { Job } from 'server/worker/job/job'
 import { triggerVerifyLinksWorker } from 'server/worker/tasks/verifyLinks/triggerVerifyLinksWorker'
-import { VisitCycleLinksQueueFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory'
+import { VerifyLinksQueueFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory'
 
 const name = 'Scheduler-NotifyLinksInvalid'
 const cycleName = CycleNames.latest
@@ -30,12 +30,12 @@ export class NotifyLinksInvalid extends Job {
     const user = await UserController.getUserRobot()
 
     // get existing job or create new job and process it
-    const existingJob = await VisitCycleLinksQueueFactory.getQueuedOrActiveJob({ assessment, cycle })
+    const existingJob = await VerifyLinksQueueFactory.getQueuedOrActiveVerifyAllLinksJob({ assessment, cycle })
     const job = existingJob ?? (await CycleDataController.Links.verify({ assessment, cycle, user }))
     await triggerVerifyLinksWorker()
 
     const connection = { url: ProcessEnv.redisQueueUrl }
-    const queueEvents = new QueueEvents(VisitCycleLinksQueueFactory.queueName, { connection })
+    const queueEvents = new QueueEvents(VerifyLinksQueueFactory.queueName, { connection })
 
     try {
       await job.waitUntilFinished(queueEvents)

--- a/src/server/worker/tasks/verifyLinks/jobNames.ts
+++ b/src/server/worker/tasks/verifyLinks/jobNames.ts
@@ -1,0 +1,4 @@
+export enum VerifyLinksJobName {
+  verifyAllLinks = 'verifyAllLinks',
+  verifyDescriptionLinks = 'verifyDescriptionLinks',
+}

--- a/src/server/worker/tasks/verifyLinks/props.ts
+++ b/src/server/worker/tasks/verifyLinks/props.ts
@@ -1,0 +1,8 @@
+import { Job } from 'bullmq'
+
+import { VisitCycleLinksProps } from 'server/worker/tasks/verifyLinks/visitCycleLinks/props'
+import { VisitDescriptionLinksProps } from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/props'
+
+export type VerifyLinksQueueProps = VisitCycleLinksProps | VisitDescriptionLinksProps
+
+export type VerifyLinksQueueJob = Job<VerifyLinksQueueProps>

--- a/src/server/worker/tasks/verifyLinks/props.ts
+++ b/src/server/worker/tasks/verifyLinks/props.ts
@@ -1,8 +1,8 @@
 import { Job } from 'bullmq'
 
-import { VisitCycleLinksProps } from 'server/worker/tasks/verifyLinks/visitCycleLinks/props'
-import { VisitDescriptionLinksProps } from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/props'
+import { VerifyAllLinksJobProps } from 'server/worker/tasks/verifyLinks/visitCycleLinks/props'
+import { VerifyDescriptionLinksJobProps } from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/props'
 
-export type VerifyLinksQueueProps = VisitCycleLinksProps | VisitDescriptionLinksProps
+export type VerifyLinksQueueProps = VerifyAllLinksJobProps | VerifyDescriptionLinksJobProps
 
 export type VerifyLinksQueueJob = Job<VerifyLinksQueueProps>

--- a/src/server/worker/tasks/verifyLinks/verifyLinksJob.ts
+++ b/src/server/worker/tasks/verifyLinks/verifyLinksJob.ts
@@ -4,7 +4,7 @@ import { Cycle } from 'meta/assessment/cycle'
 
 import { Job } from 'server/worker/job/job'
 import { JobStatus } from 'server/worker/job/jobStatus'
-import { VisitCycleLinksJob } from 'server/worker/tasks/verifyLinks/visitCycleLinks/props'
+import { VerifyAllLinksJob } from 'server/worker/tasks/verifyLinks/visitCycleLinks/props'
 import workerProcessor from 'server/worker/tasks/verifyLinks/visitCycleLinks/worker'
 
 type VerifyLinksJobContext = {
@@ -16,7 +16,7 @@ type VerifyLinksJobContext = {
 const jobNamePrefix = 'VerifyLinks'
 
 export class VerifyLinksJob extends Job {
-  #queueJob?: VisitCycleLinksJob
+  #queueJob?: VerifyAllLinksJob
 
   public constructor(context: VerifyLinksJobContext) {
     super(VerifyLinksJob.getJobName(context))
@@ -28,7 +28,7 @@ export class VerifyLinksJob extends Job {
     return countryIso ? `${baseJobName}/${countryIso}` : baseJobName
   }
 
-  public async runFromQueue(job: VisitCycleLinksJob): Promise<void> {
+  public async runFromQueue(job: VerifyAllLinksJob): Promise<void> {
     const jobId = job.id?.toString()
     this.#queueJob = job
 

--- a/src/server/worker/tasks/verifyLinks/visitCycleLinks/props.ts
+++ b/src/server/worker/tasks/verifyLinks/visitCycleLinks/props.ts
@@ -7,11 +7,11 @@ import { User } from 'meta/user/user'
 
 import { VerifyLinksJobName } from 'server/worker/tasks/verifyLinks/jobNames'
 
-export type VisitCycleLinksProps = {
+export type VerifyAllLinksJobProps = {
   assessment: Assessment
   countryIso?: CountryIso
   cycle: Cycle
   user: User
 }
 
-export type VisitCycleLinksJob = Job<VisitCycleLinksProps, void, typeof VerifyLinksJobName.verifyAllLinks>
+export type VerifyAllLinksJob = Job<VerifyAllLinksJobProps, void, typeof VerifyLinksJobName.verifyAllLinks>

--- a/src/server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory.ts
+++ b/src/server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory.ts
@@ -1,4 +1,4 @@
-import { Job, Queue, QueueOptions } from 'bullmq'
+import { Queue, QueueOptions } from 'bullmq'
 import IORedis from 'ioredis'
 
 import { CountryIso } from 'meta/area/countryIso'
@@ -6,16 +6,17 @@ import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 
 import { ProcessEnv } from 'server/utils'
-
-import { VisitCycleLinksProps } from './props'
+import { VerifyLinksJobName } from 'server/worker/tasks/verifyLinks/jobNames'
+import { VerifyLinksQueueProps } from 'server/worker/tasks/verifyLinks/props'
+import { VerifyAllLinksJob } from 'server/worker/tasks/verifyLinks/visitCycleLinks/props'
 
 const queueName = 'verifyLinks'
-let queue: Queue<VisitCycleLinksProps> | undefined
+let queue: Queue<VerifyLinksQueueProps> | undefined
 
 const connection = new IORedis(ProcessEnv.redisQueueUrl)
 connection.options.maxRetriesPerRequest = null
 
-type Props = {
+type VerifyAllLinksJobScope = {
   assessment: Assessment
   countryIso?: CountryIso
   cycle: Cycle
@@ -26,36 +27,37 @@ const opts: QueueOptions = {
   streams: { events: { maxLen: 1 } },
 }
 
-const getInstance = (): Queue<VisitCycleLinksProps> => {
+const getInstance = (): Queue<VerifyLinksQueueProps> => {
   if (queue) return queue
 
-  queue = new Queue<VisitCycleLinksProps>(queueName, opts)
+  queue = new Queue<VerifyLinksQueueProps>(queueName, opts)
   return queue
 }
 
-const getJobId = (props: Props): string => {
+const getVerifyAllLinksJobId = (props: VerifyAllLinksJobScope): string => {
   const { assessment, countryIso, cycle } = props
 
-  // Job ID with assessment/cycle to avoid requests from enqueuing duplicates.
+  // Verify-all job ID with assessment/cycle to avoid requests from enqueuing duplicates.
   const baseJobId = `verifyLinks/${assessment.props.name}/${cycle.name}`
   return countryIso ? `${baseJobId}/${countryIso}` : baseJobId
 }
 
 const activeStates = ['active', 'delayed', 'paused', 'waiting', 'waiting-children']
 
-const getQueuedOrActiveJob = async (props: Props): Promise<Job<VisitCycleLinksProps> | null> => {
+const getQueuedOrActiveVerifyAllLinksJob = async (props: VerifyAllLinksJobScope): Promise<VerifyAllLinksJob | null> => {
   const queueInstance = getInstance()
-  const job = await queueInstance.getJob(getJobId(props))
+  const job = await queueInstance.getJob(getVerifyAllLinksJobId(props))
   if (!job) return null
+  if (job.name !== VerifyLinksJobName.verifyAllLinks) return null
 
   const state = await job.getState()
-  return activeStates.includes(state) ? job : null
+  return activeStates.includes(state) ? (job as VerifyAllLinksJob) : null
 }
 
-export const VisitCycleLinksQueueFactory = {
+export const VerifyLinksQueueFactory = {
   connection,
   getInstance,
-  getJobId,
-  getQueuedOrActiveJob,
+  getVerifyAllLinksJobId,
+  getQueuedOrActiveVerifyAllLinksJob,
   queueName,
 }

--- a/src/server/worker/tasks/verifyLinks/visitCycleLinks/visitCycleLinks.ts
+++ b/src/server/worker/tasks/verifyLinks/visitCycleLinks/visitCycleLinks.ts
@@ -7,8 +7,8 @@ import { Logger } from 'server/utils/logger'
 import { VerifyLinksJobName } from 'server/worker/tasks/verifyLinks/jobNames'
 import { VerifyLinksJob } from 'server/worker/tasks/verifyLinks/verifyLinksJob'
 
-import { VisitCycleLinksProps } from './props'
-import { VisitCycleLinksQueueFactory } from './queueFactory'
+import { VerifyAllLinksJobProps } from './props'
+import { VerifyLinksQueueFactory } from './queueFactory'
 
 const jobOptions: JobsOptions = {
   attempts: 1,
@@ -16,14 +16,14 @@ const jobOptions: JobsOptions = {
   removeOnFail: true,
 }
 
-export const visitCycleLinks = async (props: VisitCycleLinksProps): Promise<Job | undefined> => {
+export const visitCycleLinks = async (props: VerifyAllLinksJobProps): Promise<Job | undefined> => {
   const { assessment, countryIso, cycle } = props
   const scope = countryIso
     ? `${assessment.props.name} / ${cycle.name} / ${countryIso}`
     : `${assessment.props.name} / ${cycle.name}`
 
   // Skip if a verification job is already active.
-  const activeJob = await VisitCycleLinksQueueFactory.getQueuedOrActiveJob(props)
+  const activeJob = await VerifyLinksQueueFactory.getQueuedOrActiveVerifyAllLinksJob(props)
   const isVerificationInProgress = Boolean(activeJob)
 
   if (isVerificationInProgress) {
@@ -31,9 +31,9 @@ export const visitCycleLinks = async (props: VisitCycleLinksProps): Promise<Job 
     return undefined
   }
 
-  const queue = VisitCycleLinksQueueFactory.getInstance()
+  const queue = VerifyLinksQueueFactory.getInstance()
   // Job ID is scoped by assessment/cycle so concurrent requests collapse to one job.
-  const jobId = VisitCycleLinksQueueFactory.getJobId({ assessment, countryIso, cycle })
+  const jobId = VerifyLinksQueueFactory.getVerifyAllLinksJobId({ assessment, countryIso, cycle })
   const job = await queue.add(VerifyLinksJobName.verifyAllLinks, props, { ...jobOptions, jobId })
 
   const verifyLinksJob = new VerifyLinksJob({ assessment, countryIso, cycle })

--- a/src/server/worker/tasks/verifyLinks/visitCycleLinks/visitCycleLinks.ts
+++ b/src/server/worker/tasks/verifyLinks/visitCycleLinks/visitCycleLinks.ts
@@ -4,6 +4,7 @@ import { Sockets } from 'meta/socket/sockets'
 
 import { SocketServer } from 'server/service/socket'
 import { Logger } from 'server/utils/logger'
+import { VerifyLinksJobName } from 'server/worker/tasks/verifyLinks/jobNames'
 import { VerifyLinksJob } from 'server/worker/tasks/verifyLinks/verifyLinksJob'
 
 import { VisitCycleLinksProps } from './props'
@@ -15,7 +16,7 @@ const jobOptions: JobsOptions = {
   removeOnFail: true,
 }
 
-export const visitCycleLinks = async (props: VisitCycleLinksProps): Promise<Job<VisitCycleLinksProps> | undefined> => {
+export const visitCycleLinks = async (props: VisitCycleLinksProps): Promise<Job | undefined> => {
   const { assessment, countryIso, cycle } = props
   const scope = countryIso
     ? `${assessment.props.name} / ${cycle.name} / ${countryIso}`
@@ -33,7 +34,7 @@ export const visitCycleLinks = async (props: VisitCycleLinksProps): Promise<Job<
   const queue = VisitCycleLinksQueueFactory.getInstance()
   // Job ID is scoped by assessment/cycle so concurrent requests collapse to one job.
   const jobId = VisitCycleLinksQueueFactory.getJobId({ assessment, countryIso, cycle })
-  const job = await queue.add('verifyLinks', props, { ...jobOptions, jobId })
+  const job = await queue.add(VerifyLinksJobName.verifyAllLinks, props, { ...jobOptions, jobId })
 
   const verifyLinksJob = new VerifyLinksJob({ assessment, countryIso, cycle })
   await verifyLinksJob.setQueued(job.id?.toString())

--- a/src/server/worker/tasks/verifyLinks/visitCycleLinks/worker.ts
+++ b/src/server/worker/tasks/verifyLinks/visitCycleLinks/worker.ts
@@ -9,9 +9,9 @@ import { Logger } from 'server/utils/logger'
 import { filterLinks } from './utils/filterLinks'
 import { mergeLinks } from './utils/mergeLinks'
 import { visitLinks } from './utils/visitLinks'
-import { VisitCycleLinksJob } from './props'
+import { VerifyAllLinksJob } from './props'
 
-const _getLogKey = (job: VisitCycleLinksJob): string => {
+const _getLogKey = (job: VerifyAllLinksJob): string => {
   const { assessment, countryIso, cycle } = job.data
 
   const assessmentName = assessment.props.name
@@ -20,7 +20,7 @@ const _getLogKey = (job: VisitCycleLinksJob): string => {
   return `[visitCycleLinks-workerThread] [${scope}] [job-${job.id}]`
 }
 
-export default async (job: VisitCycleLinksJob): Promise<void> => {
+export default async (job: VerifyAllLinksJob): Promise<void> => {
   const logKey = _getLogKey(job)
   try {
     const { assessment, countryIso, cycle, user } = job.data

--- a/src/server/worker/tasks/verifyLinks/visitCycleLinks/workerFactory.ts
+++ b/src/server/worker/tasks/verifyLinks/visitCycleLinks/workerFactory.ts
@@ -12,8 +12,10 @@ import { ActivityLogRepository } from 'server/db/repository/public/activityLog'
 import { SocketServer } from 'server/service/socket'
 import { ProcessEnv } from 'server/utils'
 import { Logger } from 'server/utils/logger'
+import { VerifyLinksJobName } from 'server/worker/tasks/verifyLinks/jobNames'
+import { VerifyLinksQueueJob, VerifyLinksQueueProps } from 'server/worker/tasks/verifyLinks/props'
 
-import { VisitCycleLinksJob, VisitCycleLinksProps } from './props'
+import { VisitCycleLinksJob } from './props'
 
 const connection = new IORedis(ProcessEnv.redisQueueUrl)
 connection.options.maxRetriesPerRequest = null
@@ -36,7 +38,7 @@ type EmitEventProps = {
 }
 
 // BullMQ accepts either a processor function (dev) or a path to compiled JS (prod).
-type VisitCycleLinksProcessor = string | ((job: VisitCycleLinksJob) => Promise<void>)
+type VisitCycleLinksProcessor = string | ((job: VerifyLinksQueueJob) => Promise<void>)
 
 const _emitEvent = (props: EmitEventProps): void => {
   const { assessment, countryIso, cycle, event } = props
@@ -48,21 +50,31 @@ const _emitEvent = (props: EmitEventProps): void => {
   SocketServer.emit(linksVerificationEvent, { event })
 }
 
-const newInstance = (props: { key: string; processor: VisitCycleLinksProcessor }): Worker<VisitCycleLinksProps> => {
+const _isVerifyAllLinksJob = (job: VerifyLinksQueueJob): job is VisitCycleLinksJob =>
+  job.name === VerifyLinksJobName.verifyAllLinks
+
+const newInstance = (props: { key: string; processor: VisitCycleLinksProcessor }): Worker<VerifyLinksQueueProps> => {
   const { key, processor } = props
 
-  const worker = new Worker<VisitCycleLinksProps>(key, processor, workerOptions)
+  const worker = new Worker<VerifyLinksQueueProps>(key, processor, workerOptions)
 
   worker.on('error', (error) => {
     Logger.error(`[visitCycleLinks-worker] job error ${error}`)
   })
 
   worker.on('active', async (job) => {
+    if (!_isVerifyAllLinksJob(job)) return
+
     const { assessment, countryIso, cycle } = job.data
     _emitEvent({ assessment, countryIso, cycle, event: 'active' })
   })
 
   worker.on('completed', async (job) => {
+    if (!_isVerifyAllLinksJob(job)) {
+      Logger.debug(`[visitDescriptionLinks-worker] [job-${job.id}] completed`)
+      return
+    }
+
     const { assessment, countryIso, cycle, user } = job.data
 
     _emitEvent({ assessment, countryIso, cycle, event: 'completed' })
@@ -78,6 +90,11 @@ const newInstance = (props: { key: string; processor: VisitCycleLinksProcessor }
   })
 
   worker.on('failed', async (job, error) => {
+    if (!job || !_isVerifyAllLinksJob(job)) {
+      Logger.debug(`[visitDescriptionLinks-worker] job failed with error: ${error}`)
+      return
+    }
+
     const { assessment, countryIso, cycle, user } = job.data
 
     _emitEvent({ assessment, countryIso, cycle, event: 'failed' })

--- a/src/server/worker/tasks/verifyLinks/visitCycleLinks/workerFactory.ts
+++ b/src/server/worker/tasks/verifyLinks/visitCycleLinks/workerFactory.ts
@@ -15,7 +15,7 @@ import { Logger } from 'server/utils/logger'
 import { VerifyLinksJobName } from 'server/worker/tasks/verifyLinks/jobNames'
 import { VerifyLinksQueueJob, VerifyLinksQueueProps } from 'server/worker/tasks/verifyLinks/props'
 
-import { VisitCycleLinksJob } from './props'
+import { VerifyAllLinksJob } from './props'
 
 const connection = new IORedis(ProcessEnv.redisQueueUrl)
 connection.options.maxRetriesPerRequest = null
@@ -38,7 +38,7 @@ type EmitEventProps = {
 }
 
 // BullMQ accepts either a processor function (dev) or a path to compiled JS (prod).
-type VisitCycleLinksProcessor = string | ((job: VerifyLinksQueueJob) => Promise<void>)
+type VerifyLinksProcessor = string | ((job: VerifyLinksQueueJob) => Promise<void>)
 
 const _emitEvent = (props: EmitEventProps): void => {
   const { assessment, countryIso, cycle, event } = props
@@ -50,10 +50,10 @@ const _emitEvent = (props: EmitEventProps): void => {
   SocketServer.emit(linksVerificationEvent, { event })
 }
 
-const _isVerifyAllLinksJob = (job: VerifyLinksQueueJob): job is VisitCycleLinksJob =>
+const _isVerifyAllLinksJob = (job: VerifyLinksQueueJob): job is VerifyAllLinksJob =>
   job.name === VerifyLinksJobName.verifyAllLinks
 
-const newInstance = (props: { key: string; processor: VisitCycleLinksProcessor }): Worker<VerifyLinksQueueProps> => {
+const newInstance = (props: { key: string; processor: VerifyLinksProcessor }): Worker<VerifyLinksQueueProps> => {
   const { key, processor } = props
 
   const worker = new Worker<VerifyLinksQueueProps>(key, processor, workerOptions)

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/props.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/props.ts
@@ -3,15 +3,18 @@ import { Job } from 'bullmq'
 import { CountryIso } from 'meta/area/countryIso'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
-import { User } from 'meta/user/user'
 
 import { VerifyLinksJobName } from 'server/worker/tasks/verifyLinks/jobNames'
 
-export type VisitCycleLinksProps = {
+export type VisitDescriptionLinksProps = {
   assessment: Assessment
-  countryIso?: CountryIso
+  countryIso: CountryIso
   cycle: Cycle
-  user: User
+  descriptionIds: Array<number>
 }
 
-export type VisitCycleLinksJob = Job<VisitCycleLinksProps, void, typeof VerifyLinksJobName.verifyAllLinks>
+export type VisitDescriptionLinksJob = Job<
+  VisitDescriptionLinksProps,
+  void,
+  typeof VerifyLinksJobName.verifyDescriptionLinks
+>

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/props.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/props.ts
@@ -6,15 +6,15 @@ import { Cycle } from 'meta/assessment/cycle'
 
 import { VerifyLinksJobName } from 'server/worker/tasks/verifyLinks/jobNames'
 
-export type VisitDescriptionLinksProps = {
+export type VerifyDescriptionLinksJobProps = {
   assessment: Assessment
   countryIso: CountryIso
   cycle: Cycle
   descriptionIds: Array<number>
 }
 
-export type VisitDescriptionLinksJob = Job<
-  VisitDescriptionLinksProps,
+export type VerifyDescriptionLinksJob = Job<
+  VerifyDescriptionLinksJobProps,
   void,
   typeof VerifyLinksJobName.verifyDescriptionLinks
 >

--- a/src/server/worker/tasks/verifyLinks/workerRuntime/idleMonitor.ts
+++ b/src/server/worker/tasks/verifyLinks/workerRuntime/idleMonitor.ts
@@ -1,6 +1,6 @@
 import { Queue } from 'bullmq'
 
-import { VisitCycleLinksProps } from 'server/worker/tasks/verifyLinks/visitCycleLinks/props'
+import { VerifyLinksQueueProps } from 'server/worker/tasks/verifyLinks/props'
 
 // Idle grace period to keep dyno alive briefly for possible new incoming jobs.
 const idleGraceMs = 60 * 1000
@@ -11,7 +11,7 @@ type Props = {
   exitOnIdle: boolean
   isShuttingDown: () => boolean
   onIdle: () => Promise<void>
-  queue: Queue<VisitCycleLinksProps>
+  queue: Queue<VerifyLinksQueueProps>
 }
 
 type VerifyLinksIdleMonitor = {

--- a/src/server/worker/tasks/verifyLinks/workerRuntime/processor.ts
+++ b/src/server/worker/tasks/verifyLinks/workerRuntime/processor.ts
@@ -1,8 +1,17 @@
+import { VerifyLinksJobName } from 'server/worker/tasks/verifyLinks/jobNames'
+// import { VisitDescriptionLinksJob } from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/props'
+// import visitDescriptionLinksWorker from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/worker'
+import { VerifyLinksQueueJob } from 'server/worker/tasks/verifyLinks/props'
 import { VerifyLinksJob } from 'server/worker/tasks/verifyLinks/verifyLinksJob'
 import { VisitCycleLinksJob } from 'server/worker/tasks/verifyLinks/visitCycleLinks/props'
 
-export const verifyLinksWorkerProcessor = async (job: VisitCycleLinksJob): Promise<void> => {
-  const { assessment, countryIso, cycle } = job.data
+export const verifyLinksWorkerProcessor = async (job: VerifyLinksQueueJob): Promise<void> => {
+  if (job.name === VerifyLinksJobName.verifyDescriptionLinks) {
+    // TODO: await visitDescriptionLinksWorker(job as VisitDescriptionLinksJob)
+    return
+  }
+
+  const { assessment, countryIso, cycle } = (job as VisitCycleLinksJob).data
   const verifyLinksJob = new VerifyLinksJob({ assessment, countryIso, cycle })
-  await verifyLinksJob.runFromQueue(job)
+  await verifyLinksJob.runFromQueue(job as VisitCycleLinksJob)
 }

--- a/src/server/worker/tasks/verifyLinks/workerRuntime/processor.ts
+++ b/src/server/worker/tasks/verifyLinks/workerRuntime/processor.ts
@@ -1,17 +1,17 @@
 import { VerifyLinksJobName } from 'server/worker/tasks/verifyLinks/jobNames'
-// import { VisitDescriptionLinksJob } from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/props'
+// import { VerifyDescriptionLinksJob } from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/props'
 // import visitDescriptionLinksWorker from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/worker'
 import { VerifyLinksQueueJob } from 'server/worker/tasks/verifyLinks/props'
 import { VerifyLinksJob } from 'server/worker/tasks/verifyLinks/verifyLinksJob'
-import { VisitCycleLinksJob } from 'server/worker/tasks/verifyLinks/visitCycleLinks/props'
+import { VerifyAllLinksJob } from 'server/worker/tasks/verifyLinks/visitCycleLinks/props'
 
 export const verifyLinksWorkerProcessor = async (job: VerifyLinksQueueJob): Promise<void> => {
   if (job.name === VerifyLinksJobName.verifyDescriptionLinks) {
-    // TODO: await visitDescriptionLinksWorker(job as VisitDescriptionLinksJob)
+    // TODO: await visitDescriptionLinksWorker(job as VerifyDescriptionLinksJob)
     return
   }
 
-  const { assessment, countryIso, cycle } = (job as VisitCycleLinksJob).data
+  const { assessment, countryIso, cycle } = (job as VerifyAllLinksJob).data
   const verifyLinksJob = new VerifyLinksJob({ assessment, countryIso, cycle })
-  await verifyLinksJob.runFromQueue(job as VisitCycleLinksJob)
+  await verifyLinksJob.runFromQueue(job as VerifyAllLinksJob)
 }

--- a/src/server/worker/tasks/verifyLinks/workerRuntime/runtime.ts
+++ b/src/server/worker/tasks/verifyLinks/workerRuntime/runtime.ts
@@ -2,7 +2,7 @@ import http from 'http'
 
 import { SocketServer } from 'server/service/socket'
 import { VerifyLinksWorkerPresence } from 'server/worker/tasks/verifyLinks/verifyLinksWorkerPresence'
-import { VisitCycleLinksQueueFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory'
+import { VerifyLinksQueueFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory'
 import { WorkerFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/workerFactory'
 
 import { startVerifyLinksWorkerHeartbeat } from './heartbeat'
@@ -18,7 +18,7 @@ type Props = {
 export const startVerifyLinksWorkerRuntime = async (props: Props): Promise<void> => {
   const { exitOnIdle, workerId } = props
 
-  const queue = VisitCycleLinksQueueFactory.getInstance()
+  const queue = VerifyLinksQueueFactory.getInstance()
 
   // Init SocketServer only for the worker dyno so it can emit events.
   if (exitOnIdle) {
@@ -31,7 +31,7 @@ export const startVerifyLinksWorkerRuntime = async (props: Props): Promise<void>
   const heartbeatInterval = startVerifyLinksWorkerHeartbeat({ workerId })
 
   const worker = WorkerFactory.newInstance({
-    key: VisitCycleLinksQueueFactory.queueName,
+    key: VerifyLinksQueueFactory.queueName,
     processor: verifyLinksWorkerProcessor,
   })
 

--- a/src/server/worker/tasks/verifyLinks/workerRuntime/shutdown.ts
+++ b/src/server/worker/tasks/verifyLinks/workerRuntime/shutdown.ts
@@ -3,7 +3,7 @@ import { Queue, Worker } from 'bullmq'
 import { Logger } from 'server/utils/logger'
 import { VerifyLinksQueueProps } from 'server/worker/tasks/verifyLinks/props'
 import { VerifyLinksWorkerPresence } from 'server/worker/tasks/verifyLinks/verifyLinksWorkerPresence'
-import { VisitCycleLinksQueueFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory'
+import { VerifyLinksQueueFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory'
 import { WorkerFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/workerFactory'
 
 type Props = {
@@ -25,7 +25,7 @@ export const shutdownVerifyLinksWorker = async (props: Props): Promise<void> => 
     VerifyLinksWorkerPresence.clearWorkerLock(),
     queue.close(),
     VerifyLinksWorkerPresence.disconnect(),
-    VisitCycleLinksQueueFactory.connection.quit(),
+    VerifyLinksQueueFactory.connection.quit(),
     WorkerFactory.connection.quit(),
   ])
 

--- a/src/server/worker/tasks/verifyLinks/workerRuntime/shutdown.ts
+++ b/src/server/worker/tasks/verifyLinks/workerRuntime/shutdown.ts
@@ -1,16 +1,16 @@
 import { Queue, Worker } from 'bullmq'
 
 import { Logger } from 'server/utils/logger'
+import { VerifyLinksQueueProps } from 'server/worker/tasks/verifyLinks/props'
 import { VerifyLinksWorkerPresence } from 'server/worker/tasks/verifyLinks/verifyLinksWorkerPresence'
-import { VisitCycleLinksProps } from 'server/worker/tasks/verifyLinks/visitCycleLinks/props'
 import { VisitCycleLinksQueueFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory'
 import { WorkerFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/workerFactory'
 
 type Props = {
   exitOnIdle: boolean
-  queue: Queue<VisitCycleLinksProps>
+  queue: Queue<VerifyLinksQueueProps>
   reason: string
-  worker: Worker<VisitCycleLinksProps>
+  worker: Worker<VerifyLinksQueueProps>
 }
 
 export const shutdownVerifyLinksWorker = async (props: Props): Promise<void> => {

--- a/src/test/integration/integration.test.ts
+++ b/src/test/integration/integration.test.ts
@@ -4,7 +4,7 @@ import { RedisData } from 'server/cache/repository/redisData'
 import { UpdateDependenciesQueueFactory } from 'server/controller/cycleData/updateDependencies/queueFactory'
 import { WorkerFactory } from 'server/controller/cycleData/updateDependencies/workerFactory'
 import { DB } from 'server/db/db'
-import { VisitCycleLinksQueueFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory'
+import { VerifyLinksQueueFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory'
 import { WorkerFactory as VisitLinksWorkerFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/workerFactory'
 
 import assessmentCreate from 'test/integration/assessment/createAssessment'
@@ -34,7 +34,7 @@ afterAll(async () => {
   // TODO: find a better strategy to handle Redis connections
   UpdateDependenciesQueueFactory.connection.quit()
   WorkerFactory.connection.quit()
-  VisitCycleLinksQueueFactory.connection.quit()
+  VerifyLinksQueueFactory.connection.quit()
   VisitLinksWorkerFactory.connection.quit()
   RedisData.getInstance().quit()
 })

--- a/src/tools/migrations/steps/index.ts
+++ b/src/tools/migrations/steps/index.ts
@@ -7,7 +7,7 @@ import { UpdateDependenciesQueueFactory } from 'server/controller/cycleData/upda
 import { WorkerFactory } from 'server/controller/cycleData/updateDependencies/workerFactory'
 import { DB } from 'server/db/db'
 import { Logger } from 'server/utils/logger'
-import { VisitCycleLinksQueueFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory'
+import { VerifyLinksQueueFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory'
 import { WorkerFactory as VisitLinksWorkerFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/workerFactory'
 
 import { getMigrationFiles } from './utils'
@@ -52,7 +52,7 @@ const close = async (): Promise<void> => {
   // TODO: find a better strategy to handle Redis connections
   UpdateDependenciesQueueFactory.connection.quit()
   WorkerFactory.connection.quit()
-  VisitCycleLinksQueueFactory.connection.quit()
+  VerifyLinksQueueFactory.connection.quit()
   VisitLinksWorkerFactory.connection.quit()
   await DB.$pool.end()
   RedisData.getInstance().quit()


### PR DESCRIPTION
Adding the new types definitions for the new Job: `verifyDescriptionLinks`. That job will verify the text of the descriptions passed only. The current verifyAllLinks job will be unaffected. 
Those two jobs have to be separate because the verifyAll job scans the entire country or assessment and has other logic to delete links that are not present anymore, and refresh locations.