### PR TITLE
5758 - Navigation: Data errors - NDP - Persist link validations and notify clients

### DIFF
--- a/src/meta/assessment/validation/nationalDataPointValidations/index.ts
+++ b/src/meta/assessment/validation/nationalDataPointValidations/index.ts
@@ -1,7 +1,9 @@
 import { calculateSummary } from 'meta/assessment/validation/nationalDataPointValidations/calculateSummary'
 import { hasError } from 'meta/assessment/validation/nationalDataPointValidations/hasError'
+import { mergeLinkValidations } from 'meta/assessment/validation/nationalDataPointValidations/mergeLinkValidations'
 
 export const NationalDataPointValidations = {
   calculateSummary,
   hasError,
+  mergeLinkValidations,
 }

--- a/src/meta/assessment/validation/nationalDataPointValidations/mergeLinkValidations.ts
+++ b/src/meta/assessment/validation/nationalDataPointValidations/mergeLinkValidations.ts
@@ -1,0 +1,64 @@
+import { NDPDataSourceValidation, NDPValidation } from 'meta/assessment/validation/nationalDataPoint'
+import { NDPCommentLinkFields, NDPLinkField } from 'meta/cycleData/links/nationalDataPointLink'
+import { UUID } from 'meta/uuid/uuid'
+import { Objects } from 'utils/objects'
+
+type Props = {
+  current: NDPValidation
+  fields: Array<NDPLinkField>
+  update: NDPValidation
+}
+
+// Merges an incoming link validation update onto a national data point's current validations
+// and returns the result. Only the given fields are updated.
+// Example:
+//   current: { comments: { extentOfForest: { valid: false } }, year: { valid: false } }
+//   fields:  [commentsExtentOfForest]
+//   update:  {}
+//   result:  { year: { valid: false } }
+export const mergeLinkValidations = (props: Props): NDPValidation => {
+  const { current, fields, update } = props
+  const value: NDPValidation = { ...current }
+
+  // Replace the comment link validations of the given comment fields.
+  const comments = { ...current.comments }
+  NDPCommentLinkFields.forEach(({ commentKey, linkField }) => {
+    if (!fields.includes(linkField)) return
+
+    const commentValidation = update.comments?.[commentKey]
+    if (commentValidation) {
+      comments[commentKey] = commentValidation
+    } else {
+      delete comments[commentKey]
+    }
+  })
+  if (!Objects.isEmpty(comments)) {
+    value.comments = comments
+  } else {
+    delete value.comments
+  }
+
+  if (fields.includes(NDPLinkField.dataSourceReferences)) {
+    // Replace only the reference link validations
+    const dataSources: Record<UUID, NDPDataSourceValidation> = {}
+    const uuids = new Set([...Object.keys(current.dataSources ?? {}), ...Object.keys(update.dataSources ?? {})])
+
+    uuids.forEach((uuid) => {
+      const dataSourceValidation: NDPDataSourceValidation = { ...current.dataSources?.[uuid] }
+      delete dataSourceValidation.reference
+
+      const reference = update.dataSources?.[uuid]?.reference
+      if (reference) dataSourceValidation.reference = reference
+
+      if (!Objects.isEmpty(dataSourceValidation)) dataSources[uuid] = dataSourceValidation
+    })
+
+    if (!Objects.isEmpty(dataSources)) {
+      value.dataSources = dataSources
+    } else {
+      delete value.dataSources
+    }
+  }
+
+  return value
+}

--- a/src/server/cache/repository/validation/nationalDataPoint/deleteValidations.ts
+++ b/src/server/cache/repository/validation/nationalDataPoint/deleteValidations.ts
@@ -2,6 +2,7 @@ import { CountryIso } from 'meta/area/countryIso'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import { UUID } from 'meta/uuid/uuid'
+import { Objects } from 'utils/objects'
 
 import { getKeyCountry, Keys } from 'server/cache/repository/keys'
 import { RedisData } from 'server/cache/repository/redisData'
