### PR TITLE
5758 - Navigation: Data errors - Descriptions - 7

### DIFF
--- a/src/server/db/repository/assessmentCycle/links/index.ts
+++ b/src/server/db/repository/assessmentCycle/links/index.ts
@@ -3,6 +3,7 @@ import { buildGetManyQuery, getMany } from 'server/db/repository/assessmentCycle
 import { getVerificationSummary } from 'server/db/repository/assessmentCycle/links/getVerificationSummary'
 import { markDeletedMany } from 'server/db/repository/assessmentCycle/links/markDeletedMany'
 import { update } from 'server/db/repository/assessmentCycle/links/update'
+import { upsertDescriptionLinks } from 'server/db/repository/assessmentCycle/links/upsertDescriptionLinks'
 import { upsertMany } from 'server/db/repository/assessmentCycle/links/upsertMany'
 
 export const LinkRepository = {
@@ -12,5 +13,6 @@ export const LinkRepository = {
   getVerificationSummary,
   markDeletedMany,
   update,
+  upsertDescriptionLinks,
   upsertMany,
 }

--- a/src/server/db/repository/assessmentCycle/links/upsertDescriptionLinks.ts
+++ b/src/server/db/repository/assessmentCycle/links/upsertDescriptionLinks.ts
@@ -1,0 +1,70 @@
+import pgPromise from 'pg-promise'
+
+import { Assessment } from 'meta/assessment/assessment'
+import { Cycle } from 'meta/assessment/cycle'
+import { Link, LinkProps, LinkToVisit, LinkVisit, VisitedLink } from 'meta/cycleData/links/link'
+import { Objects } from 'utils/objects'
+
+import { BaseProtocol, DB } from 'server/db/db'
+import { Schemas } from 'server/db/schemas'
+
+type Props = {
+  assessment: Assessment
+  cycle: Cycle
+  linkVisits: Array<VisitedLink>
+  linksToVisit: Array<LinkToVisit>
+}
+
+export const upsertDescriptionLinks = async (props: Props, client: BaseProtocol = DB): Promise<Array<Link>> => {
+  const { assessment, cycle, linkVisits, linksToVisit } = props
+  if (Objects.isEmpty(linksToVisit)) return []
+
+  const linkVisitsByKey = linkVisits.reduce<Record<string, LinkVisit>>((acc, visit) => {
+    acc[`${visit.countryIso}_${visit.link ?? ''}`] = { code: visit.code, timestamp: visit.timestamp }
+    return acc
+  }, {})
+
+  const values = linksToVisit.map((linkToVisit) => {
+    const { countryIso, link, locations, name } = linkToVisit
+    const visit = linkVisitsByKey[`${countryIso}_${link ?? ''}`]
+    const initialProps: LinkProps = { deleted: false, name }
+
+    return {
+      country_iso: countryIso,
+      link: link ?? '',
+      locations: JSON.stringify(locations),
+      props: JSON.stringify(initialProps),
+      visits: JSON.stringify(visit ? [visit] : []),
+    }
+  })
+
+  const schemaCycle = Schemas.getNameCycle(assessment, cycle)
+
+  const pgp = pgPromise()
+  const columns = [
+    'country_iso',
+    { name: 'link', cast: 'varchar(2048)' },
+    { name: 'locations', cast: 'jsonb' },
+    { name: 'props', cast: 'jsonb' },
+    { name: 'visits', cast: 'jsonb' },
+  ]
+  const table = { table: 'link', schema: schemaCycle }
+  const cs = new pgp.helpers.ColumnSet(columns, { table })
+
+  // Description validation only appends locations.
+  // Locations clean up for removed links is handled in the full country job.
+  const query = `${pgp.helpers.insert(values, cs)}
+    on conflict (country_iso, link) do update
+    set visits = case
+      when jsonb_array_length(excluded.visits) > 0 then link.visits || excluded.visits
+      else link.visits
+    end,
+    locations = (
+      select coalesce(jsonb_agg(distinct location), '[]'::jsonb)
+      from jsonb_array_elements(coalesce(link.locations, '[]'::jsonb) || excluded.locations) as location
+    ),
+    props = jsonb_set(link.props || excluded.props, '{deleted}', 'false'::jsonb, true)
+    returning *`
+
+  return client.map<Link>(query, [], (row) => Objects.camelize(row))
+}

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/worker.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/worker.ts
@@ -64,12 +64,12 @@ export default async (job: VerifyDescriptionLinksJob): Promise<void> => {
     })
     const linkVisits = await visitLinks(filterLinks({ approvedLinks, linksToVisit }))
 
-    // TODO: await LinkRepository.upsertDescriptionLinks({
-    //   assessment,
-    //   cycle,
-    //   linkVisits,
-    //   linksToVisit,
-    // })
+    await LinkRepository.upsertDescriptionLinks({
+      assessment,
+      cycle,
+      linkVisits,
+      linksToVisit,
+    })
 
     const duration = (new Date().getTime() - time) / 1000
     Logger.info(`${logKey} ended in ${duration} seconds with ${linkVisits.length} links visited.`)


### PR DESCRIPTION
Adding `upsertDescriptionLinks`. As opposed to the `upsert` for full country/assessment validation, this method doesn't delete and replace locations, it just appends the descriptions locations. 