### PR TITLE
5758 - Navigation: Data errors - Descriptions - Handle removing links

### DIFF
--- a/src/server/controller/cycleData/validations/descriptions/updateDescriptionTextValidations.ts
+++ b/src/server/controller/cycleData/validations/descriptions/updateDescriptionTextValidations.ts
@@ -2,7 +2,6 @@ import { Country } from 'meta/area/country'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import { CommentableDescription } from 'meta/assessment/descriptionValue'
-import { Htmls } from 'utils/htmls'
 import { Objects } from 'utils/objects'
 
 import { visitDescriptionLinks } from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/visitDescriptionLinks'
@@ -20,14 +19,10 @@ export const updateDescriptionTextValidations = async (props: Props): Promise<vo
 
   if (Objects.isEmpty(descriptions)) return
 
-  const descriptionsWithLinks = descriptions.filter(({ value }) => !Objects.isEmpty(Htmls.getLinks(value.text)))
-
-  if (Objects.isEmpty(descriptionsWithLinks)) return
-
   await visitDescriptionLinks({
     assessment,
     countryIso,
     cycle,
-    descriptionIds: descriptionsWithLinks.map(({ id }) => id),
+    descriptionIds: descriptions.map(({ id }) => id),
   })
 }

--- a/src/server/db/repository/assessmentCycle/links/upsertDescriptionLinks.ts
+++ b/src/server/db/repository/assessmentCycle/links/upsertDescriptionLinks.ts
@@ -51,8 +51,6 @@ export const upsertDescriptionLinks = async (props: Props, client: BaseProtocol 
   const table = { table: 'link', schema: schemaCycle }
   const cs = new pgp.helpers.ColumnSet(columns, { table })
 
-  // Description validation only appends locations.
-  // Locations clean up for removed links is handled in the full country job.
   const query = `${pgp.helpers.insert(values, cs)}
     on conflict (country_iso, link) do update
     set visits = case

--- a/src/server/worker/tasks/verifyLinks/visitCycleLinks/worker.ts
+++ b/src/server/worker/tasks/verifyLinks/visitCycleLinks/worker.ts
@@ -36,11 +36,14 @@ export default async (job: VerifyAllLinksJob): Promise<void> => {
     const time = new Date().getTime()
     Logger.info(`${logKey} started.`)
 
-    const approvedLinksFilters = countryIso ? { approved: true, countries: [countryIso] } : { approved: true }
+    // Include deleted approved rows, so a previously approved URL stays approved if it is added back.
+    const filters = countryIso
+      ? { approved: true, countries: [countryIso], excludeDeleted: false }
+      : { approved: true, excludeDeleted: false }
 
     const [linksToVisit, approvedLinks] = await Promise.all([
       CycleDataController.Links.getAllLinksToVisit({ assessment, countryIso, cycle }),
-      LinkRepository.getMany({ assessment, cycle, filters: approvedLinksFilters }),
+      LinkRepository.getMany({ assessment, cycle, filters }),
     ])
 
     const mergedLinks = mergeLinks({ linksToVisit })

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/buildDescriptionLinkValidations.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/buildDescriptionLinkValidations.ts
@@ -1,4 +1,4 @@
-import { CommentableDescriptionName } from 'meta/assessment/descriptionValue'
+import { CommentableDescription, CommentableDescriptionName } from 'meta/assessment/descriptionValue'
 import { RecordDescriptionValidations } from 'meta/assessment/validation/description'
 import { Link, LinkLocation, LinkToVisit, LinkValidationStatusCode, VisitedLink } from 'meta/cycleData/links/link'
 import { Links } from 'meta/cycleData/links/links'
@@ -13,16 +13,26 @@ const _isDescriptionTextLocation = (
 
 type Props = {
   approvedLinks: Array<Link>
+  initialDescriptions?: Array<CommentableDescription>
   linkVisits: Array<VisitedLink>
   linksToVisit: Array<LinkToVisit>
 }
 
 export const buildDescriptionLinkValidations = (props: Props): RecordDescriptionValidations => {
-  const { approvedLinks, linkVisits, linksToVisit } = props
+  const { approvedLinks, initialDescriptions = [], linkVisits, linksToVisit } = props
 
   const approvedLinksSet = new Set<string>(approvedLinks.map(_getLinkKey))
   const linkVisitsByKey = linkVisits.reduce<Record<string, VisitedLink>>((acc, linkVisit) => {
     acc[_getLinkKey(linkVisit)] = linkVisit
+    return acc
+  }, {})
+
+  // Mark the validated descriptions as valid first, so removing the last invalid link clears the previous error.
+  const initialValidations = initialDescriptions.reduce<RecordDescriptionValidations>((acc, description) => {
+    const { name, sectionName } = description
+    const sectionValidation = (acc[sectionName] ??= { descriptions: {} })
+    sectionValidation.descriptions ??= {}
+    sectionValidation.descriptions[name] = { valid: true }
     return acc
   }, {})
 
@@ -47,7 +57,7 @@ export const buildDescriptionLinkValidations = (props: Props): RecordDescription
     })
 
     return acc
-  }, {})
+  }, initialValidations)
 }
 
 export const buildDescriptionLinkValidationsByCountry = (

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/getDescriptionLinks.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/getDescriptionLinks.ts
@@ -1,0 +1,38 @@
+import { CountryIso } from 'meta/area/countryIso'
+import { Assessment } from 'meta/assessment/assessment'
+import { Cycle } from 'meta/assessment/cycle'
+import { CommentableDescription } from 'meta/assessment/descriptionValue'
+import { LinkToVisit } from 'meta/cycleData/links/link'
+import { Routes } from 'meta/routes/routes'
+import { Htmls } from 'utils/htmls'
+
+import { DescriptionRepository } from 'server/db/repository/assessmentCycle/descriptions'
+
+type Props = {
+  assessment: Assessment
+  countryIso: CountryIso
+  cycle: Cycle
+  descriptionIds: Array<number>
+}
+
+type Returned = {
+  descriptions: Array<CommentableDescription>
+  linksToVisit: Array<LinkToVisit>
+}
+
+export const getDescriptionLinks = async (props: Props): Promise<Returned> => {
+  const { assessment, countryIso, cycle, descriptionIds } = props
+
+  const descriptions = await DescriptionRepository.getManyByIds({ assessment, countryIso, cycle, ids: descriptionIds })
+
+  const linksToVisit = descriptions.flatMap((description) => {
+    const { id, name: descriptionName, sectionName, value } = description
+    const urlParams = { assessmentName: assessment.props.name, countryIso, cycleName: cycle.name, sectionName }
+    const url = Routes.Section.generatePath(urlParams)
+    const locations = [{ colName: 'value', descriptionName, id, path: ['text'], sectionName, url }]
+
+    return Htmls.getLinks(value.text).map(({ link, name }) => ({ countryIso, link: link ?? '', locations, name }))
+  })
+
+  return { descriptions, linksToVisit }
+}

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/syncDescriptionLinks.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/syncDescriptionLinks.ts
@@ -1,0 +1,60 @@
+import { CountryIso } from 'meta/area/countryIso'
+import { Assessment } from 'meta/assessment/assessment'
+import { Cycle } from 'meta/assessment/cycle'
+import { Link, LinkToVisit, VisitedLink } from 'meta/cycleData/links/link'
+import { Objects } from 'utils/objects'
+
+import { DB } from 'server/db/db'
+import { LinkRepository } from 'server/db/repository/assessmentCycle/links'
+import { filterLinks } from 'server/worker/tasks/verifyLinks/visitCycleLinks/utils/filterLinks'
+import { mergeLinks } from 'server/worker/tasks/verifyLinks/visitCycleLinks/utils/mergeLinks'
+import { visitLinks } from 'server/worker/tasks/verifyLinks/visitCycleLinks/utils/visitLinks'
+
+type LocationToRefresh = {
+  id: number
+  path: Array<string>
+}
+
+type Props = {
+  assessment: Assessment
+  countryIso: CountryIso
+  cycle: Cycle
+  descriptionIds: Array<number>
+  locationPath: Array<string>
+  linksToVisit: Array<LinkToVisit>
+}
+
+type Returned = {
+  approvedLinks: Array<Link>
+  linkVisits: Array<VisitedLink>
+}
+
+// Keeps link table locations aligned with the validated descriptions:
+// 1. Build the description locations to refresh, so stale locations can be removed even when no links remain.
+// 2. Visit the links that are not approved.
+// 3. When the descriptions still contain links, update the database in one transaction: remove old locations and save the current ones.
+export const syncDescriptionLinks = async (props: Props): Promise<Returned> => {
+  const { assessment, countryIso, cycle, descriptionIds, linksToVisit: rawLinksToVisit, locationPath } = props
+
+  const locations: Array<LocationToRefresh> = descriptionIds.map((id) => ({ id, path: locationPath }))
+  const linksToVisit = mergeLinks({ linksToVisit: rawLinksToVisit }) // Merge duplicated links
+
+  if (Objects.isEmpty(linksToVisit)) {
+    // No links to visit means there may be old link rows pointing at these descriptions, so we remove them.
+    await LinkRepository.removeLocations({ assessment, countryIso, cycle, locations })
+    return { approvedLinks: [], linkVisits: [] }
+  }
+
+  // Prevent verifying already approved links.
+  const approvedProps = { assessment, cycle, filters: { approved: true, countries: [countryIso] } }
+  const approvedLinks = await LinkRepository.getMany(approvedProps)
+  const linkVisits = await visitLinks(filterLinks({ approvedLinks, linksToVisit }))
+
+  // Replace stale description locations with the current ones in a single transaction.
+  await DB.tx(async (client) => {
+    await LinkRepository.removeLocations({ assessment, countryIso, cycle, locations }, client)
+    await LinkRepository.upsertDescriptionLinks({ assessment, cycle, linkVisits, linksToVisit }, client)
+  })
+
+  return { approvedLinks, linkVisits }
+}

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/syncDescriptionLinks.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/syncDescriptionLinks.ts
@@ -45,9 +45,9 @@ export const syncDescriptionLinks = async (props: Props): Promise<Returned> => {
     return { approvedLinks: [], linkVisits: [] }
   }
 
-  // Prevent verifying already approved links.
-  const approvedProps = { assessment, cycle, filters: { approved: true, countries: [countryIso] } }
-  const approvedLinks = await LinkRepository.getMany(approvedProps)
+  // Include deleted approved rows, so a previously approved URL stays approved if it is added back.
+  const filters = { approved: true, countries: [countryIso], excludeDeleted: false }
+  const approvedLinks = await LinkRepository.getMany({ assessment, cycle, filters })
   const linkVisits = await visitLinks(filterLinks({ approvedLinks, linksToVisit }))
 
   // Replace stale description locations with the current ones in a single transaction.

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/worker.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/worker.ts
@@ -1,18 +1,13 @@
-import { LinkToVisit } from 'meta/cycleData/links/link'
-import { Routes } from 'meta/routes/routes'
 import { Sockets } from 'meta/socket/sockets'
-import { Htmls } from 'utils/htmls'
+import { Objects } from 'utils/objects'
 
 import { DescriptionValidationRedisRepository } from 'server/cache/repository/validation/description'
-import { DescriptionRepository } from 'server/db/repository/assessmentCycle/descriptions'
-import { LinkRepository } from 'server/db/repository/assessmentCycle/links'
 import { SocketServer } from 'server/service/socket'
 import { Logger } from 'server/utils/logger'
-import { filterLinks } from 'server/worker/tasks/verifyLinks/visitCycleLinks/utils/filterLinks'
-import { mergeLinks } from 'server/worker/tasks/verifyLinks/visitCycleLinks/utils/mergeLinks'
-import { visitLinks } from 'server/worker/tasks/verifyLinks/visitCycleLinks/utils/visitLinks'
 
 import { buildDescriptionLinkValidations } from './utils/buildDescriptionLinkValidations'
+import { getDescriptionLinks } from './utils/getDescriptionLinks'
+import { syncDescriptionLinks } from './utils/syncDescriptionLinks'
 import { VerifyDescriptionLinksJob } from './props'
 
 const _getLogKey = (job: VerifyDescriptionLinksJob): string => {
@@ -21,62 +16,39 @@ const _getLogKey = (job: VerifyDescriptionLinksJob): string => {
   return `[visitDescriptionLinks-workerThread] [${assessment.props.name}-${cycle.name}-${countryIso}] [job-${job.id}]`
 }
 
-const _getLinksToVisit = async (job: VerifyDescriptionLinksJob): Promise<Array<LinkToVisit>> => {
-  const { assessment, countryIso, cycle, descriptionIds } = job.data
-
-  const descriptions = await DescriptionRepository.getManyByIds({
-    assessment,
-    countryIso,
-    cycle,
-    ids: descriptionIds,
-  })
-
-  return descriptions.flatMap((description) => {
-    const { id, name, sectionName, value } = description
-    const urlParams = { assessmentName: assessment.props.name, countryIso, cycleName: cycle.name, sectionName }
-    const url = Routes.Section.generatePath(urlParams)
-    const locations = [{ colName: 'value', descriptionName: name, id, path: ['text'], sectionName, url }]
-
-    return Htmls.getLinks(value.text).map(({ link, name: linkName }) => ({
-      countryIso,
-      link: link ?? '',
-      locations,
-      name: linkName,
-    }))
-  })
-}
-
 export default async (job: VerifyDescriptionLinksJob): Promise<void> => {
   const logKey = _getLogKey(job)
 
   try {
-    const { assessment, countryIso, cycle } = job.data
+    const { assessment, countryIso, cycle, descriptionIds } = job.data
     const time = new Date().getTime()
 
     Logger.info(`${logKey} started.`)
 
-    const linksToVisit = mergeLinks({ linksToVisit: await _getLinksToVisit(job) })
-    if (linksToVisit.length === 0) {
-      Logger.info(`${logKey} ended with no current links to visit.`)
+    const { descriptions, linksToVisit } = await getDescriptionLinks({ assessment, countryIso, cycle, descriptionIds })
+
+    if (Objects.isEmpty(descriptions)) {
+      Logger.info(`${logKey} ended with no descriptions to validate.`)
       return
     }
 
-    const approvedLinks = await LinkRepository.getMany({
+    const { approvedLinks, linkVisits } = await syncDescriptionLinks({
       assessment,
+      countryIso,
       cycle,
-      filters: { approved: true, countries: [countryIso] },
+      descriptionIds,
+      locationPath: ['text'],
+      linksToVisit,
     })
-    const linkVisits = await visitLinks(filterLinks({ approvedLinks, linksToVisit }))
 
-    await LinkRepository.upsertDescriptionLinks({
-      assessment,
-      cycle,
+    const descriptionValidations = buildDescriptionLinkValidations({
+      approvedLinks,
+      initialDescriptions: descriptions,
       linkVisits,
       linksToVisit,
     })
 
-    const descriptionValidations = buildDescriptionLinkValidations({ approvedLinks, linkVisits, linksToVisit })
-    const sectionNames = Object.keys(descriptionValidations)
+    const sectionNames = Array.from(new Set(descriptions.map(({ sectionName }) => sectionName)))
 
     await DescriptionValidationRedisRepository.setDescriptionValidations({
       assessment,


### PR DESCRIPTION
Handling link removals in descriptions:

Flow:
Description edited -> description links validation triggered -> current links are read from the latest description text -> old saved locations for that description are removed -> current link locations are saved again if links still exist -> validation cache is rebuilt.

Subtle edge case handled: when an approved URL is removed everywhere, its link row can be marked as deleted. If the same URL is added back later, we still want to treat it as approved. That’s why the approved-link lookup now includes deleted approved rows.



https://github.com/user-attachments/assets/297988ca-d92e-413c-ad97-f0bf240dc90d