@@ -10,14 +11,16 @@ type Props = {
   assessment: Assessment
   countryIso: CountryIso
   cycle: Cycle
-  uuid: UUID
+  uuids: Array<UUID>
 }
 
-export const deleteValidation = async (props: Props): Promise<void> => {
-  const { assessment, countryIso, cycle, uuid } = props
+export const deleteValidations = async (props: Props): Promise<void> => {
+  const { assessment, countryIso, cycle, uuids } = props
+
+  if (Objects.isEmpty(uuids)) return
 
   const redis = RedisData.getInstance()
   const key = getKeyCountry({ assessment, countryIso, cycle, key: Keys.Data.validationNationalDataPoints })
 
-  await redis.hdel(key, uuid)
+  await redis.hdel(key, ...uuids)
 }

--- a/src/server/cache/repository/validation/nationalDataPoint/index.ts
+++ b/src/server/cache/repository/validation/nationalDataPoint/index.ts
@@ -1,10 +1,10 @@
-import { deleteValidation } from 'server/cache/repository/validation/nationalDataPoint/deleteValidation'
+import { deleteValidations } from 'server/cache/repository/validation/nationalDataPoint/deleteValidations'
 import { getValidation } from 'server/cache/repository/validation/nationalDataPoint/getValidation'
 import { getValidations } from 'server/cache/repository/validation/nationalDataPoint/getValidations'
 import { setValidations } from 'server/cache/repository/validation/nationalDataPoint/setValidations'
 
 export const NationalDataPointValidationRedisRepository = {
-  deleteValidation,
+  deleteValidations,
   getValidation,
   getValidations,
   setValidations,

--- a/src/server/controller/cycleData/nationalDataPoint/remove.ts
+++ b/src/server/controller/cycleData/nationalDataPoint/remove.ts
@@ -78,11 +78,11 @@ export const remove = async (props: Props, client: BaseProtocol = DB): Promise<O
     return target
   })
 
-  await NationalDataPointValidationRedisRepository.deleteValidation({
+  await NationalDataPointValidationRedisRepository.deleteValidations({
     assessment,
     countryIso,
     cycle,
-    uuid,
+    uuids: [uuid],
   })
   notifyNationalDataPointValidationDelete({ assessment, countryIso, cycle, uuid })
 

--- a/src/server/controller/cycleData/validations/nationalDataPoint/notifyNationalDataPointValidationUpdate.ts
+++ b/src/server/controller/cycleData/validations/nationalDataPoint/notifyNationalDataPointValidationUpdate.ts
@@ -1,9 +1,8 @@
 import { CountryIso } from 'meta/area/countryIso'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
-import { NDPValidation } from 'meta/assessment/validation/nationalDataPoint'
+import { RecordNDPValidations } from 'meta/assessment/validation/nationalDataPoint'
 import { Sockets } from 'meta/socket/sockets'
-import { UUID } from 'meta/uuid/uuid'
 
 import { SocketServer } from 'server/service/socket'
 
@@ -11,12 +10,11 @@ type Props = {
   assessment: Assessment
   countryIso: CountryIso
   cycle: Cycle
-  uuid: UUID
-  validation: NDPValidation
+  validations: RecordNDPValidations
 }
 
 export const notifyNationalDataPointValidationUpdate = (props: Props): void => {
-  const { assessment, countryIso, cycle, uuid, validation } = props
+  const { assessment, countryIso, cycle, validations } = props
 
   const eventName = Sockets.getNationalDataPointValidationsUpdateEvent({
     assessmentName: assessment.props.name,
@@ -24,5 +22,5 @@ export const notifyNationalDataPointValidationUpdate = (props: Props): void => {
     cycleName: cycle.name,
   })
 
-  SocketServer.emit(eventName, { validations: { [uuid]: validation } })
+  SocketServer.emit(eventName, { validations })
 }

--- a/src/server/controller/cycleData/validations/nationalDataPoint/validateNationalClasses.ts
+++ b/src/server/controller/cycleData/validations/nationalDataPoint/validateNationalClasses.ts
@@ -38,5 +38,5 @@ export const validateNationalClasses = async (props: Props): Promise<void> => {
     validations: { [uuid]: updatedValidation },
   })
 
-  notifyNationalDataPointValidationUpdate({ assessment, countryIso, cycle, uuid, validation: updatedValidation })
+  notifyNationalDataPointValidationUpdate({ assessment, countryIso, cycle, validations: { [uuid]: updatedValidation } })
 }

--- a/src/server/controller/cycleData/validations/nationalDataPoint/validateYear.ts
+++ b/src/server/controller/cycleData/validations/nationalDataPoint/validateYear.ts
@@ -38,5 +38,5 @@ export const validateYear = async (props: Props): Promise<void> => {
     validations: { [uuid]: updatedValidation },
   })
 
