### PR TITLE
5758 - Navigation: Data errors - Data sources - Validate fields BE

### DIFF
--- a/src/server/controller/cycleData/validations/descriptions/updateDataSourceFieldValidations.ts
+++ b/src/server/controller/cycleData/validations/descriptions/updateDataSourceFieldValidations.ts
@@ -1,0 +1,68 @@
+import { Country } from 'meta/area/country'
+import { Assessment } from 'meta/assessment/assessment'
+import { Cycle } from 'meta/assessment/cycle'
+import { CommentableDescription, DataSource } from 'meta/assessment/descriptionValue'
+import { RecordDescriptionValidations } from 'meta/assessment/validation/description'
+import { Validation } from 'meta/assessment/validation/validation'
+import { Sockets } from 'meta/socket/sockets'
+import { Objects } from 'utils/objects'
+
+import { DescriptionValidationRedisRepository } from 'server/cache/repository/validation/description'
+import { SocketServer } from 'server/service/socket'
+
+type Props = {
+  assessment: Assessment
+  country: Country
+  cycle: Cycle
+  descriptions: Array<CommentableDescription>
+}
+
+// Required data source fields. TODO: The reference field will be validated by the links worker.
+const requiredFields: Array<keyof Pick<DataSource, 'type' | 'variables' | 'year'>> = ['type', 'variables', 'year']
+
+const _getRequiredValidation = (value: DataSource[keyof DataSource]): Validation => {
+  if (Objects.isEmpty(value)) return { valid: false, messages: [{ key: 'generalValidation.notEmpty' }] }
+  return { valid: true }
+}
+
+// Validates the required data source fields (type, variables, year) when the data sources are saved.
+export const updateDataSourceFieldValidations = async (props: Props): Promise<void> => {
+  const { assessment, country, cycle, descriptions } = props
+  const { countryIso } = country
+
+  const dataSourceDescriptions = descriptions.filter(({ value }) => value.dataSources !== undefined)
+  if (Objects.isEmpty(dataSourceDescriptions)) return
+
+  const descriptionValidations = dataSourceDescriptions.reduce<RecordDescriptionValidations>((acc, description) => {
+    const { sectionName, value } = description
+    const sectionValidation = (acc[sectionName] ??= {})
+    const dataSources = (sectionValidation.dataSources ??= {})
+
+    value.dataSources?.forEach((dataSource) => {
+      const { placeholder, uuid } = dataSource
+      if (placeholder || Objects.isEmpty(uuid)) return
+
+      const dataSourceValidation = (dataSources[uuid] ??= {})
+      requiredFields.forEach((field) => {
+        dataSourceValidation[field] = _getRequiredValidation(dataSource[field])
+      })
+    })
+
+    return acc
+  }, {})
+
+  await DescriptionValidationRedisRepository.setDescriptionValidations({
+    assessment,
+    countryIso,
+    cycle,
+    descriptionValidations,
+  })
+
+  const sectionNames = Array.from(new Set(dataSourceDescriptions.map(({ sectionName }) => sectionName)))
+  const eventName = Sockets.getDescriptionValidationsUpdateEvent({
+    assessmentName: assessment.props.name,
+    countryIso,
+    cycleName: cycle.name,
+  })
+  SocketServer.emit(eventName, { descriptionValidations, sectionNames })
+}

--- a/src/server/controller/cycleData/validations/descriptions/updateDescriptionValidations.ts
+++ b/src/server/controller/cycleData/validations/descriptions/updateDescriptionValidations.ts
@@ -3,6 +3,7 @@ import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import { CommentableDescription } from 'meta/assessment/descriptionValue'
 
+import { updateDataSourceFieldValidations } from './updateDataSourceFieldValidations'
 import { updateDescriptionTextValidations } from './updateDescriptionTextValidations'
 
 type Props = {
@@ -15,7 +16,8 @@ type Props = {
 export const updateDescriptionValidations = async (props: Props): Promise<void> => {
   const { assessment, country, cycle, descriptions } = props
 
-  await updateDescriptionTextValidations({ assessment, country, cycle, descriptions })
-
-  // TODO: Validate data sources and store results under sectionValidations.dataSources.
+  await Promise.all([
+    updateDescriptionTextValidations({ assessment, country, cycle, descriptions }),
+    updateDataSourceFieldValidations({ assessment, country, cycle, descriptions }),
+  ])
 }


### PR DESCRIPTION
Adding the validation in the BE for the data sources required fields.

The reference links field is omitted here because that one we will validate later in the description links worker. 