### PR TITLE
5758 - Navigation: Data errors - Data sources - Queue reference links validations

### DIFF
--- a/src/meta/assessment/validation/descriptionValidations/index.ts
+++ b/src/meta/assessment/validation/descriptionValidations/index.ts
@@ -1,7 +1,9 @@
 import { calculateSummary } from 'meta/assessment/validation/descriptionValidations/calculateSummary'
+import { mergeLinkValidations } from 'meta/assessment/validation/descriptionValidations/mergeLinkValidations'
 import { mergeValidations } from 'meta/assessment/validation/descriptionValidations/mergeValidations'
 
 export const DescriptionValidations = {
   calculateSummary,
+  mergeLinkValidations,
   mergeValidations,
 }

--- a/src/meta/assessment/validation/descriptionValidations/mergeLinkValidations.ts
+++ b/src/meta/assessment/validation/descriptionValidations/mergeLinkValidations.ts
@@ -1,0 +1,36 @@
+import type { DataSourceRowValidations, SectionDescriptionValidations } from 'meta/assessment/validation/description'
+import { Objects } from 'utils/objects'
+
+type Props = {
+  current: SectionDescriptionValidations
+  update: SectionDescriptionValidations
+}
+
+export const mergeLinkValidations = (props: Props): SectionDescriptionValidations => {
+  const { current, update } = props
+  const value: SectionDescriptionValidations = { ...current }
+
+  // Description validation are replaced entirely with the new state.
+  if (!Objects.isEmpty(update.descriptions)) {
+    value.descriptions = update.descriptions
+  } else {
+    delete value.descriptions
+  }
+
+  if (Objects.isEmpty(update.dataSources)) return value
+
+  const currentDataSources = current.dataSources ?? {}
+  const dataSourcesUpdate = update.dataSources ?? {}
+
+  // For data sources, we update the reference link validation only.
+  value.dataSources = Object.entries(dataSourcesUpdate).reduce<DataSourceRowValidations>(
+    (acc, [uuid, dataSourceValidation]) => {
+      const { reference } = dataSourceValidation
+      if (reference) acc[uuid] = { ...acc[uuid], reference }
+      return acc
+    },
+    { ...currentDataSources }
+  )
+
+  return value
+}

--- a/src/server/cache/repository/validation/description/index.ts
+++ b/src/server/cache/repository/validation/description/index.ts
@@ -1,9 +1,9 @@
 import { getDescriptionValidations } from 'server/cache/repository/validation/description/getDescriptionValidations'
 import { setDescriptionValidations } from 'server/cache/repository/validation/description/setDescriptionValidations'
-import { updateTextDescriptionValidation } from 'server/cache/repository/validation/description/updateTextDescriptionValidation'
+import { updateDescriptionLinkValidations } from 'server/cache/repository/validation/description/updateDescriptionLinkValidations'
 
 export const DescriptionValidationRedisRepository = {
   getDescriptionValidations,
   setDescriptionValidations,
-  updateTextDescriptionValidation,
+  updateDescriptionLinkValidations,
 }

--- a/src/server/cache/repository/validation/description/updateDescriptionLinkValidations.ts
+++ b/src/server/cache/repository/validation/description/updateDescriptionLinkValidations.ts
@@ -2,7 +2,8 @@ import { CountryIso } from 'meta/area/countryIso'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import { SectionName } from 'meta/assessment/section'
-import { RecordDescriptionValidations, SectionDescriptionValidations } from 'meta/assessment/validation/description'
+import { RecordDescriptionValidations } from 'meta/assessment/validation/description'
+import { DescriptionValidations } from 'meta/assessment/validation/descriptionValidations'
 import { Objects } from 'utils/objects'
 
 import { getKeyCountry, Keys } from 'server/cache/repository/keys'
@@ -17,22 +18,7 @@ type Props = {
   sectionNames: Array<SectionName>
 }
 
