### PR TITLE
5758 - Navigation: Data errors - Descriptions - 6

### DIFF
--- a/src/server/db/repository/assessmentCycle/descriptions/getManyByIds.ts
+++ b/src/server/db/repository/assessmentCycle/descriptions/getManyByIds.ts
@@ -1,0 +1,33 @@
+import { CountryIso } from 'meta/area/countryIso'
+import { Assessment } from 'meta/assessment/assessment'
+import { Cycle } from 'meta/assessment/cycle'
+import { CommentableDescription } from 'meta/assessment/descriptionValue'
+import { Objects } from 'utils/objects'
+
+import { BaseProtocol, DB } from 'server/db/db'
+import { Schemas } from 'server/db/schemas'
+
+type Props = {
+  assessment: Assessment
+  countryIso: CountryIso
+  cycle: Cycle
+  ids: Array<number>
+}
+
+export const getManyByIds = async (props: Props, client: BaseProtocol = DB): Promise<Array<CommentableDescription>> => {
+  const { assessment, countryIso, cycle, ids } = props
+  if (Objects.isEmpty(ids)) return []
+
+  const schemaName = Schemas.getNameCycle(assessment, cycle)
+
+  return client.map<CommentableDescription>(
+    `
+      select *
+      from ${schemaName}.descriptions
+      where country_iso = $(countryIso)
+        and id in ($(ids:list))
+    `,
+    { countryIso, ids },
+    (row) => Objects.camelize(row)
+  )
+}

--- a/src/server/db/repository/assessmentCycle/descriptions/index.ts
+++ b/src/server/db/repository/assessmentCycle/descriptions/index.ts
@@ -1,4 +1,5 @@
 import { getDataSources } from 'server/db/repository/assessmentCycle/descriptions/getDataSources'
+import { getManyByIds } from 'server/db/repository/assessmentCycle/descriptions/getManyByIds'
 import { getManyWithDataSourcesLinks } from 'server/db/repository/assessmentCycle/descriptions/getManyWithDataSourcesLinks'
 import { getManyWithTextLinks } from 'server/db/repository/assessmentCycle/descriptions/getManyWithTextLinks'
 import { getValues } from 'server/db/repository/assessmentCycle/descriptions/getValues'
