### PR TITLE
5974 - User Form: Remove User Role -> wrongly shown

### DIFF
--- a/src/client/pages/User/RemoveRole/RemoveRole.tsx
+++ b/src/client/pages/User/RemoveRole/RemoveRole.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { Areas } from 'meta/area/areas'
 import { CountryIso } from 'meta/area/countryIso'
 import { Authorizer } from 'meta/auth/authorizer'
 import { User } from 'meta/user/user'
@@ -26,6 +27,8 @@ const RemoveRole: React.FC<Props> = (props) => {
   const user = useUser()
   const onClick = useOnClick({ targetUser })
 
+  if (!Areas.isISOCountry(countryIso)) return null
+  if (user?.id === targetUser.id) return null
   if (!Authorizer.canDisableUser({ countryIso, cycle, target: targetUser, user })) return null
 
   return (


### PR DESCRIPTION
<img width="1415" height="975" alt="image" src="https://github.com/user-attachments/assets/987f3d76-249c-4cf8-b7c2-285ec2f527c4" />


Root cause: 

```
  if (!Authorizer.canDisableUser({ countryIso, cycle, target: targetUser, user })) return null
```

Returns true always for admins, so admins always saw the button.
Fixed by  adding early returns correctly