### PR TITLE
6001: Dependencies upgrade: react-tooltip -> CountryMultiSelect - Fix overlapping issue

### DIFF
--- a/src/client/components/Tooltips/Tooltips.scss
+++ b/src/client/components/Tooltips/Tooltips.scss
@@ -5,9 +5,9 @@
 $border: 1px solid color.adjust($text-body, $lightness: -4%, $space: hsl);
 
 .tooltip-container {
-  z-index: $z-index-tooltip;
-
   .react-tooltip {
+    z-index: $z-index-tooltip;
+
     ul {
       list-style: none;
       padding: 0;


### PR DESCRIPTION
In the new tooltip package version, the element that is stacked is `.react-tooltip`, not `.tooltip-container`. So, we need to set the z-index directly on `.react-tooltip` to make it have precedence over the grid sticky cells.


https://github.com/user-attachments/assets/0dd21cc2-6bd7-4f26-8e42-700c4bee3d83