@@ -7,6 +8,7 @@ import { upsert } from 'server/db/repository/assessmentCycle/descriptions/upsert
 
 export const DescriptionRepository = {
   getDataSources,
+  getManyByIds,
   getManyWithDataSourcesLinks,
   getManyWithTextLinks,
   getValues,

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/visitDescriptionLinks.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/visitDescriptionLinks.ts
@@ -1,0 +1,33 @@
+import { Job, JobsOptions } from 'bullmq'
+
+import { Objects } from 'utils/objects'
+
+import { Logger } from 'server/utils/logger'
+import { VerifyLinksJobName } from 'server/worker/tasks/verifyLinks/jobNames'
+import { triggerVerifyLinksWorker } from 'server/worker/tasks/verifyLinks/triggerVerifyLinksWorker'
+import { VerifyLinksQueueFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory'
+
+import { VerifyDescriptionLinksJobProps } from './props'
+
+const jobOptions: JobsOptions = {
+  attempts: 1,
+  removeOnComplete: true,
+  removeOnFail: true,
+}
+
+export const visitDescriptionLinks = async (props: VerifyDescriptionLinksJobProps): Promise<Job | undefined> => {
+  const { assessment, countryIso, cycle, descriptionIds } = props
+
+  if (Objects.isEmpty(descriptionIds)) return undefined
+
+  const queue = VerifyLinksQueueFactory.getInstance()
+  const job = await queue.add(VerifyLinksJobName.verifyDescriptionLinks, props, jobOptions)
+
+  Logger.debug(
+    `[visitDescriptionLinks] added description links job for ${assessment.props.name} / ${cycle.name} / ${countryIso}`
+  )
+
+  await triggerVerifyLinksWorker()
+
+  return job
+}

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/worker.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/worker.ts
@@ -1,0 +1,81 @@
+import { LinkToVisit } from 'meta/cycleData/links/link'
+import { Routes } from 'meta/routes/routes'
+import { Htmls } from 'utils/htmls'
+
+import { DescriptionRepository } from 'server/db/repository/assessmentCycle/descriptions'
+import { LinkRepository } from 'server/db/repository/assessmentCycle/links'
+import { Logger } from 'server/utils/logger'
+import { filterLinks } from 'server/worker/tasks/verifyLinks/visitCycleLinks/utils/filterLinks'
+import { mergeLinks } from 'server/worker/tasks/verifyLinks/visitCycleLinks/utils/mergeLinks'
+import { visitLinks } from 'server/worker/tasks/verifyLinks/visitCycleLinks/utils/visitLinks'
+
+import { VerifyDescriptionLinksJob } from './props'
+
+const _getLogKey = (job: VerifyDescriptionLinksJob): string => {
+  const { assessment, countryIso, cycle } = job.data
+
+  return `[visitDescriptionLinks-workerThread] [${assessment.props.name}-${cycle.name}-${countryIso}] [job-${job.id}]`
+}
+
+const _getLinksToVisit = async (job: VerifyDescriptionLinksJob): Promise<Array<LinkToVisit>> => {
+  const { assessment, countryIso, cycle, descriptionIds } = job.data
+
+  const descriptions = await DescriptionRepository.getManyByIds({
+    assessment,
+    countryIso,
+    cycle,
+    ids: descriptionIds,
+  })
+
+  return descriptions.flatMap((description) => {
+    const { id, name, sectionName, value } = description
+    const urlParams = { assessmentName: assessment.props.name, countryIso, cycleName: cycle.name, sectionName }
+    const url = Routes.Section.generatePath(urlParams)
+    const locations = [{ colName: 'value', descriptionName: name, id, path: ['text'], sectionName, url }]
+
+    return Htmls.getLinks(value.text).map(({ link, name: linkName }) => ({
+      countryIso,
+      link: link ?? '',
+      locations,
+      name: linkName,
+    }))
+  })
+}
+
+export default async (job: VerifyDescriptionLinksJob): Promise<void> => {
+  const logKey = _getLogKey(job)
+
+  try {
+    const { assessment, countryIso, cycle } = job.data
+    const time = new Date().getTime()
+
+    Logger.info(`${logKey} started.`)
+
+    const linksToVisit = mergeLinks({ linksToVisit: await _getLinksToVisit(job) })
+    if (linksToVisit.length === 0) {
+      Logger.info(`${logKey} ended with no current links to visit.`)
+      return
+    }
+
+    const approvedLinks = await LinkRepository.getMany({
+      assessment,
+      cycle,
+      filters: { approved: true, countries: [countryIso] },
+    })
+    const linkVisits = await visitLinks(filterLinks({ approvedLinks, linksToVisit }))
+
+    // TODO: await LinkRepository.upsertDescriptionLinks({
+    //   assessment,
+    //   cycle,
+    //   linkVisits,
+    //   linksToVisit,
+    // })
+
+    const duration = (new Date().getTime() - time) / 1000
+    Logger.info(`${logKey} ended in ${duration} seconds with ${linkVisits.length} links visited.`)
+  } catch (error) {
+    Logger.error(`${logKey} Error.`)
+    Logger.error(error)
+    throw error
+  }
+}

--- a/src/server/worker/tasks/verifyLinks/workerRuntime/processor.ts
+++ b/src/server/worker/tasks/verifyLinks/workerRuntime/processor.ts
@@ -1,13 +1,13 @@
 import { VerifyLinksJobName } from 'server/worker/tasks/verifyLinks/jobNames'
-// import { VerifyDescriptionLinksJob } from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/props'
-// import visitDescriptionLinksWorker from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/worker'
 import { VerifyLinksQueueJob } from 'server/worker/tasks/verifyLinks/props'
 import { VerifyLinksJob } from 'server/worker/tasks/verifyLinks/verifyLinksJob'
 import { VerifyAllLinksJob } from 'server/worker/tasks/verifyLinks/visitCycleLinks/props'
+import { VerifyDescriptionLinksJob } from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/props'
+import visitDescriptionLinksWorker from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/worker'
 
 export const verifyLinksWorkerProcessor = async (job: VerifyLinksQueueJob): Promise<void> => {
   if (job.name === VerifyLinksJobName.verifyDescriptionLinks) {
-    // TODO: await visitDescriptionLinksWorker(job as VerifyDescriptionLinksJob)
+    await visitDescriptionLinksWorker(job as VerifyDescriptionLinksJob)
     return
   }
 


### PR DESCRIPTION
Adding the description links worker:

- Gets descriptions by ids -> We get the description using ids instead of passing the description values to the job because while the queue starts and the job is executed, the descriptions could change. Better read the descriptions right before validating. 
- Verifies the links in those descriptions
- (TODO) Upserts the verification result to the links table