### PR TITLE
5758 - Navigation: Data errors - Descriptions - Redux for get descriptions - 2

### DIFF
--- a/src/client/store/data/tableData/validations/actions/getDescriptionValidations.ts
+++ b/src/client/store/data/tableData/validations/actions/getDescriptionValidations.ts
@@ -1,0 +1,29 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axios from 'axios'
+
+import { ApiEndPoint } from 'meta/api/endpoint'
+import { CountryParams } from 'meta/api/request/country'
+import { SectionName } from 'meta/assessment/section'
+import { RecordDescriptionValidations } from 'meta/assessment/validation/description'
+
+import { setDescriptionValidations } from 'client/store/data/tableData/validations/actions/setDescriptionValidations'
+
+type Props = CountryParams & {
+  sectionName: SectionName
+}
+
+export const getDescriptionValidations = createAsyncThunk<void, Props>(
+  'validations/descriptionData/get',
+  async (props, { dispatch }) => {
+    const { assessmentName, countryIso, cycleName, sectionName } = props
+
+    const params = { assessmentName, countryIso, cycleName, sectionName }
+    const { data: descriptionValidations } = await axios.get<RecordDescriptionValidations>(
+      ApiEndPoint.CycleData.Validations.descriptions(),
+      { params }
+    )
+    const sectionNames = [sectionName]
+
+    dispatch(setDescriptionValidations({ assessmentName, countryIso, cycleName, descriptionValidations, sectionNames }))
+  }
+)

--- a/src/client/store/data/tableData/validations/actions/index.ts
+++ b/src/client/store/data/tableData/validations/actions/index.ts
@@ -1,3 +1,4 @@
+import { getDescriptionValidations } from 'client/store/data/tableData/validations/actions/getDescriptionValidations'
 import { getSummary } from 'client/store/data/tableData/validations/actions/getSummary'
 import { getTableValidations } from 'client/store/data/tableData/validations/actions/getTableValidations'
 import { removeValidations } from 'client/store/data/tableData/validations/actions/removeValidations'
@@ -5,6 +6,7 @@ import { setDescriptionValidations } from 'client/store/data/tableData/validatio
 import { setNodeValueValidations } from 'client/store/data/tableData/validations/actions/setNodeValueValidations'
 
 export const ValidationsActions = {
+  getDescriptionValidations,
   getSummary,
   getTableValidations,
   removeValidations,

--- a/src/client/store/data/tableData/validations/hooks/descriptions.ts
+++ b/src/client/store/data/tableData/validations/hooks/descriptions.ts
@@ -1,0 +1,32 @@
+import { CountryIso } from 'meta/area/countryIso'
+import { CommentableDescriptionName } from 'meta/assessment/descriptionValue'
+import { SectionName } from 'meta/assessment/section'
+import { Validation } from 'meta/assessment/validation/validation'
+
+import { ValidationsSelectors } from 'client/store/data/tableData/validations/selectors'
+import { useAppSelector } from 'client/store/hooks'
+import { useCountryRouteParams } from 'client/hooks/routeParams'
+
+type DescriptionValidationProps = {
+  name: CommentableDescriptionName
+  sectionName: SectionName
+}
+
+type DescriptionValidationReturned = Validation
+
+export const useDescriptionValidation = (props: DescriptionValidationProps): DescriptionValidationReturned => {
+  const { name, sectionName } = props
+
+  const { assessmentName, countryIso, cycleName } = useCountryRouteParams<CountryIso>()
+
+  return useAppSelector((state) => {
+    return ValidationsSelectors.getDescriptionValidation(
+      state,
+      assessmentName,
+      cycleName,
+      countryIso,
+      sectionName,
+      name
+    )
+  })
+}

--- a/src/client/store/data/tableData/validations/selectors/descriptions.ts
+++ b/src/client/store/data/tableData/validations/selectors/descriptions.ts
@@ -1,0 +1,34 @@
+import { createSelector } from '@reduxjs/toolkit'
+
+import { CountryIso } from 'meta/area/countryIso'
+import { AssessmentName } from 'meta/assessment/assessment'
+import { CycleName } from 'meta/assessment/cycle'
+import { CommentableDescriptionName } from 'meta/assessment/descriptionValue'
+import { SectionName } from 'meta/assessment/section'
+
+import { RootState } from 'client/store/types'
+
+import { getCountryValidations } from './base'
+
+export const getDescriptionValidation = createSelector(
+  [
+    getCountryValidations,
+    (
+      _state: RootState,
+      _assessmentName: AssessmentName,
+      _cycleName: CycleName,
+      _countryIso: CountryIso,
+      sectionName: SectionName
+    ) => sectionName,
+    (
+      _state: RootState,
+      _assessmentName: AssessmentName,
+      _cycleName: CycleName,
+      _countryIso: CountryIso,
+      _sectionName: SectionName,
+      descriptionName: CommentableDescriptionName
+    ) => descriptionName,
+  ],
+  (countryValidations, sectionName, descriptionName) =>
+    countryValidations.descriptions?.[sectionName]?.descriptions?.[descriptionName] ?? { valid: true }
+)

--- a/src/client/store/data/tableData/validations/selectors/index.ts
+++ b/src/client/store/data/tableData/validations/selectors/index.ts
@@ -1,3 +1,4 @@
+import { getDescriptionValidation } from 'client/store/data/tableData/validations/selectors/descriptions'
 import {
   getSummary,
   getSummaryHasErrors,
@@ -7,6 +8,7 @@ import {
 import { getNodeValidation, getTableValidations } from 'client/store/data/tableData/validations/selectors/tables'
 
 export const ValidationsSelectors = {
+  getDescriptionValidation,
   getNodeValidation,
   getSummary,
   getSummaryHasErrors,


### PR DESCRIPTION
Adding the actual redux for descriptions. 
___
Next PR potentially: Split validation reducers into:
```
validations: {
    descriptions,
    tables,
    summary,
  }
 ```