### PR TITLE
5758 - Navigation: Data errors - Descriptions - Add get description validations endpoint 

### DIFF
--- a/src/meta/api/endpoint/cycleData.ts
+++ b/src/meta/api/endpoint/cycleData.ts
@@ -89,7 +89,7 @@ export const CycleData = {
   },
 
   Validations: {
-    descriptionData: (): string => apiPath('cycle-data', 'validations', 'description-data'),
+    descriptions: (): string => apiPath('cycle-data', 'validations', 'descriptions'),
     summary: (): string => apiPath('cycle-data', 'validations', 'summary'),
     tableData: (): string => apiPath('cycle-data', 'validations', 'table-data'),
   },

--- a/src/meta/api/endpoint/cycleData.ts
+++ b/src/meta/api/endpoint/cycleData.ts
@@ -89,6 +89,7 @@ export const CycleData = {
   },
 
   Validations: {
+    descriptionData: (): string => apiPath('cycle-data', 'validations', 'description-data'),
     summary: (): string => apiPath('cycle-data', 'validations', 'summary'),
     tableData: (): string => apiPath('cycle-data', 'validations', 'table-data'),
   },

--- a/src/server/api/cycleData/index.ts
+++ b/src/server/api/cycleData/index.ts
@@ -157,7 +157,7 @@ export const CycleDataApi = {
     express.get(ApiEndPoint.CycleData.Review.summary(), AuthMiddleware.requireView, getReviewSummary)
     express.get(ApiEndPoint.CycleData.Validations.summary(), AuthMiddleware.requireView, getValidationSummary)
     express.get(
-      ApiEndPoint.CycleData.Validations.descriptionData(),
+      ApiEndPoint.CycleData.Validations.descriptions(),
       AuthMiddleware.requireEditDescriptions,
       getDescriptionValidations
     )

--- a/src/server/api/cycleData/index.ts
+++ b/src/server/api/cycleData/index.ts
@@ -55,6 +55,7 @@ import { getNodeValuesEstimations } from './table/getNodeValuesEstimations'
 import { getTableData } from './table/getTableData'
 import { getTableDataHistory } from './table/getTableDataHistory'
 import { persistNodeValues } from './table/persistNodeValues'
+import { getDescriptionValidations } from './validations/getDescriptionData'
 import { getValidationSummary } from './validations/getSummary'
 import { getTableValidations } from './validations/getTableData'
 
@@ -155,6 +156,11 @@ export const CycleDataApi = {
     express.get(ApiEndPoint.CycleData.Review.status(), AuthMiddleware.requireView, getReviewStatus)
     express.get(ApiEndPoint.CycleData.Review.summary(), AuthMiddleware.requireView, getReviewSummary)
     express.get(ApiEndPoint.CycleData.Validations.summary(), AuthMiddleware.requireView, getValidationSummary)
+    express.get(
+      ApiEndPoint.CycleData.Validations.descriptionData(),
+      AuthMiddleware.requireEditDescriptions,
+      getDescriptionValidations
+    )
     express.get(ApiEndPoint.CycleData.Validations.tableData(), AuthMiddleware.requireEditTableData, getTableValidations)
 
     // Country Links

--- a/src/server/api/cycleData/validations/getDescriptionData.ts
+++ b/src/server/api/cycleData/validations/getDescriptionData.ts
@@ -1,0 +1,29 @@
+import { Response } from 'express'
+
+import { CycleDataRequest } from 'meta/api/request/cycleData/cycleData'
+import { SectionName } from 'meta/assessment/section'
+
+import { CycleDataController } from 'server/controller/cycleData'
+import Requests from 'server/utils/requests'
+
+type Request = CycleDataRequest<{
+  sectionName: SectionName
+}>
+
+export const getDescriptionValidations = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { countryIso, sectionName } = req.query
+    const { assessment, cycle } = req.context
+
+    const descriptionValidations = await CycleDataController.getDescriptionValidations({
+      assessment,
+      countryIso,
+      cycle,
+      sectionNames: [sectionName],
+    })
+
+    Requests.send(res, descriptionValidations)
+  } catch (e) {
+    Requests.sendErr(res, e)
+  }
+}

--- a/src/server/controller/cycleData/index.ts
+++ b/src/server/controller/cycleData/index.ts
@@ -42,6 +42,7 @@ export const CycleDataController = {
   clearTableData,
   getLastPublishedData,
   getTableData,
+  getTableValidations: TableValidationRedisRepository.getTableValidations,
 
   // ===== original data point
   createOriginalDataPoint,
@@ -65,10 +66,8 @@ export const CycleDataController = {
   updateOriginalDataPointYear,
 
   // ===== review
-  getDescriptionValidations: DescriptionValidationRedisRepository.getDescriptionValidations,
   getReviewStatus,
   getReviewSummary: MessageTopicUserRepository.getReviewSummary,
-  getTableValidations: TableValidationRedisRepository.getTableValidations,
   getValidationSummary,
 
   // ==== activities
@@ -77,6 +76,7 @@ export const CycleDataController = {
 
   // ====== description
   Description,
+  getDescriptionValidations: DescriptionValidationRedisRepository.getDescriptionValidations,
 
   // ====== history
   History,

--- a/src/server/controller/cycleData/index.ts
+++ b/src/server/controller/cycleData/index.ts
@@ -1,3 +1,4 @@
+import { DescriptionValidationRedisRepository } from 'server/cache/repository/validation/description'
 import { TableValidationRedisRepository } from 'server/cache/repository/validation/table'
 import { History } from 'server/controller/cycleData/history'
 import { Links } from 'server/controller/cycleData/links'
@@ -64,6 +65,7 @@ export const CycleDataController = {
   updateOriginalDataPointYear,
 
   // ===== review
+  getDescriptionValidations: DescriptionValidationRedisRepository.getDescriptionValidations,
   getReviewStatus,
   getReviewSummary: MessageTopicUserRepository.getReviewSummary,
   getTableValidations: TableValidationRedisRepository.getTableValidations,


### PR DESCRIPTION
Adding an endpoint to fetch description validations, following the same pattern we use for getTableValidations. These are loaded per section, so we fetch only section the user is viewing.

After this, I will add the redux code to load, and after that I will actually display the errors in the FE.