### PR TITLE
5758 - Navigation: Data errors - Remove buildEmail isPanEuropean prop for link locations

### DIFF
--- a/src/server/service/mail/notifyLinksInvalid/buildEmail/_getHtmlItems.ts
+++ b/src/server/service/mail/notifyLinksInvalid/buildEmail/_getHtmlItems.ts
@@ -2,30 +2,28 @@ import { _getLinkLocationLinks } from './_getLinkLocationLinks'
 import { CountryRenderProps, LinkRenderProps, RenderProps } from './types'
 
 const _getLinkItem = (props: LinkRenderProps): string => {
-  const { countryIso, cycle, isPanEuropean, link, subSections, t } = props
-  const locationItems = _getLinkLocationLinks({ countryIso, cycle, isPanEuropean, link, subSections, t })
+  const { assessment, countryIso, cycle, link, subSections, t } = props
+  const locationItems = _getLinkLocationLinks({ assessment, countryIso, cycle, link, subSections, t })
     .map(({ label, url }) => `<li><a href="${url}">${label}</a></li>`)
     .join('')
   return `<li><a href="${link.link}">${link.link}</a>${locationItems ? `<ul>${locationItems}</ul>` : ''}</li>`
 }
 
 const _getCountryItem = (props: CountryRenderProps): string => {
-  const { countryEntry, cycle, isPanEuropean, subSections, t } = props
+  const { assessment, countryEntry, cycle, subSections, t } = props
   const { countryIso, countryLinksUrl, countryName, links } = countryEntry
 
   const invalidLinkCount = t('email.invalidLinks.invalidLinkCount', { count: links.length })
   const linkStatusPageInfo = t('email.invalidLinks.linkStatusPageInfo', { countryName })
-  const linkItems = links
-    .map((link) => _getLinkItem({ countryIso, cycle, isPanEuropean, link, subSections, t }))
-    .join('')
+  const linkItems = links.map((link) => _getLinkItem({ assessment, countryIso, cycle, link, subSections, t })).join('')
 
   return `<li><strong>${countryName} (${countryIso})</strong>: ${invalidLinkCount}<br />${linkStatusPageInfo}: <a href="${countryLinksUrl}">${countryLinksUrl}</a><ul>${linkItems}</ul></li>`
 }
 
 // Returns the HTML body of the email
 export const _getHtmlItems = (props: RenderProps): string => {
-  const { countryEntries, cycle, isPanEuropean, subSections, t } = props
+  const { assessment, countryEntries, cycle, subSections, t } = props
   return countryEntries
-    .map((countryEntry) => _getCountryItem({ countryEntry, cycle, isPanEuropean, subSections, t }))
+    .map((countryEntry) => _getCountryItem({ assessment, countryEntry, cycle, subSections, t }))
     .join('')
 }

