### PR TITLE
5758 - Navigation: Data errors - NDP - Show year and national class validation errors

### DIFF
--- a/src/client/pages/OriginalDataPoint/components/ExtentOfForest/ExtentOfForest.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ExtentOfForest/ExtentOfForest.tsx
@@ -30,10 +30,6 @@ const ExtentOfForest: React.FC<Props> = (props) => {
 
   const nationalClasses = originalDataPoint.nationalClasses.filter((nationalClass) => !nationalClass.placeHolder)
 
-  const nationalClassValidations = nationalClasses.map((_, index) =>
-    ODPs.validateNationalClass(originalDataPoint, index)
-  )
-
   const totalArea = Numbers.format(ODPs.calcTotalArea({ originalDataPoint }))
   const totalForestPercentArea = Numbers.format(ODPs.calcTotalFieldArea({ originalDataPoint, field: 'forestPercent' }))
   const totalOtherWoodedLandPercentArea = Numbers.format(
@@ -94,7 +90,6 @@ const ExtentOfForest: React.FC<Props> = (props) => {
                   key={nationalClass.name}
                   canEditData={canEditData}
                   index={index}
-                  nationalClassValidation={nationalClassValidations[index]}
                   originalDataPoint={originalDataPoint}
                 />
               ))}

--- a/src/client/pages/OriginalDataPoint/components/ExtentOfForest/ExtentOfForestRow.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ExtentOfForest/ExtentOfForestRow.tsx
@@ -1,13 +1,11 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-
 import classNames from 'classnames'
 
 import { ODPs } from 'meta/assessment/odps'
-import { NationalClassValidation } from 'meta/assessment/odps/validateODP'
 import { ODPNationalClass, OriginalDataPoint } from 'meta/assessment/originalDataPoint'
 import { Topics } from 'meta/messageCenter/topics'
-import { TooltipId } from 'meta/tooltip/id'
+import { Objects } from 'utils/objects'
 
 import { useCycle } from 'client/store/meta/hooks/cycles'
 import DiffText from 'client/components/DiffText'
@@ -19,7 +17,7 @@ import { Columns, useOnPaste } from 'client/pages/OriginalDataPoint/components/h
 import { useUpdateOriginalData } from 'client/pages/OriginalDataPoint/components/hooks/useUpdateOriginalData'
 import { useUpdateOriginalDataField } from 'client/pages/OriginalDataPoint/components/hooks/useUpdateOriginalDataField'
 import ODPDiffText from 'client/pages/OriginalDataPoint/components/ODPDiffText/ODPDiffText'
-import { useNationalClassValidations } from 'client/pages/OriginalDataPoint/hooks/useNationalClassValidations'
+import { useNationalClassErrorTooltip } from 'client/pages/OriginalDataPoint/hooks/useNationalClassErrorTooltip'
 import { useShowReviewIndicator } from 'client/pages/OriginalDataPoint/hooks/useShowReviewIndicator'
 
 import { useNationalClassNameComments } from '../../hooks'
