### PR TITLE
5758 - Navigation: Data errors - NDP - Add buildNationalDataPointLinkValidations 

### DIFF
--- a/src/meta/cycleData/links/getLocationLabel.ts
+++ b/src/meta/cycleData/links/getLocationLabel.ts
@@ -7,10 +7,9 @@ import { Descriptions } from 'meta/assessment/description/descriptions'
 import { CommentableDescriptionName } from 'meta/assessment/descriptionValue'
 import { Labels } from 'meta/assessment/labels'
 import { SubSection } from 'meta/assessment/section'
-import { TableNames } from 'meta/assessment/table'
+import { isOriginalDataPointLocation } from 'meta/cycleData/links/isOriginalDataPointLocation'
 import { LinkLocation } from 'meta/cycleData/links/link'
-
-import { ODPCommentColumns } from 'server/db/repository/assessmentCycle/originalDataPoint/commentColumns'
+import { NDPLinkField } from 'meta/cycleData/links/nationalDataPointLink'
 
 type GetLocationLabelProps = {
   assessment: Assessment
@@ -27,18 +26,17 @@ export const getLocationLabel = (props: GetLocationLabelProps): string => {
 
   const { sectionName } = location
 
-  // is an NDP location
-  if ('year' in location) {
+  if (isOriginalDataPointLocation(location)) {
     const { ndpSection, year } = location
 
-    const commentColumnsLabel = {
-      [ODPCommentColumns[TableNames.extentOfForest]]: t('extentOfForest.extentOfForest'),
-      [ODPCommentColumns[TableNames.forestCharacteristics]]: t('nationalDataPoint.forestCharacteristics'),
+    const commentFieldLabels: Partial<Record<NDPLinkField, string>> = {
+      [NDPLinkField.commentsExtentOfForest]: t('extentOfForest.extentOfForest'),
+      [NDPLinkField.commentsForestCharacteristics]: t('nationalDataPoint.forestCharacteristics'),
     }
 
     const sectionLabel =
-      commentColumnsLabel[ndpSection] !== undefined
-        ? `${commentColumnsLabel[ndpSection]} ${t('dataSource.comments')}`
+      commentFieldLabels[ndpSection] !== undefined
+        ? `${commentFieldLabels[ndpSection]} ${t('dataSource.comments')}`
         : t('nationalDataPoint.dataSources')
 
     const label = `${year} ${t('nationalDataPoint.nationalDataPoint')} - ${sectionLabel}`

--- a/src/meta/cycleData/links/getLocationLabel.ts
+++ b/src/meta/cycleData/links/getLocationLabel.ts
@@ -7,7 +7,7 @@ import { Descriptions } from 'meta/assessment/description/descriptions'
 import { CommentableDescriptionName } from 'meta/assessment/descriptionValue'
 import { Labels } from 'meta/assessment/labels'
 import { SubSection } from 'meta/assessment/section'
-import { isOriginalDataPointLocation } from 'meta/cycleData/links/isOriginalDataPointLocation'
+import { isNationalDataPointLocation } from 'meta/cycleData/links/isNationalDataPointLocation'
 import { LinkLocation } from 'meta/cycleData/links/link'
 import { NDPLinkField } from 'meta/cycleData/links/nationalDataPointLink'
 
@@ -26,7 +26,7 @@ export const getLocationLabel = (props: GetLocationLabelProps): string => {
 
   const { sectionName } = location
 
-  if (isOriginalDataPointLocation(location)) {
+  if (isNationalDataPointLocation(location)) {
     const { ndpSection, year } = location
 
     const commentFieldLabels: Partial<Record<NDPLinkField, string>> = {

--- a/src/meta/cycleData/links/isNationalDataPointLocation.ts
+++ b/src/meta/cycleData/links/isNationalDataPointLocation.ts
@@ -1,6 +1,6 @@
 import { LinkLocation } from 'meta/cycleData/links/link'
 import { NationalDataPointLinkLocation } from 'meta/cycleData/links/nationalDataPointLink'
 
-export const isOriginalDataPointLocation = (location: LinkLocation): location is NationalDataPointLinkLocation => {
+export const isNationalDataPointLocation = (location: LinkLocation): location is NationalDataPointLinkLocation => {
   return 'ndpSection' in location
 }

--- a/src/meta/cycleData/links/isOriginalDataPointLocation.ts
+++ b/src/meta/cycleData/links/isOriginalDataPointLocation.ts
@@ -1,0 +1,6 @@
+import { LinkLocation } from 'meta/cycleData/links/link'
+import { NationalDataPointLinkLocation } from 'meta/cycleData/links/nationalDataPointLink'
+
+export const isOriginalDataPointLocation = (location: LinkLocation): location is NationalDataPointLinkLocation => {
+  return 'ndpSection' in location
+}

--- a/src/meta/cycleData/links/links.ts
+++ b/src/meta/cycleData/links/links.ts
@@ -2,12 +2,12 @@ import { getI18nValidationStatusLabelKey } from 'meta/cycleData/links/getI18nVal
 import { getKey } from 'meta/cycleData/links/getKey'
 import { getLocationLabel } from 'meta/cycleData/links/getLocationLabel'
 import { isDescriptionLocation } from 'meta/cycleData/links/isDescriptionLocation'
-import { isOriginalDataPointLocation } from 'meta/cycleData/links/isOriginalDataPointLocation'
+import { isNationalDataPointLocation } from 'meta/cycleData/links/isNationalDataPointLocation'
 
 export const Links = {
   getI18nValidationStatusLabelKey,
   getKey,
   getLocationLabel,
   isDescriptionLocation,
-  isOriginalDataPointLocation,
+  isNationalDataPointLocation,
 }

--- a/src/meta/cycleData/links/links.ts
+++ b/src/meta/cycleData/links/links.ts
@@ -2,10 +2,12 @@ import { getI18nValidationStatusLabelKey } from 'meta/cycleData/links/getI18nVal
 import { getKey } from 'meta/cycleData/links/getKey'
 import { getLocationLabel } from 'meta/cycleData/links/getLocationLabel'
 import { isDescriptionLocation } from 'meta/cycleData/links/isDescriptionLocation'
+import { isOriginalDataPointLocation } from 'meta/cycleData/links/isOriginalDataPointLocation'
 
 export const Links = {
   getI18nValidationStatusLabelKey,
   getKey,
   getLocationLabel,
   isDescriptionLocation,
+  isOriginalDataPointLocation,
 }

--- a/src/meta/cycleData/links/nationalDataPointLink.ts
+++ b/src/meta/cycleData/links/nationalDataPointLink.ts
@@ -1,3 +1,6 @@
+import { OriginalDataPointCommentKey } from 'meta/assessment/originalDataPoint'
+import { SectionNames } from 'meta/assessment/section'
+import { TableNames } from 'meta/assessment/table'
 import { LinkLocationBase } from 'meta/cycleData/links/linkLocationBase'
 import { UUID } from 'meta/uuid/uuid'
 
@@ -8,6 +11,25 @@ export enum NDPLinkField {
 }
 
 export const NDPLinkFields: Array<NDPLinkField> = Object.values(NDPLinkField)
+
+export type NDPCommentLinkField = {
+  commentKey: OriginalDataPointCommentKey
+  linkField: NDPLinkField.commentsExtentOfForest | NDPLinkField.commentsForestCharacteristics
+  sectionName: SectionNames.extentOfForest | SectionNames.forestCharacteristics
+}
+
+export const NDPCommentLinkFields: Array<NDPCommentLinkField> = [
+  {
+    commentKey: TableNames.extentOfForest,
+    linkField: NDPLinkField.commentsExtentOfForest,
+    sectionName: SectionNames.extentOfForest,
+  },
+  {
+    commentKey: TableNames.forestCharacteristics,
+    linkField: NDPLinkField.commentsForestCharacteristics,
+    sectionName: SectionNames.forestCharacteristics,
+  },
+]
 
 export type NDPLinkTarget = {
   ndpUuid: UUID

--- a/src/server/controller/cycleData/links/getAllLinksToVisit.ts
+++ b/src/server/controller/cycleData/links/getAllLinksToVisit.ts
@@ -1,12 +1,10 @@
 import { CountryIso } from 'meta/area/countryIso'
 import { Assessment, AssessmentNames } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
-import { OriginalDataPointCommentKey } from 'meta/assessment/originalDataPoint'
 import { SectionNames } from 'meta/assessment/section'
-import { TableNames } from 'meta/assessment/table'
 import { DescriptionLinkLocationPath } from 'meta/cycleData/links/descriptionLink'
 import { LinkLocation, LinkToVisit } from 'meta/cycleData/links/link'
-import { NDPLinkField } from 'meta/cycleData/links/nationalDataPointLink'
+import { NDPCommentLinkFields, NDPLinkField } from 'meta/cycleData/links/nationalDataPointLink'
 import { Routes } from 'meta/routes/routes'
 import { Htmls } from 'utils/htmls'
 
@@ -102,28 +100,11 @@ const _getOriginalDataPointLinks = async (props: Props): Promise<Array<LinkToVis
     OriginalDataPointRepository.getManyWithReferenceLinks({ assessment, countryIso, cycle }),
   ])
 
-  const commentFieldConfigs: Array<{
-    field: OriginalDataPointCommentKey
-    linkField: NDPLinkField
-    sectionName: SectionNames
-  }> = [
-    {
-      field: TableNames.extentOfForest,
-      linkField: NDPLinkField.commentsExtentOfForest,
-      sectionName: SectionNames.extentOfForest,
-    },
-    {
-      field: TableNames.forestCharacteristics,
-      linkField: NDPLinkField.commentsForestCharacteristics,
-      sectionName: SectionNames.forestCharacteristics,
-    },
-  ]
-
   const linksToVisit: Array<LinkToVisit> = odpsByDescriptionsLinks.flatMap((odp) => {
     const { comments, countryIso, uuid, year } = odp
 
-    return commentFieldConfigs.flatMap(({ field, linkField, sectionName }) => {
-      const html = comments[field]
+    return NDPCommentLinkFields.flatMap(({ commentKey, linkField, sectionName }) => {
+      const html = comments[commentKey]
       if (!html) return []
       const urlParams = { assessmentName, countryIso, cycleName, sectionName, year: String(year) }
       const url = Routes.OriginalDataPoint.generatePath(urlParams)

--- a/src/server/worker/tasks/verifyLinks/utils/buildVisitedLinksByKey.ts
+++ b/src/server/worker/tasks/verifyLinks/utils/buildVisitedLinksByKey.ts
@@ -1,0 +1,15 @@
+import { VisitedLink } from 'meta/cycleData/links/link'
+import { Links } from 'meta/cycleData/links/links'
+
+type Props = {
+  linkVisits: Array<VisitedLink>
+}
+
+export const buildVisitedLinksByKey = (props: Props): Record<string, VisitedLink> => {
+  const { linkVisits } = props
+
+  return linkVisits.reduce<Record<string, VisitedLink>>((acc, linkVisit) => {
+    acc[Links.getKey(linkVisit)] = linkVisit
+    return acc
+  }, {})
+}

--- a/src/server/worker/tasks/verifyLinks/utils/getLinkValidationMessage.ts
+++ b/src/server/worker/tasks/verifyLinks/utils/getLinkValidationMessage.ts
@@ -1,0 +1,33 @@
+import { ValidationMessage } from 'meta/assessment/validation/validation'
+import { LinkToVisit, LinkValidationStatusCode, VisitedLink } from 'meta/cycleData/links/link'
+import { Links } from 'meta/cycleData/links/links'
+import { Objects } from 'utils/objects'
+
+type Props = {
+  approvedLinkKeys: Set<string>
+  linkToVisit: LinkToVisit
+  visitedLinksByKey: Record<string, VisitedLink>
+}
+
+// Returns the invalid-link message for a link, or undefined when the link is approved or resolves.
+export const getLinkValidationMessage = (props: Props): ValidationMessage | undefined => {
+  const { approvedLinkKeys, linkToVisit, visitedLinksByKey } = props
+
+  const linkKey = Links.getKey(linkToVisit)
+  const approved = approvedLinkKeys.has(linkKey)
+  const validationCode = visitedLinksByKey[linkKey]?.code
+
+  const isInvalid = !approved && validationCode !== undefined && validationCode !== LinkValidationStatusCode.success
+  if (!isInvalid) return undefined
+
+  const { link, name } = linkToVisit
+  const invalidLinkLabel = !Objects.isEmpty(link) ? link : name
+
+  return {
+    key: 'generalValidation.invalidLinkWithReason',
+    params: {
+      link: invalidLinkLabel,
+      reason: Links.getI18nValidationStatusLabelKey(validationCode),
+    },
+  }
+}

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/buildDescriptionLinkValidations.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/buildDescriptionLinkValidations.ts
@@ -1,9 +1,10 @@
 import { CommentableDescription } from 'meta/assessment/descriptionValue'
 import { RecordDescriptionValidations } from 'meta/assessment/validation/description'
-import { ValidationMessage } from 'meta/assessment/validation/validation'
-import { Link, LinkToVisit, LinkValidationStatusCode, VisitedLink } from 'meta/cycleData/links/link'
+import { Link, LinkToVisit, VisitedLink } from 'meta/cycleData/links/link'
 import { Links } from 'meta/cycleData/links/links'
-import { Objects } from 'utils/objects'
+
+import { buildVisitedLinksByKey } from 'server/worker/tasks/verifyLinks/utils/buildVisitedLinksByKey'
+import { getLinkValidationMessage } from 'server/worker/tasks/verifyLinks/utils/getLinkValidationMessage'
 
 import { buildInitialDescriptionValidations } from './buildInitialDescriptionValidations'
 import { updateLocationValidation } from './updateLocationValidation'
@@ -23,30 +24,10 @@ export const buildDescriptionLinkValidations = (props: Props): RecordDescription
   const descriptionValidations = buildInitialDescriptionValidations(initialDescriptions)
 
   const approvedLinkKeys = new Set<string>(approvedLinks.map(Links.getKey))
-  const visitedLinksByKey = linkVisits.reduce<Record<string, VisitedLink>>((acc, linkVisit) => {
-    acc[Links.getKey(linkVisit)] = linkVisit
-    return acc
-  }, {})
+  const visitedLinksByKey = buildVisitedLinksByKey({ linkVisits })
 
   linksToVisit.forEach((linkToVisit) => {
-    const linkKey = Links.getKey(linkToVisit)
-    const approved = approvedLinkKeys.has(linkKey)
-    const validationCode = visitedLinksByKey[linkKey]?.code
-
-    let linkValidationMessage: ValidationMessage | undefined
-    const isInvalid = !approved && validationCode !== undefined && validationCode !== LinkValidationStatusCode.success
-    if (isInvalid) {
-      const { link, name } = linkToVisit
-      const invalidLinkLabel = !Objects.isEmpty(link) ? link : name
-
-      linkValidationMessage = {
-        key: 'generalValidation.invalidLinkWithReason',
-        params: {
-          link: invalidLinkLabel,
-          reason: Links.getI18nValidationStatusLabelKey(validationCode),
-        },
-      }
-    }
+    const linkValidationMessage = getLinkValidationMessage({ approvedLinkKeys, linkToVisit, visitedLinksByKey })
 
     linkToVisit.locations.forEach((location) => {
       updateLocationValidation({ descriptionValidations, linkValidationMessage, location })

--- a/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/buildNationalDataPointLinkValidations.ts
+++ b/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/buildNationalDataPointLinkValidations.ts
@@ -1,0 +1,33 @@
+import { RecordNDPValidations } from 'meta/assessment/validation/nationalDataPoint'
+import { Link, LinkToVisit, VisitedLink } from 'meta/cycleData/links/link'
+import { Links } from 'meta/cycleData/links/links'
+
+import { buildVisitedLinksByKey } from 'server/worker/tasks/verifyLinks/utils/buildVisitedLinksByKey'
+import { getLinkValidationMessage } from 'server/worker/tasks/verifyLinks/utils/getLinkValidationMessage'
+
+import { updateNationalDataPointLocationValidation } from './updateNationalDataPointLocationValidation'
+
+type Props = {
+  approvedLinks: Array<Link>
+  linkVisits: Array<VisitedLink>
+  linksToVisit: Array<LinkToVisit>
+}
+
+export const buildNationalDataPointLinkValidations = (props: Props): RecordNDPValidations => {
+  const { approvedLinks, linkVisits, linksToVisit } = props
+
+  const nationalDataPointValidations: RecordNDPValidations = {}
+
+  const approvedLinkKeys = new Set<string>(approvedLinks.map(Links.getKey))
+  const visitedLinksByKey = buildVisitedLinksByKey({ linkVisits })
+
+  linksToVisit.forEach((linkToVisit) => {
+    const linkValidationMessage = getLinkValidationMessage({ approvedLinkKeys, linkToVisit, visitedLinksByKey })
+
+    linkToVisit.locations.forEach((location) => {
+      updateNationalDataPointLocationValidation({ linkValidationMessage, location, nationalDataPointValidations })
+    })
+  })
+
+  return nationalDataPointValidations
+}

--- a/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/getNationalDataPointLinks.ts
+++ b/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/getNationalDataPointLinks.ts
@@ -1,11 +1,14 @@
 import { CountryIso } from 'meta/area/countryIso'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
-import { OriginalDataPointCommentKey } from 'meta/assessment/originalDataPoint'
 import { SectionNames } from 'meta/assessment/section'
-import { TableNames } from 'meta/assessment/table'
 import { LinkToVisit } from 'meta/cycleData/links/link'
-import { NationalDataPointLinkLocation, NDPLinkField, NDPLinkTarget } from 'meta/cycleData/links/nationalDataPointLink'
+import {
+  NationalDataPointLinkLocation,
+  NDPCommentLinkFields,
+  NDPLinkField,
+  NDPLinkTarget,
+} from 'meta/cycleData/links/nationalDataPointLink'
 import { Routes } from 'meta/routes/routes'
 import { Htmls } from 'utils/htmls'
 import { Objects } from 'utils/objects'
@@ -18,23 +21,6 @@ type Props = {
   cycle: Cycle
   targets: Array<NDPLinkTarget>
 }
-
-const commentLinkFields: Array<{
-  commentKey: OriginalDataPointCommentKey
-  linkField: NDPLinkField
-  sectionName: SectionNames
-}> = [
-  {
-    commentKey: TableNames.extentOfForest,
-    linkField: NDPLinkField.commentsExtentOfForest,
-    sectionName: SectionNames.extentOfForest,
-  },
-  {
-    commentKey: TableNames.forestCharacteristics,
-    linkField: NDPLinkField.commentsForestCharacteristics,
-    sectionName: SectionNames.forestCharacteristics,
-  },
-]
 
 export const getNationalDataPointLinks = async (props: Props): Promise<Array<LinkToVisit>> => {
   const { assessment, countryIso, cycle, targets } = props
@@ -49,7 +35,7 @@ export const getNationalDataPointLinks = async (props: Props): Promise<Array<Lin
     const urlParams = { assessmentName: assessment.props.name, countryIso, cycleName: cycle.name, year: String(year) }
 
     // Build comment links to visit (1a / 1b)
-    const commentLinks = commentLinkFields.flatMap<LinkToVisit>(({ commentKey, linkField, sectionName }) => {
+    const commentLinks = NDPCommentLinkFields.flatMap<LinkToVisit>(({ commentKey, linkField, sectionName }) => {
       if (!target.fields.includes(linkField)) return []
 
       const html = comments[commentKey]

--- a/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/updateNationalDataPointLocationValidation.ts
+++ b/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/updateNationalDataPointLocationValidation.ts
@@ -18,19 +18,19 @@ export const updateNationalDataPointLocationValidation = (props: Props): void =>
   // Valid links are not saved in validation cache
   if (linkValidationMessage === undefined) return
 
-  const validation: NDPValidation = (nationalDataPointValidations[location.odpUuid] ??= {})
+  const validation: NDPValidation = (nationalDataPointValidations[location.ndpUuid] ??= {})
 
   let fieldValidation: Validation | undefined
 
   // For comments (1a and 1b)
-  const commentLinkField = NDPCommentLinkFields.find(({ linkField }) => linkField === location.odpSection)
+  const commentLinkField = NDPCommentLinkFields.find(({ linkField }) => linkField === location.ndpSection)
   if (!Objects.isEmpty(commentLinkField)) {
     const comments = (validation.comments ??= {})
     fieldValidation = comments[commentLinkField.commentKey] ??= { valid: true }
   }
 
   // For dataSource.reference
-  if (location.odpSection === NDPLinkField.dataSourceReferences) {
+  if (location.ndpSection === NDPLinkField.dataSourceReferences) {
     const { dataSourceUuid } = location
     if (Objects.isEmpty(dataSourceUuid)) return
 

--- a/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/updateNationalDataPointLocationValidation.ts
+++ b/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/updateNationalDataPointLocationValidation.ts
@@ -1,0 +1,48 @@
+import { NDPValidation, RecordNDPValidations } from 'meta/assessment/validation/nationalDataPoint'
+import { Validation, ValidationMessage } from 'meta/assessment/validation/validation'
+import { LinkLocation } from 'meta/cycleData/links/link'
+import { Links } from 'meta/cycleData/links/links'
+import { NDPCommentLinkFields, NDPLinkField } from 'meta/cycleData/links/nationalDataPointLink'
+import { Objects } from 'utils/objects'
+
+type Props = {
+  linkValidationMessage?: ValidationMessage
+  location: LinkLocation
+  nationalDataPointValidations: RecordNDPValidations
+}
+
+export const updateNationalDataPointLocationValidation = (props: Props): void => {
+  const { linkValidationMessage, location, nationalDataPointValidations } = props
+
+  if (!Links.isOriginalDataPointLocation(location)) return
+  // Valid links are not saved in validation cache
+  if (linkValidationMessage === undefined) return
+
+  const validation: NDPValidation = (nationalDataPointValidations[location.odpUuid] ??= {})
+
+  let fieldValidation: Validation | undefined
+
+  // For comments (1a and 1b)
+  const commentLinkField = NDPCommentLinkFields.find(({ linkField }) => linkField === location.odpSection)
+  if (!Objects.isEmpty(commentLinkField)) {
+    const comments = (validation.comments ??= {})
+    fieldValidation = comments[commentLinkField.commentKey] ??= { valid: true }
+  }
+
+  // For dataSource.reference
+  if (location.odpSection === NDPLinkField.dataSourceReferences) {
+    const { dataSourceUuid } = location
+    if (Objects.isEmpty(dataSourceUuid)) return
+
+    const dataSources = (validation.dataSources ??= {})
+    const dataSource = (dataSources[dataSourceUuid] ??= {})
+    fieldValidation = dataSource.reference ??= { valid: true }
+  }
+
+  if (!fieldValidation) return
+
+  // Append invalid message
+  fieldValidation.valid = false
+  fieldValidation.messages ??= []
+  fieldValidation.messages.push(linkValidationMessage)
+}

--- a/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/updateNationalDataPointLocationValidation.ts
+++ b/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/updateNationalDataPointLocationValidation.ts
@@ -14,7 +14,7 @@ type Props = {
 export const updateNationalDataPointLocationValidation = (props: Props): void => {
   const { linkValidationMessage, location, nationalDataPointValidations } = props
 
-  if (!Links.isOriginalDataPointLocation(location)) return
+  if (!Links.isNationalDataPointLocation(location)) return
   // Valid links are not saved in validation cache
   if (linkValidationMessage === undefined) return
 

--- a/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/worker.ts
+++ b/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/worker.ts
@@ -1,5 +1,6 @@
 import { Logger } from 'server/utils/logger'
 
+import { buildNationalDataPointLinkValidations } from './utils/buildNationalDataPointLinkValidations'
 import { getNationalDataPointLinks } from './utils/getNationalDataPointLinks'
 import { syncNationalDataPointLinks } from './utils/syncNationalDataPointLinks'
 import { VerifyNationalDataPointLinksJob } from './props'
@@ -21,7 +22,17 @@ export default async (job: VerifyNationalDataPointLinksJob): Promise<void> => {
 
     const linksToVisit = await getNationalDataPointLinks({ assessment, countryIso, cycle, targets })
 
-    const { linkVisits } = await syncNationalDataPointLinks({ assessment, countryIso, cycle, linksToVisit, targets })
+    const { approvedLinks, linkVisits } = await syncNationalDataPointLinks({
+      assessment,
+      countryIso,
+      cycle,
+      linksToVisit,
+      targets,
+    })
+
+    const linkValidations = buildNationalDataPointLinkValidations({ approvedLinks, linkVisits, linksToVisit })
+    Logger.debug(`${logKey} built link validations for ${Object.keys(linkValidations).length} national data points.`)
+    // TODO: persist the link validations and notify clients
 
     const duration = (new Date().getTime() - time) / 1000
     Logger.info(`${logKey} ended in ${duration} seconds with ${linkVisits.length} links visited.`)


### PR DESCRIPTION
Adding `buildNationalDataPointLinkValidations`, which turns link visit results into NDP validation state. Invalid links are routed to the 1a/1b comment validations or to the data source reference validation they were found in.

In this PR:

- Extracted the common `getLinkValidationMessage` and `buildVisitedLinksByKey` used by descriptions and NDPs
- Added `Links.isOriginalDataPointLocation`
- Added a common `NDPCommentLinkFields` to avoid duplication in `getNationalDataPointLinks` and `getAllLinksToVisit`

The worker now builds the validations and logs the result

Next PR: persisting and notifying clients