-  notifyNationalDataPointValidationUpdate({ assessment, countryIso, cycle, uuid, validation: updatedValidation })
+  notifyNationalDataPointValidationUpdate({ assessment, countryIso, cycle, validations: { [uuid]: updatedValidation } })
 }

--- a/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/refreshNationalDataPointValidations.ts
+++ b/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/refreshNationalDataPointValidations.ts
@@ -1,0 +1,78 @@
+import { CountryIso } from 'meta/area/countryIso'
+import { Assessment } from 'meta/assessment/assessment'
+import { Cycle } from 'meta/assessment/cycle'
+import { RecordNDPValidations } from 'meta/assessment/validation/nationalDataPoint'
+import { NationalDataPointValidations } from 'meta/assessment/validation/nationalDataPointValidations'
+import { Link, LinkToVisit, VisitedLink } from 'meta/cycleData/links/link'
+import { NDPLinkTarget } from 'meta/cycleData/links/nationalDataPointLink'
+import { UUID } from 'meta/uuid/uuid'
+import { Objects } from 'utils/objects'
+
+import { NationalDataPointValidationRedisRepository } from 'server/cache/repository/validation/nationalDataPoint'
+import { notifyNationalDataPointValidationUpdate } from 'server/controller/cycleData/validations/nationalDataPoint/notifyNationalDataPointValidationUpdate'
+
+import { buildNationalDataPointLinkValidations } from './buildNationalDataPointLinkValidations'
+
+type Props = {
+  approvedLinks: Array<Link>
+  assessment: Assessment
+  countryIso: CountryIso
+  cycle: Cycle
+  linkVisits: Array<VisitedLink>
+  linksToVisit: Array<LinkToVisit>
+  notifyClients?: boolean
+  targets: Array<NDPLinkTarget>
+}
+
+// Rebuilds the target national data points' link validations, saves them in the cache and notifies clients.
+export const refreshNationalDataPointValidations = async (props: Props): Promise<void> => {
+  const { approvedLinks, assessment, countryIso, cycle, linkVisits, linksToVisit, targets } = props
+  const { notifyClients = true } = props
+
+  if (Objects.isEmpty(targets)) return
+
+  const linkValidations = buildNationalDataPointLinkValidations({ approvedLinks, linkVisits, linksToVisit })
+  const currentValidations = await NationalDataPointValidationRedisRepository.getValidations({
+    assessment,
+    countryIso,
+    cycle,
+  })
+
+  // Emptied national data points are still included in the notification, so clients clear them too.
+  const validations: RecordNDPValidations = {}
+  const validationsToSet: RecordNDPValidations = {}
+  const uuidsToDelete: Array<UUID> = []
+
+  targets.forEach(({ fields, odpUuid }) => {
+    const current = currentValidations[odpUuid] ?? {}
+    const update = linkValidations[odpUuid] ?? {}
+    const value = NationalDataPointValidations.mergeLinkValidations({ current, fields, update })
+
+    validations[odpUuid] = value
+
+    if (Objects.isEmpty(value)) {
+      uuidsToDelete.push(odpUuid)
+    } else {
+      validationsToSet[odpUuid] = value
+    }
+  })
+
+  await Promise.all([
+    NationalDataPointValidationRedisRepository.setValidations({
+      assessment,
+      countryIso,
+      cycle,
+      validations: validationsToSet,
+    }),
+    NationalDataPointValidationRedisRepository.deleteValidations({
+      assessment,
+      countryIso,
+      cycle,
+      uuids: uuidsToDelete,
+    }),
+  ])
+
+  if (!notifyClients) return
+
+  notifyNationalDataPointValidationUpdate({ assessment, countryIso, cycle, validations })
+}