-const _updateTextDescriptionSectionValidation = (
-  current: SectionDescriptionValidations,
-  update: SectionDescriptionValidations
-): SectionDescriptionValidations => {
-  const value: SectionDescriptionValidations = { ...current }
-
-  if (!Objects.isEmpty(update.descriptions)) {
-    value.descriptions = update.descriptions
-  } else {
-    delete value.descriptions
-  }
-
-  return value
-}
-
-export const updateTextDescriptionValidation = async (props: Props): Promise<RecordDescriptionValidations> => {
+export const updateDescriptionLinkValidations = async (props: Props): Promise<RecordDescriptionValidations> => {
   const { assessment, countryIso, cycle, descriptionValidations, sectionNames } = props
 
   const redis = RedisData.getInstance()
@@ -55,7 +41,7 @@ export const updateTextDescriptionValidation = async (props: Props): Promise<Rec
     const current = currentValidations[sectionName] ?? {}
     const update = descriptionValidations[sectionName] ?? {}
     // Refresh link validation results while keeping the rest of the section state intact.
-    const value = _updateTextDescriptionSectionValidation(current, update)
+    const value = DescriptionValidations.mergeLinkValidations({ current, update })
 
     if (Objects.isEmpty(value)) {
       // Clear sections that are empty after the link validations are refreshed.

--- a/src/server/controller/cycleData/validations/descriptions/updateDataSourceFieldValidations.ts
+++ b/src/server/controller/cycleData/validations/descriptions/updateDataSourceFieldValidations.ts
@@ -17,7 +17,7 @@ type Props = {
   descriptions: Array<CommentableDescription>
 }
 
-// Required data source fields. TODO: The reference field will be validated by the links worker.
+// Reference (empty check + link verification) is validated by the description link flow.
 const requiredFields: Array<keyof Pick<DataSource, 'type' | 'variables' | 'year'>> = ['type', 'variables', 'year']
 
 const _getRequiredValidation = (value: DataSource[keyof DataSource]): Validation => {

--- a/src/server/controller/cycleData/validations/descriptions/updateDescriptionLinkValidations.ts
+++ b/src/server/controller/cycleData/validations/descriptions/updateDescriptionLinkValidations.ts
@@ -13,7 +13,7 @@ type Props = {
   descriptions: Array<CommentableDescription>
 }
 
-export const updateDescriptionTextValidations = async (props: Props): Promise<void> => {
+export const updateDescriptionLinkValidations = async (props: Props): Promise<void> => {
   const { assessment, country, cycle, descriptions } = props
   const { countryIso } = country
 

--- a/src/server/controller/cycleData/validations/descriptions/updateDescriptionValidations.ts
+++ b/src/server/controller/cycleData/validations/descriptions/updateDescriptionValidations.ts
@@ -4,7 +4,7 @@ import { Cycle } from 'meta/assessment/cycle'
 import { CommentableDescription } from 'meta/assessment/descriptionValue'
 
 import { updateDataSourceFieldValidations } from './updateDataSourceFieldValidations'
-import { updateDescriptionTextValidations } from './updateDescriptionTextValidations'
+import { updateDescriptionLinkValidations } from './updateDescriptionLinkValidations'
 
 type Props = {
   assessment: Assessment
@@ -17,7 +17,7 @@ export const updateDescriptionValidations = async (props: Props): Promise<void> 
   const { assessment, country, cycle, descriptions } = props
 
   await Promise.all([
-    updateDescriptionTextValidations({ assessment, country, cycle, descriptions }),
+    updateDescriptionLinkValidations({ assessment, country, cycle, descriptions }),
     updateDataSourceFieldValidations({ assessment, country, cycle, descriptions }),
   ])
 }

--- a/src/server/worker/tasks/verifyLinks/visitCycleLinks/utils/refreshDescriptionLinkValidationCache.ts
+++ b/src/server/worker/tasks/verifyLinks/visitCycleLinks/utils/refreshDescriptionLinkValidationCache.ts
@@ -43,13 +43,15 @@ export const refreshDescriptionLinkValidationCache = async (props: Props): Promi
     targetCountryISOs.map(async (targetCountryIso) => {
       const descriptionValidations = descriptionValidationsByCountry[targetCountryIso] ?? {}
 
-      const updatedDescriptionValidations = await DescriptionValidationRedisRepository.updateTextDescriptionValidation({
-        assessment,
-        countryIso: targetCountryIso,
-        cycle,
-        descriptionValidations,
-        sectionNames,
-      })
+      const updatedDescriptionValidations = await DescriptionValidationRedisRepository.updateDescriptionLinkValidations(
+        {
+          assessment,
+          countryIso: targetCountryIso,
+          cycle,
+          descriptionValidations,
+          sectionNames,
+        }
+      )
 
       const eventName = Sockets.getDescriptionValidationsUpdateEvent({
         assessmentName: assessment.props.name,


### PR DESCRIPTION
We should handle the validation for all description links in one place/one worker. That's why I'm renaming `updateTextDescriptionValidation` to `updateDescriptionLinkValidations` so we handle both `description.text` and `dataSource.reference` links there. 

Additionally, I'm adding `DescriptionValidations.mergeLinkValidations` to make the code cleaner and handle `dataSource.reference` link updates. 

In the next PR I will update the actual worker to process `dataSource.reference` as well. 