### PR TITLE
5955 - Fix run:heroku:local command 

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: yarn start
 worker: node dist/server/worker
-task-verifyLinks: node dist/server/worker/tasks/verifyLinks.js
+task_verifyLinks: node dist/server/worker/tasks/verifyLinks.js

--- a/src/server/worker/tasks/verifyLinks/triggerVerifyLinksWorker.ts
+++ b/src/server/worker/tasks/verifyLinks/triggerVerifyLinksWorker.ts
@@ -49,7 +49,7 @@ export const triggerVerifyLinksWorker = async (): Promise<void> => {
     const url = `https://api.heroku.com/apps/${ProcessEnv.herokuAppName}/dynos`
     const payload = {
       attach: false,
-      command: 'task-verifyLinks',
+      command: 'task_verifyLinks',
       type: 'run',
     }
 


### PR DESCRIPTION
The issue was the "-" in the task name "task-verifyLinks" 

<img width="849" height="334" alt="image" src="https://github.com/user-attachments/assets/bf42b7ae-1c81-4124-9e22-b751fed06d81" />