--- a/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/refreshNationalDataPointValidations.ts
+++ b/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/refreshNationalDataPointValidations.ts
@@ -43,17 +43,17 @@ export const refreshNationalDataPointValidations = async (props: Props): Promise
   const validationsToSet: RecordNDPValidations = {}
   const uuidsToDelete: Array<UUID> = []
 
-  targets.forEach(({ fields, odpUuid }) => {
-    const current = currentValidations[odpUuid] ?? {}
-    const update = linkValidations[odpUuid] ?? {}
+  targets.forEach(({ fields, ndpUuid }) => {
+    const current = currentValidations[ndpUuid] ?? {}
+    const update = linkValidations[ndpUuid] ?? {}
     const value = NationalDataPointValidations.mergeLinkValidations({ current, fields, update })
 
-    validations[odpUuid] = value
+    validations[ndpUuid] = value
 
     if (Objects.isEmpty(value)) {
-      uuidsToDelete.push(odpUuid)
+      uuidsToDelete.push(ndpUuid)
     } else {
-      validationsToSet[odpUuid] = value
+      validationsToSet[ndpUuid] = value
     }
   })
 

--- a/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/worker.ts
+++ b/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/worker.ts
@@ -1,7 +1,7 @@
 import { Logger } from 'server/utils/logger'
 
-import { buildNationalDataPointLinkValidations } from './utils/buildNationalDataPointLinkValidations'
 import { getNationalDataPointLinks } from './utils/getNationalDataPointLinks'
+import { refreshNationalDataPointValidations } from './utils/refreshNationalDataPointValidations'
 import { syncNationalDataPointLinks } from './utils/syncNationalDataPointLinks'
 import { VerifyNationalDataPointLinksJob } from './props'
 
@@ -15,7 +15,7 @@ export default async (job: VerifyNationalDataPointLinksJob): Promise<void> => {
   const logKey = _getLogKey(job)
 
   try {
-    const { assessment, countryIso, cycle, targets } = job.data
+    const { assessment, countryIso, cycle, notifyClients, targets } = job.data
     const time = new Date().getTime()
 
     Logger.info(`${logKey} started.`)
@@ -30,9 +30,8 @@ export default async (job: VerifyNationalDataPointLinksJob): Promise<void> => {
       targets,
     })
 
-    const linkValidations = buildNationalDataPointLinkValidations({ approvedLinks, linkVisits, linksToVisit })
-    Logger.debug(`${logKey} built link validations for ${Object.keys(linkValidations).length} national data points.`)
-    // TODO: persist the link validations and notify clients
+    const params = { approvedLinks, assessment, countryIso, cycle, linkVisits, linksToVisit, notifyClients, targets }
+    await refreshNationalDataPointValidations(params)
 
     const duration = (new Date().getTime() - time) / 1000
     Logger.info(`${logKey} ended in ${duration} seconds with ${linkVisits.length} links visited.`)


### PR DESCRIPTION
Adding `refreshNationalDataPointValidations`, to finish the NDP links worker: it rebuilds NDPs' link validations, saves them in the cache and notifies clients.

In this PR:

- Added `NationalDataPointValidations.mergeLinkValidations`, which merges a link validation update onto an NDP current validation. Only the link fields are updated, so we avoid overwriting the rest of the validations. 
- NDPs that have empty validation after the merge are deleted, since that means those are now valid. E.g if a link now resolves correctly and that was the only error in the NDP.  
- Generalized `notifyNationalDataPointValidationUpdate` to take a record of validations, since a links job can update multiple NDPs in one go
- Renamed `deleteValidation` to `deleteValidations`, since a links job can empty multiple NDPs in one run and the worker deletes them in a single call

Next PR: Triggering the job when comments/data source reference are updated 