--- a/src/server/service/mail/notifyLinksInvalid/buildEmail/_getLinkLocationLinks.ts
+++ b/src/server/service/mail/notifyLinksInvalid/buildEmail/_getLinkLocationLinks.ts
@@ -5,13 +5,13 @@ import { ProcessEnv } from 'server/utils'
 import { LinkRenderProps, LocationLink } from './types'
 
 export const _getLinkLocationLinks = (props: LinkRenderProps): Array<LocationLink> => {
-  const { countryIso, cycle, isPanEuropean, link, subSections, t } = props
+  const { assessment, countryIso, cycle, link, subSections, t } = props
   return link.locations.reduce<Array<LocationLink>>((locationLinks, location) => {
     const label = Links.getLocationLabel({
+      assessment,
       countryIso,
       cycle,
       includeCountryIso: false,
-      isPanEuropean,
       location,
       subSections,
       t,

--- a/src/server/service/mail/notifyLinksInvalid/buildEmail/_getTextLines.ts
+++ b/src/server/service/mail/notifyLinksInvalid/buildEmail/_getTextLines.ts
@@ -2,21 +2,21 @@ import { _getLinkLocationLinks } from './_getLinkLocationLinks'
 import { CountryRenderProps, LinkRenderProps, RenderProps } from './types'
 
 const _getLinkLines = (props: LinkRenderProps): string => {
-  const { countryIso, cycle, isPanEuropean, link, subSections, t } = props
-  const locationLines = _getLinkLocationLinks({ countryIso, cycle, isPanEuropean, link, subSections, t })
+  const { assessment, countryIso, cycle, link, subSections, t } = props
+  const locationLines = _getLinkLocationLinks({ assessment, countryIso, cycle, link, subSections, t })
     .map(({ label, url }) => `      ${label}: ${url}`)
     .join('\n')
   return `    - ${link.link}${locationLines ? `\n${locationLines}` : ''}`
 }
 
 const _getCountryLines = (props: CountryRenderProps): string => {
-  const { countryEntry, cycle, isPanEuropean, subSections, t } = props
+  const { assessment, countryEntry, cycle, subSections, t } = props
   const { countryIso, countryLinksUrl, countryName, links } = countryEntry
 
   const invalidLinkCount = t('email.invalidLinks.invalidLinkCount', { count: links.length })
   const linkStatusPageInfo = t('email.invalidLinks.linkStatusPageInfo', { countryName })
   const linkLines = links
-    .map((link) => _getLinkLines({ countryIso, cycle, isPanEuropean, link, subSections, t }))
+    .map((link) => _getLinkLines({ assessment, countryIso, cycle, link, subSections, t }))
     .join('\n')
 
   return `  ${countryName} (${countryIso}): ${invalidLinkCount}\n  ${linkStatusPageInfo}: ${countryLinksUrl}\n${linkLines}`
@@ -24,8 +24,8 @@ const _getCountryLines = (props: CountryRenderProps): string => {
 
 // Returns the text version of the body of the email
 export const _getTextLines = (props: RenderProps): string => {
-  const { countryEntries, cycle, isPanEuropean, subSections, t } = props
+  const { assessment, countryEntries, cycle, subSections, t } = props
   return countryEntries
-    .map((countryEntry) => _getCountryLines({ countryEntry, cycle, isPanEuropean, subSections, t }))
+    .map((countryEntry) => _getCountryLines({ assessment, countryEntry, cycle, subSections, t }))
     .join('\n\n')
 }

--- a/src/server/service/mail/notifyLinksInvalid/buildEmail/index.ts
+++ b/src/server/service/mail/notifyLinksInvalid/buildEmail/index.ts
@@ -1,4 +1,4 @@
-import { Assessment, AssessmentNames } from 'meta/assessment/assessment'
+import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import { User } from 'meta/user/user'
 import { Users } from 'meta/user/users'
@@ -35,10 +35,9 @@ export const buildEmail = async (props: Props): Promise<MailServiceEmail> => {
 
   const sections = await MetadataController.getSections({ assessment, cycle })
   const subSections = sections.flatMap((section) => section.subSections ?? [])
-  const isPanEuropean = assessment.props.name === AssessmentNames.panEuropean
 
   const countryEntries = _getCountryEntries({ assessmentName, cycleName, linksByCountry, t })
-  const renderProps: RenderProps = { countryEntries, cycle, isPanEuropean, subSections, t }
+  const renderProps: RenderProps = { assessment, countryEntries, cycle, subSections, t }
   const textLines = _getTextLines(renderProps)
   const htmlItems = _getHtmlItems(renderProps)
 

--- a/src/server/service/mail/notifyLinksInvalid/buildEmail/types.ts
+++ b/src/server/service/mail/notifyLinksInvalid/buildEmail/types.ts
@@ -1,13 +1,14 @@
 import { TFunction } from 'i18next'
 
 import { CountryIso } from 'meta/area/countryIso'
+import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import { SubSection } from 'meta/assessment/section'
 import { Link } from 'meta/cycleData/links/link'
 
 export type RenderContext = {
+  assessment: Assessment
   cycle: Cycle
-  isPanEuropean: boolean
   subSections: Array<SubSection>
   t: TFunction
 }


### PR DESCRIPTION
Updating the code introduced in #6008 because we pass `assessment` instead of `isPanEuropean` in the updated `Links.getLocationLabel`