@@ -29,7 +27,6 @@ type Props = {
   canEditData: boolean
   index: number
   originalDataPoint: OriginalDataPoint
-  nationalClassValidation: NationalClassValidation
 }
 
 const columns: Columns = [
@@ -40,7 +37,7 @@ const columns: Columns = [
 ]
 
 const ExtentOfForestRow: React.FC<Props> = (props) => {
-  const { canEditData, index, nationalClassValidation, originalDataPoint } = props
+  const { canEditData, index, originalDataPoint } = props
 
   const { t } = useTranslation()
   const cycle = useCycle()
@@ -52,13 +49,16 @@ const ExtentOfForestRow: React.FC<Props> = (props) => {
 
   const displayHistory = useODPDisplayHistory()
 
-  let validationErrorMessage = useNationalClassValidations({
-    index,
-    originalDataPoint,
-    variable: 'validExtentOfForestPercentage',
+  const areaErrorTooltip = useNationalClassErrorTooltip({
+    field: 'area',
+    nationalClassUuid: uuid,
+    nationalDataPointUuid: originalDataPoint.uuid,
   })
-
-  validationErrorMessage = displayHistory ? null : validationErrorMessage
+  const percentageErrorTooltip = useNationalClassErrorTooltip({
+    field: 'extentOfForestPercentage',
+    nationalClassUuid: uuid,
+    nationalDataPointUuid: originalDataPoint.uuid,
+  })
 
   const otherLandPercent = ODPs.calculateNationalClassOtherLandPercent(nationalClass)
 
@@ -84,8 +84,10 @@ const ExtentOfForestRow: React.FC<Props> = (props) => {
       </th>
       <td
         className={classNames(`fra-table__cell fra-table__divider`, {
-          'validation-error': !nationalClassValidation.validArea,
+          'validation-error': !Objects.isEmpty(areaErrorTooltip),
         })}
+        data-tooltip-content={areaErrorTooltip?.content}
+        data-tooltip-id={areaErrorTooltip?.id}
       >
         {displayHistory ? (
           <ODPDiffText
@@ -112,9 +114,9 @@ const ExtentOfForestRow: React.FC<Props> = (props) => {
       </td>
 
       <td
-        className={classNames('fra-table__cell', { 'validation-error': Boolean(validationErrorMessage) })}
-        data-tooltip-content={validationErrorMessage}
-        data-tooltip-id={TooltipId.error}
+        className={classNames('fra-table__cell', { 'validation-error': !Objects.isEmpty(percentageErrorTooltip) })}
+        data-tooltip-content={percentageErrorTooltip?.content}
+        data-tooltip-id={percentageErrorTooltip?.id}
       >
         {displayHistory ? (
           <div className="odp-percent-diff">
@@ -143,9 +145,9 @@ const ExtentOfForestRow: React.FC<Props> = (props) => {
       </td>
 
       <td
-        className={classNames('fra-table__cell', { 'validation-error': Boolean(validationErrorMessage) })}
-        data-tooltip-content={validationErrorMessage}
-        data-tooltip-id={TooltipId.error}
+        className={classNames('fra-table__cell', { 'validation-error': !Objects.isEmpty(percentageErrorTooltip) })}
+        data-tooltip-content={percentageErrorTooltip?.content}
+        data-tooltip-id={percentageErrorTooltip?.id}
       >
         {displayHistory ? (
           <div className="odp-percent-diff">

--- a/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristicsNaturallyRegeneratingRow.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristicsNaturallyRegeneratingRow.tsx
@@ -6,8 +6,8 @@ import { ODPs } from 'meta/assessment/odps'
 import { OriginalDataPoint } from 'meta/assessment/originalDataPoint'
 import { SectionNames } from 'meta/assessment/section'
 import { Topics } from 'meta/messageCenter/topics'
-import { TooltipId } from 'meta/tooltip/id'
 import { Numbers } from 'utils/numbers'
+import { Objects } from 'utils/objects'
 
 import DiffText from 'client/components/DiffText'
 import InputPercent from 'client/components/Inputs/InputPercent'
@@ -17,7 +17,7 @@ import { Columns, useOnPaste } from 'client/pages/OriginalDataPoint/components/h
 import { useUpdateOriginalData } from 'client/pages/OriginalDataPoint/components/hooks/useUpdateOriginalData'
 import { useUpdateOriginalDataField } from 'client/pages/OriginalDataPoint/components/hooks/useUpdateOriginalDataField'
 import ODPDiffText from 'client/pages/OriginalDataPoint/components/ODPDiffText/ODPDiffText'
-import { useNationalClassValidations } from 'client/pages/OriginalDataPoint/hooks/useNationalClassValidations'
+import { useNationalClassErrorTooltip } from 'client/pages/OriginalDataPoint/hooks/useNationalClassErrorTooltip'
 import { useShowReviewIndicator } from 'client/pages/OriginalDataPoint/hooks/useShowReviewIndicator'
 
 import { useNationalClassNameComments } from '../../hooks'
@@ -52,12 +52,11 @@ const ForestCharacteristicsNaturallyRegeneratingRow: React.FC<Props> = (props) =
 
   const displayHistory = useODPDisplayHistory()
 
-  let validationErrorMessage = useNationalClassValidations({
-    index,
-    originalDataPoint,
-    variable: 'validPrimaryForest',
+  const errorTooltip = useNationalClassErrorTooltip({
+    field: 'primaryForest',
+    nationalClassUuid: uuid,
+    nationalDataPointUuid: originalDataPoint.uuid,
   })
-  validationErrorMessage = displayHistory ? null : validationErrorMessage
 
   const _onPaste = useOnPaste({
     columns,
@@ -87,9 +86,9 @@ const ForestCharacteristicsNaturallyRegeneratingRow: React.FC<Props> = (props) =
         {displayHistory ? <DiffText changes={changes?.naturalForestPercentArea} /> : Numbers.format(ofWhichPrimary)}
       </th>
       <td
-        className={classNames(`fra-table__cell`, { 'validation-error': Boolean(validationErrorMessage) })}
-        data-tooltip-content={validationErrorMessage}
-        data-tooltip-id={TooltipId.error}
+        className={classNames(`fra-table__cell`, { 'validation-error': !Objects.isEmpty(errorTooltip) })}
+        data-tooltip-content={errorTooltip?.content}
+        data-tooltip-id={errorTooltip?.id}
       >
         {displayHistory ? (
           <div className="odp-percent-diff">

--- a/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristicsPlantationRow.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristicsPlantationRow.tsx
@@ -6,8 +6,8 @@ import { ODPs } from 'meta/assessment/odps'
 import { ODPNationalClass, OriginalDataPoint } from 'meta/assessment/originalDataPoint'
 import { SectionNames } from 'meta/assessment/section'
 import { Topics } from 'meta/messageCenter/topics'
-import { TooltipId } from 'meta/tooltip/id'
 import { Numbers } from 'utils/numbers'
+import { Objects } from 'utils/objects'
 
 import DiffText from 'client/components/DiffText'
 import InputPercent from 'client/components/Inputs/InputPercent'
@@ -16,7 +16,7 @@ import { useODPDisplayHistory } from 'client/pages/OriginalDataPoint/components/
 import { Columns, useOnPaste } from 'client/pages/OriginalDataPoint/components/hooks/useOnPaste'
 import { useUpdateOriginalData } from 'client/pages/OriginalDataPoint/components/hooks/useUpdateOriginalData'
 import { useUpdateOriginalDataField } from 'client/pages/OriginalDataPoint/components/hooks/useUpdateOriginalDataField'
-import { useNationalClassValidations } from 'client/pages/OriginalDataPoint/hooks/useNationalClassValidations'
+import { useNationalClassErrorTooltip } from 'client/pages/OriginalDataPoint/hooks/useNationalClassErrorTooltip'
 import { useShowReviewIndicator } from 'client/pages/OriginalDataPoint/hooks/useShowReviewIndicator'
 
 import { useNationalClassNameComments } from '../../hooks'
@@ -48,12 +48,11 @@ const ForestCharacteristicsPlantationRow: React.FC<Props> = (props) => {
 
   const displayHistory = useODPDisplayHistory()
 
-  let validationErrorMessage = useNationalClassValidations({
-    index,
-    originalDataPoint,
-    variable: 'validForestPlantationIntroducedPercent',
+  const errorTooltip = useNationalClassErrorTooltip({
+    field: 'forestPlantationIntroducedPercentage',
+    nationalClassUuid: uuid,
+    nationalDataPointUuid: originalDataPoint.uuid,
   })
-  validationErrorMessage = displayHistory ? null : validationErrorMessage
 
   const _onPaste = useOnPaste({
     columns,
@@ -87,9 +86,9 @@ const ForestCharacteristicsPlantationRow: React.FC<Props> = (props) => {
         )}
       </th>
       <td
-        className={classNames('fra-table__cell', { 'validation-error': Boolean(validationErrorMessage) })}
-        data-tooltip-content={validationErrorMessage}
-        data-tooltip-id={TooltipId.error}
+        className={classNames('fra-table__cell', { 'validation-error': !Objects.isEmpty(errorTooltip) })}
+        data-tooltip-content={errorTooltip?.content}
+        data-tooltip-id={errorTooltip?.id}
       >
         {displayHistory ? (
           <div className="odp-percent-diff">

--- a/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristicsRow.tsx
+++ b/src/client/pages/OriginalDataPoint/components/ForestCharacteristics/ForestCharacteristicsRow.tsx
@@ -1,13 +1,12 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-
 import classNames from 'classnames'
 
 import { ODPs } from 'meta/assessment/odps'
 import { ODPNationalClass, OriginalDataPoint } from 'meta/assessment/originalDataPoint'
 import { SectionNames } from 'meta/assessment/section'
 import { Topics } from 'meta/messageCenter/topics'
-import { TooltipId } from 'meta/tooltip/id'
+import { Objects } from 'utils/objects'
 
 import DiffText from 'client/components/DiffText'
 import InputPercent from 'client/components/Inputs/InputPercent'
@@ -17,7 +16,7 @@ import { Columns, useOnPaste } from 'client/pages/OriginalDataPoint/components/h
 import { useUpdateOriginalData } from 'client/pages/OriginalDataPoint/components/hooks/useUpdateOriginalData'
 import { useUpdateOriginalDataField } from 'client/pages/OriginalDataPoint/components/hooks/useUpdateOriginalDataField'
 import ODPDiffText from 'client/pages/OriginalDataPoint/components/ODPDiffText/ODPDiffText'
-import { useNationalClassValidations } from 'client/pages/OriginalDataPoint/hooks/useNationalClassValidations'
+import { useNationalClassErrorTooltip } from 'client/pages/OriginalDataPoint/hooks/useNationalClassErrorTooltip'
 import { useShowReviewIndicator } from 'client/pages/OriginalDataPoint/hooks/useShowReviewIndicator'
 
 import { useNationalClassNameComments } from '../../hooks'
@@ -58,12 +57,11 @@ const ForestCharacteristicsRow: React.FC<Props> = (props) => {
 
   const displayHistory = useODPDisplayHistory()
 
-  let validationErrorMessage = useNationalClassValidations({
-    index,
-    originalDataPoint,
-    variable: 'validForestCharacteristicsPercentage',
+  const errorTooltip = useNationalClassErrorTooltip({
+    field: 'forestCharacteristicsPercentage',
+    nationalClassUuid: uuid,
+    nationalDataPointUuid: originalDataPoint.uuid,
   })
-  validationErrorMessage = displayHistory ? null : validationErrorMessage
 
   const nationalClassForestArea = ODPs.calculateNationalClassForestArea(nationalClass)
   const nationalClassForestAreaChange = useNationalClassForestAreaChange({
@@ -92,9 +90,9 @@ const ForestCharacteristicsRow: React.FC<Props> = (props) => {
       </th>
 
       <td
-        className={classNames('fra-table__cell', { 'validation-error': Boolean(validationErrorMessage) })}
-        data-tooltip-content={validationErrorMessage}
-        data-tooltip-id={TooltipId.error}
+        className={classNames('fra-table__cell', { 'validation-error': !Objects.isEmpty(errorTooltip) })}
+        data-tooltip-content={errorTooltip?.content}
+        data-tooltip-id={errorTooltip?.id}
       >
         {displayHistory ? (
           <div className="odp-percent-diff">
@@ -123,9 +121,9 @@ const ForestCharacteristicsRow: React.FC<Props> = (props) => {
       </td>
 
       <td
-        className={classNames('fra-table__cell', { 'validation-error': Boolean(validationErrorMessage) })}
-        data-tooltip-content={validationErrorMessage}
-        data-tooltip-id={TooltipId.error}
+        className={classNames('fra-table__cell', { 'validation-error': !Objects.isEmpty(errorTooltip) })}
+        data-tooltip-content={errorTooltip?.content}
+        data-tooltip-id={errorTooltip?.id}
       >
         {displayHistory ? (
           <div className="odp-percent-diff">
@@ -154,9 +152,9 @@ const ForestCharacteristicsRow: React.FC<Props> = (props) => {
       </td>
 
       <td
-        className={classNames('fra-table__cell', { 'validation-error': Boolean(validationErrorMessage) })}
-        data-tooltip-content={validationErrorMessage}
-        data-tooltip-id={TooltipId.error}
+        className={classNames('fra-table__cell', { 'validation-error': !Objects.isEmpty(errorTooltip) })}
+        data-tooltip-content={errorTooltip?.content}
+        data-tooltip-id={errorTooltip?.id}
       >
         {displayHistory ? (
           <div className="odp-percent-diff">

--- a/src/client/pages/OriginalDataPoint/components/NationalClasses/components/NationalClass.tsx
+++ b/src/client/pages/OriginalDataPoint/components/NationalClasses/components/NationalClass.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
+import classNames from 'classnames'
 
-import { ODPs } from 'meta/assessment/odps'
 import { OriginalDataPoint } from 'meta/assessment/originalDataPoint'
+import { Objects } from 'utils/objects'
 
 import { useIsPrintRoute } from 'client/hooks/routes'
 import { DataCell, DataRow } from 'client/components/DataGrid'
 import InputText from 'client/components/Inputs/InputText'
 import TextArea from 'client/components/Inputs/TextArea'
+import { TooltipType } from 'client/components/Tooltips/type'
 import { useODPDisplayHistory } from 'client/pages/OriginalDataPoint/components/hooks/useODPDisplayHistory'
 import ODPDiffText from 'client/pages/OriginalDataPoint/components/ODPDiffText/ODPDiffText'
 // import { useNationalClassNameComments } from 'client/pages/OriginalDataPoint/hooks'
@@ -15,6 +17,7 @@ import {
   useIsEditODPDescriptionEnabled,
   useIsEditODPEnabled,
 } from 'client/pages/OriginalDataPoint/hooks/useIsEditODPEnabled'
+import { useNationalClassErrorTooltip } from 'client/pages/OriginalDataPoint/hooks/useNationalClassErrorTooltip'
 
 import { useOnChangeNationalClass } from './hooks/onChangeNationalClass'
 import { useRowActions } from './hooks/useRowActions'
@@ -29,7 +32,7 @@ const NationalClass: React.FC<Props> = (props) => {
 
   const { nationalClasses } = originalDataPoint
   const nationalClass = nationalClasses[index]
-  const { definition, name, placeHolder } = nationalClass
+  const { definition, name, placeHolder, uuid } = nationalClass
 
   const { t } = useTranslation()
   const { print } = useIsPrintRoute()
@@ -45,8 +48,13 @@ const NationalClass: React.FC<Props> = (props) => {
   // const target = [originalDataPoint.id, 'class', `${uuid}`, 'definition'] as string[]
   // const classNameRowComments = useNationalClassNameComments(target)
 
-  const nationalClassValidation = ODPs.validateNationalClass(originalDataPoint, index)
-  const error = !nationalClassValidation.validClassName
+  const errorTooltip = useNationalClassErrorTooltip({
+    field: 'name',
+    nationalClassUuid: uuid,
+    nationalDataPointUuid: originalDataPoint.uuid,
+  })
+  const error = !Objects.isEmpty(errorTooltip)
+  const tooltip = error ? { content: errorTooltip.content, type: TooltipType.error } : undefined
 
   // Hide placeholder row if user doesn't have table data permission (prevents adding new items)
   if (!canEditOdp && placeHolder) {
@@ -55,7 +63,7 @@ const NationalClass: React.FC<Props> = (props) => {
 
   return (
     <DataRow actions={actions}>
-      <DataCell error={error} lastRow={lastRow}>
+      <DataCell className={classNames({ 'validation-error': error })} error={error} lastRow={lastRow} tooltip={tooltip}>
         {displayHistory ? (
           <ODPDiffText
             className="input-text disabled"

--- a/src/client/pages/OriginalDataPoint/components/YearSelection/YearSelection.tsx
+++ b/src/client/pages/OriginalDataPoint/components/YearSelection/YearSelection.tsx
@@ -8,9 +8,9 @@ import { useODPYears, useOriginalDataPoint } from 'client/store/data/originalDat
 import { useIsEditTableDataEnabled } from 'client/store/user/hooks/auth'
 import { useOriginalDataPointRouteParams } from 'client/hooks/routeParams'
 import Select, { Option } from 'client/components/Inputs/Select'
-import { useYearErrorTooltip } from 'client/pages/OriginalDataPoint/hooks/useYearErrorTooltip'
 
 import { useOnChange } from './hooks/useOnChange'
+import { useYearErrorTooltip } from './hooks/useYearErrorTooltip'
 
 const YearSelection: React.FC = () => {
   const { t } = useTranslation()

--- a/src/client/pages/OriginalDataPoint/components/YearSelection/YearSelection.tsx
+++ b/src/client/pages/OriginalDataPoint/components/YearSelection/YearSelection.tsx
@@ -19,7 +19,7 @@ const YearSelection: React.FC = () => {
   const canEditData = useIsEditTableDataEnabled(sectionName)
   const onChange = useOnChange()
   const { reservedYears, years } = useODPYears()
-  const errorTooltip = useYearErrorTooltip({ nationalDataPointUuid: originalDataPoint.uuid })
+  const errorTooltip = useYearErrorTooltip({ nationalDataPointUuid: originalDataPoint?.uuid })
   const disabled = Boolean(!canEditData)
   const options = years.map<Option>((y) => {
     return { label: String(y), value: String(y) }

--- a/src/client/pages/OriginalDataPoint/components/YearSelection/YearSelection.tsx
+++ b/src/client/pages/OriginalDataPoint/components/YearSelection/YearSelection.tsx
@@ -2,12 +2,13 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import classNames from 'classnames'
 
-import { ODPs } from 'meta/assessment/odps'
+import { Objects } from 'utils/objects'
 
 import { useODPYears, useOriginalDataPoint } from 'client/store/data/originalDataPoint/hooks/originalDataPoint'
 import { useIsEditTableDataEnabled } from 'client/store/user/hooks/auth'
 import { useOriginalDataPointRouteParams } from 'client/hooks/routeParams'
 import Select, { Option } from 'client/components/Inputs/Select'
+import { useYearErrorTooltip } from 'client/pages/OriginalDataPoint/hooks/useYearErrorTooltip'
 
 import { useOnChange } from './hooks/useOnChange'
 
@@ -18,7 +19,7 @@ const YearSelection: React.FC = () => {
   const canEditData = useIsEditTableDataEnabled(sectionName)
   const onChange = useOnChange()
   const { reservedYears, years } = useODPYears()
-  const validYear = ODPs.validateYear(originalDataPoint)
+  const errorTooltip = useYearErrorTooltip({ nationalDataPointUuid: originalDataPoint.uuid })
   const disabled = Boolean(!canEditData)
   const options = years.map<Option>((y) => {
     return { label: String(y), value: String(y) }
@@ -30,13 +31,14 @@ const YearSelection: React.FC = () => {
       <div className="odp__year-selection">
         <Select
           bordered
-          classNames={{ container: classNames({ 'validation-error': !validYear }) }}
+          classNames={{ container: classNames({ 'validation-error': !Objects.isEmpty(errorTooltip) }) }}
           disabled={disabled}
           isClearable={false}
           isOptionDisabled={(option: Option) => reservedYears.includes(Number(option.value))}
           onChange={onChange}
           options={options}
           placeholder=""
+          tooltip={errorTooltip}
           value={originalDataPoint?.year ? String(originalDataPoint.year) : ''}
         />
       </div>

--- a/src/client/pages/OriginalDataPoint/components/YearSelection/YearSelection.tsx
+++ b/src/client/pages/OriginalDataPoint/components/YearSelection/YearSelection.tsx
@@ -19,7 +19,7 @@ const YearSelection: React.FC = () => {
   const canEditData = useIsEditTableDataEnabled(sectionName)
   const onChange = useOnChange()
   const { reservedYears, years } = useODPYears()
-  const errorTooltip = useYearErrorTooltip({ nationalDataPointUuid: originalDataPoint?.uuid })
+  const errorTooltip = useYearErrorTooltip({ nationalDataPoint: originalDataPoint })
   const disabled = Boolean(!canEditData)
   const options = years.map<Option>((y) => {
     return { label: String(y), value: String(y) }

--- a/src/client/pages/OriginalDataPoint/components/YearSelection/hooks/useYearErrorTooltip.ts
+++ b/src/client/pages/OriginalDataPoint/components/YearSelection/hooks/useYearErrorTooltip.ts
@@ -2,8 +2,7 @@ import { OriginalDataPoint } from 'meta/assessment/originalDataPoint'
 import { Validation } from 'meta/assessment/validation/validation'
 
 import { useNationalDataPointValidation } from 'client/store/data/tableData/validations/hooks/nationalDataPoints'
-
-import { ErrorTooltip, useErrorTooltip } from './useErrorTooltip'
+import { ErrorTooltip, useErrorTooltip } from 'client/pages/OriginalDataPoint/hooks/useErrorTooltip'
 
 type Props = {
   nationalDataPoint: OriginalDataPoint

--- a/src/client/pages/OriginalDataPoint/hooks/useErrorTooltip.ts
+++ b/src/client/pages/OriginalDataPoint/hooks/useErrorTooltip.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Validation } from 'meta/assessment/validation/validation'
+import { TooltipId } from 'meta/tooltip/id'
+import { MessageParser } from 'meta/validations/messageParser'
+import { Objects } from 'utils/objects'
+
+import { useCanEditCycleData } from 'client/store/user/hooks/auth'
+import { useIsPrintRoute } from 'client/hooks/routes'
+import { useODPDisplayHistory } from 'client/pages/OriginalDataPoint/components/hooks/useODPDisplayHistory'
+
+type Props = {
+  validation?: Validation
+}
+
+export type ErrorTooltip = {
+  content: string
+  id: TooltipId.error
+}
+
+export const useErrorTooltip = (props: Props): ErrorTooltip | undefined => {
+  const { validation } = props
+
+  const { t } = useTranslation()
+  const canEditCycleData = useCanEditCycleData()
+  const displayHistory = useODPDisplayHistory()
+  const { print } = useIsPrintRoute()
+
+  return useMemo<ErrorTooltip | undefined>(() => {
+    if (!canEditCycleData || displayHistory || print) return undefined
+
+    const message = MessageParser.getMessages(t, validation).join('\n')
+    return Objects.isEmpty(message) ? undefined : { content: message, id: TooltipId.error }
+  }, [canEditCycleData, displayHistory, print, t, validation])
+}

--- a/src/client/pages/OriginalDataPoint/hooks/useNationalClassErrorTooltip.ts
+++ b/src/client/pages/OriginalDataPoint/hooks/useNationalClassErrorTooltip.ts
@@ -1,0 +1,19 @@
+import { NDPNationalClassValidationField } from 'meta/assessment/validation/nationalDataPoint'
+import { UUID } from 'meta/uuid/uuid'
+
+import { useNationalClassValidation } from 'client/store/data/tableData/validations/hooks/nationalDataPoints'
+
+import { ErrorTooltip, useErrorTooltip } from './useErrorTooltip'
+
+type Props = {
+  field: NDPNationalClassValidationField
+  nationalClassUuid?: UUID
+  nationalDataPointUuid?: UUID
+}
+
+export const useNationalClassErrorTooltip = (props: Props): ErrorTooltip | undefined => {
+  const { field, nationalClassUuid, nationalDataPointUuid } = props
+  const nationalClassValidation = useNationalClassValidation({ nationalClassUuid, nationalDataPointUuid })
+
+  return useErrorTooltip({ validation: nationalClassValidation[field] })
+}

--- a/src/client/pages/OriginalDataPoint/hooks/useYearErrorTooltip.ts
+++ b/src/client/pages/OriginalDataPoint/hooks/useYearErrorTooltip.ts
@@ -1,0 +1,16 @@
+import { UUID } from 'meta/uuid/uuid'
+
+import { useNationalDataPointValidation } from 'client/store/data/tableData/validations/hooks/nationalDataPoints'
+
+import { ErrorTooltip, useErrorTooltip } from './useErrorTooltip'
+
+type Props = {
+  nationalDataPointUuid?: UUID
+}
+
+export const useYearErrorTooltip = (props: Props): ErrorTooltip | undefined => {
+  const { nationalDataPointUuid } = props
+  const nationalDataPointValidation = useNationalDataPointValidation({ uuid: nationalDataPointUuid })
+
+  return useErrorTooltip({ validation: nationalDataPointValidation.year })
+}

--- a/src/client/pages/OriginalDataPoint/hooks/useYearErrorTooltip.ts
+++ b/src/client/pages/OriginalDataPoint/hooks/useYearErrorTooltip.ts
@@ -9,7 +9,7 @@ type Props = {
   nationalDataPoint: OriginalDataPoint
 }
 
-// Draft ODPs use year -1 and do not exist in the backend yet, so backend validations cannot cover this draft case.
+// Draft NDPs use year -1 and do not exist in the backend yet, so backend validations cannot cover this draft case.
 const draftYearValidation: Validation = { valid: false, messages: [{ key: 'generalValidation.notEmpty' }] }
 
 export const useYearErrorTooltip = (props: Props): ErrorTooltip | undefined => {

--- a/src/client/pages/OriginalDataPoint/hooks/useYearErrorTooltip.ts
+++ b/src/client/pages/OriginalDataPoint/hooks/useYearErrorTooltip.ts
@@ -1,16 +1,22 @@
-import { UUID } from 'meta/uuid/uuid'
+import { OriginalDataPoint } from 'meta/assessment/originalDataPoint'
+import { Validation } from 'meta/assessment/validation/validation'
 
 import { useNationalDataPointValidation } from 'client/store/data/tableData/validations/hooks/nationalDataPoints'
 
 import { ErrorTooltip, useErrorTooltip } from './useErrorTooltip'
 
 type Props = {
-  nationalDataPointUuid?: UUID
+  nationalDataPoint: OriginalDataPoint
 }
 
-export const useYearErrorTooltip = (props: Props): ErrorTooltip | undefined => {
-  const { nationalDataPointUuid } = props
-  const nationalDataPointValidation = useNationalDataPointValidation({ uuid: nationalDataPointUuid })
+// Draft ODPs use year -1 and do not exist in the backend yet, so backend validations cannot cover this draft case.
+const draftYearValidation: Validation = { valid: false, messages: [{ key: 'generalValidation.notEmpty' }] }
 
-  return useErrorTooltip({ validation: nationalDataPointValidation.year })
+export const useYearErrorTooltip = (props: Props): ErrorTooltip | undefined => {
+  const { nationalDataPoint } = props
+  const { uuid, year } = nationalDataPoint
+  const nationalDataPointValidation = useNationalDataPointValidation({ uuid })
+  const validation = year === -1 ? draftYearValidation : nationalDataPointValidation.year
+
+  return useErrorTooltip({ validation })
 }

--- a/src/client/pages/Section/DataTable/Table/RowData/Cell/hooks/useErrorMessages.tsx
+++ b/src/client/pages/Section/DataTable/Table/RowData/Cell/hooks/useErrorMessages.tsx
@@ -17,17 +17,16 @@ export default (props: Props): TooltipProps | undefined => {
   const { t } = useTranslation()
   const historyLastApprovedIsActive = useHistoryLastApprovedIsActive()
 
-  const { messages = [], valid } = validation
+  const messages = MessageParser.getMessages(t, validation)
 
-  if (historyLastApprovedIsActive || valid || messages.length === 0) {
+  if (historyLastApprovedIsActive || messages.length === 0) {
     return undefined
   }
 
   const content: ReactNode = (
     <ul>
-      {messages.map((message) => {
-        const { key } = message
-        return <li key={key}>{MessageParser.getMessage(t, message)}</li>
+      {messages.map((message, index) => {
+        return <li key={`${message}-${index}`}>{message}</li>
       })}
     </ul>
   )

--- a/src/client/pages/Section/Descriptions/CommentableDescription/hooks/useValidationErrors.ts
+++ b/src/client/pages/Section/Descriptions/CommentableDescription/hooks/useValidationErrors.ts
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 import { CommentableDescriptionName } from 'meta/assessment/descriptionValue'
 import { SectionName } from 'meta/assessment/section'
 import { MessageParser } from 'meta/validations/messageParser'
-import { Objects } from 'utils/objects'
 
 import { useDescriptionValidation } from 'client/store/data/tableData/validations/hooks/descriptions'
 import { useCanEditCycleData } from 'client/store/user/hooks/auth'
@@ -28,9 +27,6 @@ export const useValidationErrors = (props: Props): Returned => {
   return useMemo<Returned>(() => {
     if (!canEditCycleData || print) return []
 
-    const { messages = [], valid } = descriptionValidation
-    if (valid || Objects.isEmpty(messages)) return []
-
-    return messages.map((message) => MessageParser.getMessage(t, message))
+    return MessageParser.getMessages(t, descriptionValidation)
   }, [canEditCycleData, descriptionValidation, print, t])
 }

--- a/src/client/pages/Section/Descriptions/NationalDataDescriptions/NationalDataSources/hooks/useValidationErrors.ts
+++ b/src/client/pages/Section/Descriptions/NationalDataDescriptions/NationalDataSources/hooks/useValidationErrors.ts
@@ -5,7 +5,6 @@ import type { DataSourceValidationErrorsRecord } from 'meta/assessment/descripti
 import { SectionName } from 'meta/assessment/section'
 import type { DataSourceValidation, DataSourceValidationField } from 'meta/assessment/validation/description'
 import { MessageParser } from 'meta/validations/messageParser'
-import { Objects } from 'utils/objects'
 
 import { useDataSourceValidations } from 'client/store/data/tableData/validations/hooks/descriptions'
 import { useCanEditCycleData } from 'client/store/user/hooks/auth'
@@ -28,20 +27,12 @@ export const useValidationErrors = (props: Props): DataSourceValidationErrorsRec
     if (!canEditCycleData || print) return {}
 
     const getReferenceErrors = (dataSourceValidation: DataSourceValidation): Array<string> => {
-      const validation = dataSourceValidation.reference
-
-      if (!validation || validation.valid || Objects.isEmpty(validation.messages)) return []
-
-      return validation.messages.map((message) => MessageParser.getMessage(t, message))
+      return MessageParser.getMessages(t, dataSourceValidation.reference)
     }
 
     const getRequiredFieldError = (dataSourceValidation: DataSourceValidation, field: RequiredField): string => {
-      const validation = dataSourceValidation[field]
-
-      if (!validation || validation.valid || Objects.isEmpty(validation.messages)) return ''
-
-      const [message] = validation.messages
-      return MessageParser.getMessage(t, message)
+      const [message = ''] = MessageParser.getMessages(t, dataSourceValidation[field])
+      return message
     }
 
     return Object.entries(dataSourceValidations).reduce<DataSourceValidationErrorsRecord>(

--- a/src/client/store/data/tableData/validations/hooks/nationalDataPoints.ts
+++ b/src/client/store/data/tableData/validations/hooks/nationalDataPoints.ts
@@ -1,5 +1,5 @@
 import { CountryIso } from 'meta/area/countryIso'
-import { NDPValidation } from 'meta/assessment/validation/nationalDataPoint'
+import { NDPNationalClassValidation, NDPValidation } from 'meta/assessment/validation/nationalDataPoint'
 import { UUID } from 'meta/uuid/uuid'
 import { Objects } from 'utils/objects'
 
@@ -27,5 +27,28 @@ export const useNationalDataPointValidation = (props: NationalDataPointValidatio
     if (Objects.isEmpty(uuid)) return {}
 
     return ValidationsSelectors.getNationalDataPointValidation(state, assessmentName, cycleName, countryIso, uuid)
+  })
+}
+
+type NationalClassValidationProps = {
+  nationalClassUuid?: UUID
+  nationalDataPointUuid?: UUID
+}
+
+export const useNationalClassValidation = (props: NationalClassValidationProps): NDPNationalClassValidation => {
+  const { nationalClassUuid, nationalDataPointUuid } = props
+  const { assessmentName, countryIso, cycleName } = useCountryRouteParams<CountryIso>()
+
+  return useAppSelector((state) => {
+    if (Objects.isEmpty(nationalDataPointUuid) || Objects.isEmpty(nationalClassUuid)) return {}
+
+    return ValidationsSelectors.getNationalClassValidation(
+      state,
+      assessmentName,
+      cycleName,
+      countryIso,
+      nationalDataPointUuid,
+      nationalClassUuid
+    )
   })
 }

--- a/src/client/store/data/tableData/validations/hooks/nationalDataPoints.ts
+++ b/src/client/store/data/tableData/validations/hooks/nationalDataPoints.ts
@@ -1,4 +1,7 @@
 import { CountryIso } from 'meta/area/countryIso'
+import { NDPValidation } from 'meta/assessment/validation/nationalDataPoint'
+import { UUID } from 'meta/uuid/uuid'
+import { Objects } from 'utils/objects'
 
 import { ValidationsSelectors } from 'client/store/data/tableData/validations/selectors'
 import { useAppSelector } from 'client/store/hooks'
@@ -10,4 +13,19 @@ export const useNationalDataPointValidationsFetched = (): boolean => {
   return useAppSelector((state) =>
     ValidationsSelectors.nationalDataPointValidationsFetched(state, assessmentName, cycleName, countryIso)
   )
+}
+
+type NationalDataPointValidationProps = {
+  uuid?: UUID
+}
+
+export const useNationalDataPointValidation = (props: NationalDataPointValidationProps): NDPValidation => {
+  const { uuid } = props
+  const { assessmentName, countryIso, cycleName } = useCountryRouteParams<CountryIso>()
+
+  return useAppSelector((state) => {
+    if (Objects.isEmpty(uuid)) return {}
+
+    return ValidationsSelectors.getNationalDataPointValidation(state, assessmentName, cycleName, countryIso, uuid)
+  })
 }

--- a/src/client/store/data/tableData/validations/selectors/index.ts
+++ b/src/client/store/data/tableData/validations/selectors/index.ts
@@ -3,6 +3,7 @@ import {
   getDescriptionValidation,
 } from 'client/store/data/tableData/validations/selectors/descriptions'
 import {
+  getNationalClassValidation,
   getNationalDataPointValidation,
   getNationalDataPointValidations,
   nationalDataPointValidationsFetched,
@@ -18,6 +19,7 @@ import { getNodeValidation, getTableValidations } from 'client/store/data/tableD
 export const ValidationsSelectors = {
   getDataSourceValidations,
   getDescriptionValidation,
+  getNationalClassValidation,
   getNationalDataPointValidation,
   getNationalDataPointValidations,
   getNodeValidation,

--- a/src/client/store/data/tableData/validations/selectors/nationalDataPoints.ts
+++ b/src/client/store/data/tableData/validations/selectors/nationalDataPoints.ts
@@ -3,7 +3,7 @@ import { createSelector } from '@reduxjs/toolkit'
 import { CountryIso } from 'meta/area/countryIso'
 import { AssessmentName } from 'meta/assessment/assessment'
 import { CycleName } from 'meta/assessment/cycle'
-import { NDPValidation } from 'meta/assessment/validation/nationalDataPoint'
+import { NDPNationalClassValidation, NDPValidation } from 'meta/assessment/validation/nationalDataPoint'
 import { UUID } from 'meta/uuid/uuid'
 import { Objects } from 'utils/objects'
 
@@ -36,4 +36,20 @@ export const nationalDataPointValidationsFetched = createSelector(
     const validations = state.nationalDataPoints?.[assessmentName]?.[cycleName]?.[countryIso]
     return !Objects.isNil(validations)
   }
+)
+
+export const getNationalClassValidation = createSelector(
+  [
+    getNationalDataPointValidation,
+    (
+      _state: RootState,
+      _assessmentName: AssessmentName,
+      _cycleName: CycleName,
+      _countryIso: CountryIso,
+      _nationalDataPointUuid: UUID,
+      nationalClassUuid: UUID
+    ) => nationalClassUuid,
+  ],
+  (nationalDataPointValidation, nationalClassUuid): NDPNationalClassValidation =>
+    nationalDataPointValidation.nationalClasses?.[nationalClassUuid] ?? {}
 )

--- a/src/meta/validations/messageParser.ts
+++ b/src/meta/validations/messageParser.ts
@@ -1,5 +1,7 @@
 import { getMessage } from './messageParser/getMessage'
+import { getMessages } from './messageParser/getMessages'
 
 export const MessageParser = {
   getMessage,
+  getMessages,
 }

--- a/src/meta/validations/messageParser/getMessages.ts
+++ b/src/meta/validations/messageParser/getMessages.ts
@@ -1,0 +1,14 @@
+import { TFunction } from 'i18next'
+
+import { Validation } from 'meta/assessment/validation/validation'
+import { Objects } from 'utils/objects'
+
+import { getMessage } from './getMessage'
+
+export const getMessages = (t: TFunction, validation?: Validation): Array<string> => {
+  const { messages = [], valid } = validation ?? {}
+
+  if (valid || Objects.isEmpty(messages)) return []
+
+  return messages.map<string>((message) => getMessage(t, message))
+}


### PR DESCRIPTION
Adding the code to actually display the BE validations in the client.

Year error when NDP is in draft client side only (year === -1):
<img width="956" height="797" alt="image" src="https://github.com/user-attachments/assets/46bdf9e3-ceb9-4f60-a6b9-f2ba51c2eaf0" />


National class errors:
<img width="1966" height="526" alt="image" src="https://github.com/user-attachments/assets/aeb1c7b5-5738-4499-9745-d58e456bee14" />

<img width="1973" height="195" alt="image" src="https://github.com/user-attachments/assets/b1862cc5-5038-4cbc-b2fa-b26ce16195dc" />

<img width="1993" height="765" alt="image" src="https://github.com/user-attachments/assets/c9a3dd96-d595-4f43-97ca-8b2b1f4b8eec" />

<img width="1980" height="411" alt="image" src="https://github.com/user-attachments/assets/ccb1f461-2ef4-4839-8a59-2ccb7a9b2f25" />

Next PR: Removing leftover NDP client side validation code
