### PR TITLE
5758 - Navigation: Data errors - Reference links - Validate in worker

### DIFF
--- a/src/meta/cycleData/links/isDescriptionLocation.ts
+++ b/src/meta/cycleData/links/isDescriptionLocation.ts
@@ -1,0 +1,5 @@
+import { DescriptionsLocation, LinkLocation } from 'meta/cycleData/links/link'
+
+export const isDescriptionLocation = (location: LinkLocation): location is DescriptionsLocation => {
+  return 'descriptionName' in location
+}

--- a/src/meta/cycleData/links/isLocationPath.ts
+++ b/src/meta/cycleData/links/isLocationPath.ts
@@ -1,3 +1,0 @@
-export const isLocationPath = (path: Array<string>, locationPath: Array<string>): boolean => {
-  return path.length === locationPath.length && path.every((pathItem, index) => pathItem === locationPath[index])
-}

--- a/src/meta/cycleData/links/isLocationPath.ts
+++ b/src/meta/cycleData/links/isLocationPath.ts
@@ -1,0 +1,3 @@
+export const isLocationPath = (path: Array<string>, locationPath: Array<string>): boolean => {
+  return path.length === locationPath.length && path.every((pathItem, index) => pathItem === locationPath[index])
+}

--- a/src/meta/cycleData/links/link.ts
+++ b/src/meta/cycleData/links/link.ts
@@ -1,4 +1,5 @@
 import { CountryIso } from 'meta/area/countryIso'
+import { CommentableDescriptionName } from 'meta/assessment/descriptionValue'
 
 type LinkLocationBase = {
   id: number
@@ -10,9 +11,9 @@ export const DescriptionLinkLocationPath = {
   text: ['text'],
 }
 
-type DescriptionsLocation = LinkLocationBase & {
+export type DescriptionsLocation = LinkLocationBase & {
   colName: string
-  descriptionName: string
+  descriptionName: CommentableDescriptionName
   path: Array<string>
   sectionName: string
   uuid?: string

--- a/src/meta/cycleData/links/links.ts
+++ b/src/meta/cycleData/links/links.ts
@@ -2,12 +2,10 @@ import { getI18nValidationStatusLabelKey } from 'meta/cycleData/links/getI18nVal
 import { getKey } from 'meta/cycleData/links/getKey'
 import { getLocationLabel } from 'meta/cycleData/links/getLocationLabel'
 import { isDescriptionLocation } from 'meta/cycleData/links/isDescriptionLocation'
-import { isLocationPath } from 'meta/cycleData/links/isLocationPath'
 
 export const Links = {
   getI18nValidationStatusLabelKey,
   getKey,
   getLocationLabel,
   isDescriptionLocation,
-  isLocationPath,
 }

--- a/src/meta/cycleData/links/links.ts
+++ b/src/meta/cycleData/links/links.ts
@@ -1,9 +1,13 @@
 import { getI18nValidationStatusLabelKey } from 'meta/cycleData/links/getI18nValidationStatusLabelKey'
 import { getKey } from 'meta/cycleData/links/getKey'
 import { getLocationLabel } from 'meta/cycleData/links/getLocationLabel'
+import { isDescriptionLocation } from 'meta/cycleData/links/isDescriptionLocation'
+import { isLocationPath } from 'meta/cycleData/links/isLocationPath'
 
 export const Links = {
   getI18nValidationStatusLabelKey,
   getKey,
   getLocationLabel,
+  isDescriptionLocation,
+  isLocationPath,
 }

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/buildDescriptionLinkValidations.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/buildDescriptionLinkValidations.ts
@@ -1,23 +1,12 @@
-import { CommentableDescription, CommentableDescriptionName } from 'meta/assessment/descriptionValue'
+import { CommentableDescription } from 'meta/assessment/descriptionValue'
 import { RecordDescriptionValidations } from 'meta/assessment/validation/description'
-import { Link, LinkLocation, LinkToVisit, LinkValidationStatusCode, VisitedLink } from 'meta/cycleData/links/link'
+import { ValidationMessage } from 'meta/assessment/validation/validation'
+import { Link, LinkToVisit, LinkValidationStatusCode, VisitedLink } from 'meta/cycleData/links/link'
 import { Links } from 'meta/cycleData/links/links'
 import { Objects } from 'utils/objects'
 
-const _isDescriptionTextLocation = (
-  location: LinkLocation
-): location is Extract<LinkLocation, { descriptionName: string }> => {
-  return 'descriptionName' in location && location.path.length === 1 && location.path[0] === 'text'
-}
-
-const _getInvalidLinkLabel = (linkToVisit: LinkToVisit): string => {
-  const { link, name } = linkToVisit
-
-  if (!Objects.isEmpty(link)) return link
-  if (!Objects.isEmpty(name)) return name
-
-  return ''
-}
+import { buildInitialDescriptionValidations } from './buildInitialDescriptionValidations'
+import { updateLocationValidation } from './updateLocationValidation'
 
 type Props = {
   approvedLinks: Array<Link>
@@ -29,49 +18,42 @@ type Props = {
 export const buildDescriptionLinkValidations = (props: Props): RecordDescriptionValidations => {
   const { approvedLinks, initialDescriptions = [], linkVisits, linksToVisit } = props
 
-  const approvedLinksSet = new Set<string>(approvedLinks.map(Links.getKey))
-  const linkVisitsByKey = linkVisits.reduce<Record<string, VisitedLink>>((acc, linkVisit) => {
+  // Start from a clean validation state for the edited descriptions,
+  // so old link errors disappear when links are fixed or removed.
+  const descriptionValidations = buildInitialDescriptionValidations(initialDescriptions)
+
+  const approvedLinkKeys = new Set<string>(approvedLinks.map(Links.getKey))
+  const visitedLinksByKey = linkVisits.reduce<Record<string, VisitedLink>>((acc, linkVisit) => {
     acc[Links.getKey(linkVisit)] = linkVisit
     return acc
   }, {})
 
-  // Mark the validated descriptions as valid first, so removing the last invalid link clears the previous error.
-  const initialValidations = initialDescriptions.reduce<RecordDescriptionValidations>((acc, description) => {
-    const { name, sectionName } = description
-    const sectionValidation = (acc[sectionName] ??= { descriptions: {} })
-    sectionValidation.descriptions ??= {}
-    sectionValidation.descriptions[name] = { valid: true }
-    return acc
-  }, {})
-
-  return linksToVisit.reduce<RecordDescriptionValidations>((acc, linkToVisit) => {
+  linksToVisit.forEach((linkToVisit) => {
     const linkKey = Links.getKey(linkToVisit)
-    const approved = approvedLinksSet.has(linkKey)
-    const validationCode = linkVisitsByKey[linkKey]?.code
-    const valid = approved || validationCode === LinkValidationStatusCode.success
+    const approved = approvedLinkKeys.has(linkKey)
+    const validationCode = visitedLinksByKey[linkKey]?.code
 
-    linkToVisit.locations.filter(_isDescriptionTextLocation).forEach((location) => {
-      const { descriptionName, sectionName } = location
-      const sectionValidation = (acc[sectionName] ??= { descriptions: {} })
-      const descriptions = (sectionValidation.descriptions ??= {})
-      const descriptionValidation = (descriptions[descriptionName as CommentableDescriptionName] ??= { valid: true })
+    let linkValidationMessage: ValidationMessage | undefined
+    const isInvalid = !approved && validationCode !== undefined && validationCode !== LinkValidationStatusCode.success
+    if (isInvalid) {
+      const { link, name } = linkToVisit
+      const invalidLinkLabel = !Objects.isEmpty(link) ? link : name
 
-      descriptionValidation.valid = descriptionValidation.valid && valid
-
-      if (!valid && validationCode) {
-        descriptionValidation.messages ??= []
-        descriptionValidation.messages.push({
-          key: 'generalValidation.invalidLinkWithReason',
-          params: {
-            link: _getInvalidLinkLabel(linkToVisit),
-            reason: Links.getI18nValidationStatusLabelKey(validationCode),
-          },
-        })
+      linkValidationMessage = {
+        key: 'generalValidation.invalidLinkWithReason',
+        params: {
+          link: invalidLinkLabel,
+          reason: Links.getI18nValidationStatusLabelKey(validationCode),
+        },
       }
-    })
+    }
 
-    return acc
-  }, initialValidations)
+    linkToVisit.locations.forEach((location) => {
+      updateLocationValidation({ descriptionValidations, linkValidationMessage, location })
+    })
+  })
+
+  return descriptionValidations
 }
 
 export const buildDescriptionLinkValidationsByCountry = (

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/buildInitialDescriptionValidations.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/buildInitialDescriptionValidations.ts
@@ -1,0 +1,37 @@
+import { CommentableDescription } from 'meta/assessment/descriptionValue'
+import { RecordDescriptionValidations } from 'meta/assessment/validation/description'
+import { Validation } from 'meta/assessment/validation/validation'
+import { Objects } from 'utils/objects'
+
+// Builds the initial description validation state before link results are applied. Description text starts valid;
+// data source references also include required-field validation, so empty references are flagged.
+export const buildInitialDescriptionValidations = (
+  initialDescriptions: Array<CommentableDescription>
+): RecordDescriptionValidations => {
+  const validations: RecordDescriptionValidations = {}
+
+  initialDescriptions.forEach((description) => {
+    const { name, sectionName, value } = description
+    const sectionValidation = (validations[sectionName] ??= {})
+
+    const descriptions = (sectionValidation.descriptions ??= {})
+    descriptions[name] = { valid: true }
+
+    if (value.dataSources === undefined) return
+
+    const dataSources = (sectionValidation.dataSources ??= {})
+    value.dataSources.forEach((dataSource) => {
+      const { placeholder, reference, uuid } = dataSource
+      if (placeholder || Objects.isEmpty(uuid)) return
+
+      const referenceValidation: Validation = { valid: true }
+      if (Objects.isEmpty(reference)) {
+        referenceValidation.valid = false
+        referenceValidation.messages = [{ key: 'generalValidation.notEmpty' }]
+      }
+      dataSources[uuid] = { reference: referenceValidation }
+    })
+  })
+
+  return validations
+}

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/getDescriptionLinks.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/getDescriptionLinks.ts
@@ -2,9 +2,10 @@ import { CountryIso } from 'meta/area/countryIso'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import { CommentableDescription } from 'meta/assessment/descriptionValue'
-import { LinkToVisit } from 'meta/cycleData/links/link'
+import { DescriptionLinkLocationPath, LinkToVisit } from 'meta/cycleData/links/link'
 import { Routes } from 'meta/routes/routes'
 import { Htmls } from 'utils/htmls'
+import { Objects } from 'utils/objects'
 
 import { DescriptionRepository } from 'server/db/repository/assessmentCycle/descriptions'
 
@@ -29,9 +30,29 @@ export const getDescriptionLinks = async (props: Props): Promise<Returned> => {
     const { id, name: descriptionName, sectionName, value } = description
     const urlParams = { assessmentName: assessment.props.name, countryIso, cycleName: cycle.name, sectionName }
     const url = Routes.Section.generatePath(urlParams)
-    const locations = [{ colName: 'value', descriptionName, id, path: ['text'], sectionName, url }]
 
-    return Htmls.getLinks(value.text).map(({ link, name }) => ({ countryIso, link: link ?? '', locations, name }))
+    // Build text links to visit
+    const path = DescriptionLinkLocationPath.text
+    const textLocations = [{ colName: 'value', descriptionName, id, path, sectionName, url }]
+    const textLinks = Htmls.getLinks(value.text).map(({ link, name }) => ({
+      countryIso,
+      link: link ?? '',
+      locations: textLocations,
+      name,
+    }))
+
+    // Build reference links to visit
+    const referenceLinks = (value.dataSources ?? []).flatMap((dataSource) => {
+      const { placeholder, reference, uuid } = dataSource
+      if (placeholder || Objects.isEmpty(uuid)) return []
+
+      const path = DescriptionLinkLocationPath.dataSourceReference
+      const locations = [{ colName: 'value', descriptionName, id, path, sectionName, url, uuid }]
+
+      return Htmls.getLinks(reference).map(({ link, name }) => ({ countryIso, link: link ?? '', locations, name }))
+    })
+
+    return textLinks.concat(referenceLinks)
   })
 
   return { descriptions, linksToVisit }

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/updateLocationValidation.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/updateLocationValidation.ts
@@ -1,0 +1,45 @@
+import { RecordDescriptionValidations } from 'meta/assessment/validation/description'
+import { Validation, ValidationMessage } from 'meta/assessment/validation/validation'
+import { DescriptionLinkLocationPath, LinkLocation } from 'meta/cycleData/links/link'
+import { Links } from 'meta/cycleData/links/links'
+import { Objects } from 'utils/objects'
+
+type Props = {
+  descriptionValidations: RecordDescriptionValidations
+  linkValidationMessage?: ValidationMessage
+  location: LinkLocation
+}
+
+export const updateLocationValidation = (props: Props): void => {
+  const { descriptionValidations, linkValidationMessage, location } = props
+
+  if (!Links.isDescriptionLocation(location)) return
+
+  let validation: Validation | undefined
+  const { sectionName } = location
+  const sectionValidation = (descriptionValidations[sectionName] ??= {})
+
+  // For description.text
+  if (Links.isLocationPath(location.path, DescriptionLinkLocationPath.text)) {
+    const { descriptionName } = location
+    const descriptions = (sectionValidation.descriptions ??= {})
+    validation = descriptions[descriptionName] ??= { valid: true }
+  }
+
+  // For dataSource.reference
+  if (Links.isLocationPath(location.path, DescriptionLinkLocationPath.dataSourceReference)) {
+    const { uuid } = location
+    if (Objects.isEmpty(uuid)) return
+
+    const dataSources = (sectionValidation.dataSources ??= {})
+    const dataSource = (dataSources[uuid] ??= {})
+    validation = dataSource.reference ??= { valid: true }
+  }
+
+  if (!validation || linkValidationMessage === undefined) return
+
+  // Append invalid message
+  validation.valid = false
+  validation.messages ??= []
+  validation.messages.push(linkValidationMessage)
+}

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/updateLocationValidation.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/updateLocationValidation.ts
@@ -20,14 +20,14 @@ export const updateLocationValidation = (props: Props): void => {
   const sectionValidation = (descriptionValidations[sectionName] ??= {})
 
   // For description.text
-  if (Links.isLocationPath(location.path, DescriptionLinkLocationPath.text)) {
+  if (Objects.isEqual(location.path, DescriptionLinkLocationPath.text)) {
     const { descriptionName } = location
     const descriptions = (sectionValidation.descriptions ??= {})
     validation = descriptions[descriptionName] ??= { valid: true }
   }
 
   // For dataSource.reference
-  if (Links.isLocationPath(location.path, DescriptionLinkLocationPath.dataSourceReference)) {
+  if (Objects.isEqual(location.path, DescriptionLinkLocationPath.dataSourceReference)) {
     const { uuid } = location
     if (Objects.isEmpty(uuid)) return
 


### PR DESCRIPTION
Handling the reference links in the worker, by adding them to the list of links to validate and by updating the reference validation under dataSources. 
Here we also validate that the reference is not empty. 


https://github.com/user-attachments/assets/bf8035b9-32d3-4e40-9dda-ee6063caf79d


