### PR TITLE
5758 - Navigation: Data errors - NDP - Trigger NDP link validation & Display errors

### DIFF
--- a/src/client/pages/OriginalDataPoint/components/Comments/Comments.tsx
+++ b/src/client/pages/OriginalDataPoint/components/Comments/Comments.tsx
@@ -6,17 +6,15 @@ import { OriginalDataPointCommentKey } from 'meta/assessment/originalDataPoint'
 
 import { useOriginalDataPoint } from 'client/store/data/originalDataPoint/hooks/originalDataPoint'
 import { useIsDataLocked } from 'client/store/ui/countryReport/hooks/datalock'
-import { useCanEditCycleData } from 'client/store/user/hooks/auth'
-import { useIsPrintRoute } from 'client/hooks/routes'
 import Button, { ButtonSize } from 'client/components/Buttons/Button'
 import { DataCell, DataGrid, DataRow } from 'client/components/DataGrid'
 import EditorWYSIWYG from 'client/components/EditorWYSIWYG'
-import { useLinkValidationErrors } from 'client/components/EditorWYSIWYG/hooks/useLinkValidationErrors'
 import { useODPDisplayHistory } from 'client/pages/OriginalDataPoint/components/hooks/useODPDisplayHistory'
 import ODPCommentsDiffView from 'client/pages/OriginalDataPoint/components/ODPCommentsDiffView/ODPCommentsDiffView'
 import { useIsEditODPDescriptionEnabled } from 'client/pages/OriginalDataPoint/hooks/useIsEditODPEnabled'
 
 import { useUpdateComment } from './hooks/useUpdateDescription'
+import { useValidationErrors } from './hooks/useValidationErrors'
 import { useCommentsActions } from './useCommentsActions'
 
 type Props = {
@@ -29,17 +27,12 @@ const Comments: React.FC<Props> = (props) => {
   const { t } = useTranslation()
   const originalDataPoint = useOriginalDataPoint()
   const isDataLocked = useIsDataLocked()
-  const canEditCycleData = useCanEditCycleData()
   const updateComment = useUpdateComment({ field })
   const actions = useCommentsActions({ field })
   const canEditData = useIsEditODPDescriptionEnabled()
-  const { print } = useIsPrintRoute()
   const [open, setOpen] = useState<boolean>(false)
   const displayHistory = useODPDisplayHistory()
-  const validationErrors = useLinkValidationErrors({
-    enabled: canEditCycleData && !print,
-    value: originalDataPoint.comments?.[field] ?? '',
-  })
+  const validationErrors = useValidationErrors({ field })
 
   useEffect(() => {
     if (open && isDataLocked) {

--- a/src/client/pages/OriginalDataPoint/components/Comments/hooks/useValidationErrors.ts
+++ b/src/client/pages/OriginalDataPoint/components/Comments/hooks/useValidationErrors.ts
@@ -14,7 +14,9 @@ type Props = {
   field: OriginalDataPointCommentKey
 }
 
-export const useValidationErrors = (props: Props): Array<string> => {
+type Returned = Array<string>
+
+export const useValidationErrors = (props: Props): Returned => {
   const { field } = props
   const { t } = useTranslation()
   const canEditCycleData = useCanEditCycleData()
@@ -24,7 +26,7 @@ export const useValidationErrors = (props: Props): Array<string> => {
   const validation = useNationalDataPointValidation({ uuid: nationalDataPoint.uuid })
   const commentValidation = validation.comments?.[field]
 
-  return useMemo<Array<string>>(() => {
+  return useMemo<Returned>(() => {
     if (!canEditCycleData || print || displayHistory) return []
 
     return MessageParser.getMessages(t, commentValidation)

--- a/src/client/pages/OriginalDataPoint/components/Comments/hooks/useValidationErrors.ts
+++ b/src/client/pages/OriginalDataPoint/components/Comments/hooks/useValidationErrors.ts
@@ -1,0 +1,32 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { OriginalDataPointCommentKey } from 'meta/assessment/originalDataPoint'
+import { MessageParser } from 'meta/validations/messageParser'
+
+import { useOriginalDataPoint } from 'client/store/data/originalDataPoint/hooks/originalDataPoint'
+import { useNationalDataPointValidation } from 'client/store/data/tableData/validations/hooks/nationalDataPoints'
+import { useCanEditCycleData } from 'client/store/user/hooks/auth'
+import { useIsPrintRoute } from 'client/hooks/routes'
+import { useODPDisplayHistory } from 'client/pages/OriginalDataPoint/components/hooks/useODPDisplayHistory'
+
+type Props = {
+  field: OriginalDataPointCommentKey
+}
+
+export const useValidationErrors = (props: Props): Array<string> => {
+  const { field } = props
+  const { t } = useTranslation()
+  const canEditCycleData = useCanEditCycleData()
+  const { print } = useIsPrintRoute()
+  const displayHistory = useODPDisplayHistory()
+  const nationalDataPoint = useOriginalDataPoint()
+  const validation = useNationalDataPointValidation({ uuid: nationalDataPoint.uuid })
+  const commentValidation = validation.comments?.[field]
+
+  return useMemo<Array<string>>(() => {
+    if (!canEditCycleData || print || displayHistory) return []
+
+    return MessageParser.getMessages(t, commentValidation)
+  }, [canEditCycleData, commentValidation, displayHistory, print, t])
+}

--- a/src/client/pages/OriginalDataPoint/components/Comments/hooks/useValidationErrors.ts
+++ b/src/client/pages/OriginalDataPoint/components/Comments/hooks/useValidationErrors.ts
@@ -6,9 +6,8 @@ import { MessageParser } from 'meta/validations/messageParser'
 
 import { useOriginalDataPoint } from 'client/store/data/originalDataPoint/hooks/originalDataPoint'
 import { useNationalDataPointValidation } from 'client/store/data/tableData/validations/hooks/nationalDataPoints'
-import { useCanEditCycleData } from 'client/store/user/hooks/auth'
-import { useIsPrintRoute } from 'client/hooks/routes'
-import { useODPDisplayHistory } from 'client/pages/OriginalDataPoint/components/hooks/useODPDisplayHistory'
+import { useShowNDPValidationErrors } from 'client/pages/OriginalDataPoint/components/hooks/useShowNDPValidationErrors'
+import { useIsEditODPDescriptionEnabled } from 'client/pages/OriginalDataPoint/hooks/useIsEditODPEnabled'
 
 type Props = {
   field: OriginalDataPointCommentKey
@@ -19,16 +18,15 @@ type Returned = Array<string>
 export const useValidationErrors = (props: Props): Returned => {
   const { field } = props
   const { t } = useTranslation()
-  const canEditCycleData = useCanEditCycleData()
-  const { print } = useIsPrintRoute()
-  const displayHistory = useODPDisplayHistory()
+  const canEdit = useIsEditODPDescriptionEnabled()
+  const showValidationErrors = useShowNDPValidationErrors({ canEdit })
   const nationalDataPoint = useOriginalDataPoint()
   const validation = useNationalDataPointValidation({ uuid: nationalDataPoint.uuid })
   const commentValidation = validation.comments?.[field]
 
   return useMemo<Returned>(() => {
-    if (!canEditCycleData || print || displayHistory) return []
+    if (!showValidationErrors) return []
 
     return MessageParser.getMessages(t, commentValidation)
-  }, [canEditCycleData, commentValidation, displayHistory, print, t])
+  }, [commentValidation, showValidationErrors, t])
 }

--- a/src/client/pages/OriginalDataPoint/components/DataSources/DataSourcesV2/DataSourcesV2.tsx
+++ b/src/client/pages/OriginalDataPoint/components/DataSources/DataSourcesV2/DataSourcesV2.tsx
@@ -11,6 +11,7 @@ import { useDataSourcesData } from './hooks/useDataSourcesData'
 import { useDataSourcesHistoryLastApproved } from './hooks/useDataSourcesHistoryLastApproved'
 import { useOnChange } from './hooks/useOnChange'
 import { useOnDelete } from './hooks/useOnDelete'
+import { useValidationErrors } from './hooks/useValidationErrors'
 
 type Props = {
   originalDataPoint: OriginalDataPoint
@@ -28,6 +29,7 @@ const DataSourcesV2: React.FC<Props> = (props) => {
   const { dataSources } = dataSourcesData
   const historyCompares = useDataSourcesHistoryLastApproved({ dataSources })
   const displayHistory = useODPDisplayHistory()
+  const validationErrors = useValidationErrors({ nationalDataPoint: originalDataPoint })
 
   return (
     <DataSources
@@ -37,6 +39,7 @@ const DataSourcesV2: React.FC<Props> = (props) => {
       onChange={onChange}
       onDelete={onDelete}
       options={{ canEdit, canReview: canEdit, displayHistory }}
+      validationErrors={validationErrors}
     />
   )
 }

--- a/src/client/pages/OriginalDataPoint/components/DataSources/DataSourcesV2/DataSourcesV2.tsx
+++ b/src/client/pages/OriginalDataPoint/components/DataSources/DataSourcesV2/DataSourcesV2.tsx
@@ -29,7 +29,7 @@ const DataSourcesV2: React.FC<Props> = (props) => {
   const { dataSources } = dataSourcesData
   const historyCompares = useDataSourcesHistoryLastApproved({ dataSources })
   const displayHistory = useODPDisplayHistory()
-  const validationErrors = useValidationErrors({ nationalDataPoint: originalDataPoint })
+  const validationErrors = useValidationErrors()
 
   return (
     <DataSources

--- a/src/client/pages/OriginalDataPoint/components/DataSources/DataSourcesV2/hooks/useValidationErrors.ts
+++ b/src/client/pages/OriginalDataPoint/components/DataSources/DataSourcesV2/hooks/useValidationErrors.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import type { DataSourceValidationErrorsRecord } from 'meta/assessment/descriptionValue/dataSource'
+import { OriginalDataPoint } from 'meta/assessment/originalDataPoint'
+import { MessageParser } from 'meta/validations/messageParser'
+
+import { useNationalDataPointValidation } from 'client/store/data/tableData/validations/hooks/nationalDataPoints'
+import { useCanEditCycleData } from 'client/store/user/hooks/auth'
+import { useIsPrintRoute } from 'client/hooks/routes'
+import { useODPDisplayHistory } from 'client/pages/OriginalDataPoint/components/hooks/useODPDisplayHistory'
+
+type Props = {
+  nationalDataPoint: OriginalDataPoint
+}
+
+export const useValidationErrors = (props: Props): DataSourceValidationErrorsRecord => {
+  const { nationalDataPoint } = props
+  const { t } = useTranslation()
+  const canEditCycleData = useCanEditCycleData()
+  const { print } = useIsPrintRoute()
+  const displayHistory = useODPDisplayHistory()
+  const validation = useNationalDataPointValidation({ uuid: nationalDataPoint.uuid })
+  const dataSourceValidations = validation.dataSources
+
+  return useMemo<DataSourceValidationErrorsRecord>(() => {
+    if (!canEditCycleData || print || displayHistory) return {}
+
+    const validationErrors: DataSourceValidationErrorsRecord = {}
+    Object.entries(dataSourceValidations ?? {}).forEach(([uuid, dataSourceValidation]) => {
+      validationErrors[uuid] = { reference: MessageParser.getMessages(t, dataSourceValidation.reference) }
+    })
+
+    return validationErrors
+  }, [canEditCycleData, dataSourceValidations, displayHistory, print, t])
+}

--- a/src/client/pages/OriginalDataPoint/components/DataSources/DataSourcesV2/hooks/useValidationErrors.ts
+++ b/src/client/pages/OriginalDataPoint/components/DataSources/DataSourcesV2/hooks/useValidationErrors.ts
@@ -2,29 +2,23 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { DataSourceValidationErrorsRecord } from 'meta/assessment/descriptionValue/dataSource'
-import { OriginalDataPoint } from 'meta/assessment/originalDataPoint'
 import { MessageParser } from 'meta/validations/messageParser'
 
+import { useOriginalDataPoint } from 'client/store/data/originalDataPoint/hooks/originalDataPoint'
 import { useNationalDataPointValidation } from 'client/store/data/tableData/validations/hooks/nationalDataPoints'
-import { useCanEditCycleData } from 'client/store/user/hooks/auth'
-import { useIsPrintRoute } from 'client/hooks/routes'
-import { useODPDisplayHistory } from 'client/pages/OriginalDataPoint/components/hooks/useODPDisplayHistory'
+import { useShowNDPValidationErrors } from 'client/pages/OriginalDataPoint/components/hooks/useShowNDPValidationErrors'
+import { useIsEditODPEnabled } from 'client/pages/OriginalDataPoint/hooks/useIsEditODPEnabled'
 
-type Props = {
-  nationalDataPoint: OriginalDataPoint
-}
-
-export const useValidationErrors = (props: Props): DataSourceValidationErrorsRecord => {
-  const { nationalDataPoint } = props
+export const useValidationErrors = (): DataSourceValidationErrorsRecord => {
   const { t } = useTranslation()
-  const canEditCycleData = useCanEditCycleData()
-  const { print } = useIsPrintRoute()
-  const displayHistory = useODPDisplayHistory()
+  const canEdit = useIsEditODPEnabled()
+  const showValidationErrors = useShowNDPValidationErrors({ canEdit })
+  const nationalDataPoint = useOriginalDataPoint()
   const validation = useNationalDataPointValidation({ uuid: nationalDataPoint.uuid })
   const dataSourceValidations = validation.dataSources
 
   return useMemo<DataSourceValidationErrorsRecord>(() => {
-    if (!canEditCycleData || print || displayHistory) return {}
+    if (!showValidationErrors) return {}
 
     const validationErrors: DataSourceValidationErrorsRecord = {}
     Object.entries(dataSourceValidations ?? {}).forEach(([uuid, dataSourceValidation]) => {
@@ -32,5 +26,5 @@ export const useValidationErrors = (props: Props): DataSourceValidationErrorsRec
     })
 
     return validationErrors
-  }, [canEditCycleData, dataSourceValidations, displayHistory, print, t])
+  }, [dataSourceValidations, showValidationErrors, t])
 }

--- a/src/client/pages/OriginalDataPoint/components/hooks/useShowNDPValidationErrors.ts
+++ b/src/client/pages/OriginalDataPoint/components/hooks/useShowNDPValidationErrors.ts
@@ -1,0 +1,12 @@
+import { useODPDisplayHistory } from './useODPDisplayHistory'
+
+type Props = {
+  canEdit: boolean
+}
+
+export const useShowNDPValidationErrors = (props: Props): boolean => {
+  const { canEdit } = props
+  const displayHistory = useODPDisplayHistory()
+
+  return canEdit && !displayHistory
+}

--- a/src/server/controller/cycleData/links/update.ts
+++ b/src/server/controller/cycleData/links/update.ts
@@ -5,6 +5,7 @@ import { Cycle } from 'meta/assessment/cycle'
 import { DescriptionIdentifier } from 'meta/assessment/descriptionValue'
 import { Link } from 'meta/cycleData/links/link'
 import { Links } from 'meta/cycleData/links/links'
+import { NDPLinkTarget } from 'meta/cycleData/links/nationalDataPointLink'
 import { SectionNames } from 'meta/routes/sectionNames'
 import { User } from 'meta/user/user'
 import { Objects } from 'utils/objects'
@@ -13,6 +14,7 @@ import { BaseProtocol, DB } from 'server/db/db'
 import { LinkRepository } from 'server/db/repository/assessmentCycle/links'
 import { ActivityLogRepository } from 'server/db/repository/public/activityLog'
 import { visitDescriptionLinks } from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/visitDescriptionLinks'
+import { visitNationalDataPointLinks } from 'server/worker/tasks/verifyLinks/visitNationalDataPointLinks/visitNationalDataPointLinks'
 
 type Props = {
   assessment: Assessment
@@ -50,6 +52,17 @@ export const update = async (props: Props): Promise<Link> => {
       })
     )
     await visitDescriptionLinks({ assessment, countryIso, cycle, descriptionIdentifiers })
+  }
+
+  // If the link has national data point locations, we trigger the flow that updates the ndp validation cache.
+  const nationalDataPointLocations = updatedLink.locations.filter(Links.isNationalDataPointLocation)
+  if (!Objects.isEmpty(nationalDataPointLocations)) {
+    const { countryIso } = updatedLink
+    const targets = nationalDataPointLocations.map<NDPLinkTarget>(({ ndpSection, ndpUuid }) => ({
+      ndpUuid,
+      fields: [ndpSection],
+    }))
+    await visitNationalDataPointLinks({ assessment, countryIso, cycle, targets })
   }
 
   return updatedLink

--- a/src/server/controller/cycleData/nationalDataPoint/remove.ts
+++ b/src/server/controller/cycleData/nationalDataPoint/remove.ts
@@ -5,6 +5,7 @@ import { Cycle } from 'meta/assessment/cycle'
 import { CommentableDescriptionName } from 'meta/assessment/descriptionValue'
 import { OriginalDataPoint } from 'meta/assessment/originalDataPoint'
 import { SectionNames } from 'meta/assessment/section'
+import { NDPLinkFields } from 'meta/cycleData/links/nationalDataPointLink'
 import { Topics } from 'meta/messageCenter/topics'
 import { Sockets } from 'meta/socket/sockets'
 import { User } from 'meta/user/user'
@@ -18,6 +19,7 @@ import { OriginalDataPointRepository } from 'server/db/repository/assessmentCycl
 import { ActivityLogRepository } from 'server/db/repository/public/activityLog'
 import { CountryService } from 'server/service/country'
 import { SocketServer } from 'server/service/socket'
+import { visitNationalDataPointLinks } from 'server/worker/tasks/verifyLinks/visitNationalDataPointLinks/visitNationalDataPointLinks'
 
 import { updateOriginalDataPointDependentNodes } from './updateDependants/updateOriginalDataPointDependentNodes'
 
@@ -85,6 +87,16 @@ export const remove = async (props: Props, client: BaseProtocol = DB): Promise<O
     uuids: [uuid],
   })
   notifyNationalDataPointValidationDelete({ assessment, countryIso, cycle, uuid })
+
+  // Remove the deleted national data point's link locations.
+  // Clients are already notified through the delete event above.
+  await visitNationalDataPointLinks({
+    assessment,
+    countryIso,
+    cycle,
+    notifyClients: false,
+    targets: [{ ndpUuid: uuid, fields: NDPLinkFields }],
+  })
 
   return target
 }

--- a/src/server/controller/cycleData/nationalDataPoint/updateComments.ts
+++ b/src/server/controller/cycleData/nationalDataPoint/updateComments.ts
@@ -31,7 +31,7 @@ export const updateComments = async (props: Props, client: BaseProtocol = DB): P
   const { assessment, country, cycle, field, originalDataPoint, user } = props
   const { countryIso } = originalDataPoint
 
-  const updatedOriginalDataPoint = await client.tx(async (t) => {
+  const updatedNationalDataPoint = await client.tx(async (t) => {
     const updated = await OriginalDataPointRepository.updateDescription(
       { assessment, cycle, field, originalDataPoint },
       t
@@ -61,8 +61,8 @@ export const updateComments = async (props: Props, client: BaseProtocol = DB): P
     assessment,
     countryIso,
     cycle,
-    targets: [{ ndpUuid: updatedOriginalDataPoint.uuid, fields: [commentLinkField.linkField] }],
+    targets: [{ ndpUuid: updatedNationalDataPoint.uuid, fields: [commentLinkField.linkField] }],
   })
 
-  return updatedOriginalDataPoint
+  return updatedNationalDataPoint
 }

--- a/src/server/controller/cycleData/nationalDataPoint/updateComments.ts
+++ b/src/server/controller/cycleData/nationalDataPoint/updateComments.ts
@@ -4,12 +4,14 @@ import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import { OriginalDataPoint, OriginalDataPointCommentKey } from 'meta/assessment/originalDataPoint'
 import { TableNames } from 'meta/assessment/table'
+import { NDPCommentLinkFields } from 'meta/cycleData/links/nationalDataPointLink'
 import { User } from 'meta/user/user'
 
 import { BaseProtocol, DB } from 'server/db/db'
 import { OriginalDataPointRepository } from 'server/db/repository/assessmentCycle/originalDataPoint'
 import { ActivityLogRepository } from 'server/db/repository/public/activityLog'
 import { CountryService } from 'server/service/country'
+import { visitNationalDataPointLinks } from 'server/worker/tasks/verifyLinks/visitNationalDataPointLinks/visitNationalDataPointLinks'
 
 type Props = {
   assessment: Assessment
@@ -29,8 +31,8 @@ export const updateComments = async (props: Props, client: BaseProtocol = DB): P
   const { assessment, country, cycle, field, originalDataPoint, user } = props
   const { countryIso } = originalDataPoint
 
-  return client.tx(async (t) => {
-    const updatedOriginalDataPoint = await OriginalDataPointRepository.updateDescription(
+  const updatedOriginalDataPoint = await client.tx(async (t) => {
+    const updated = await OriginalDataPointRepository.updateDescription(
       { assessment, cycle, field, originalDataPoint },
       t
     )
@@ -38,7 +40,7 @@ export const updateComments = async (props: Props, client: BaseProtocol = DB): P
     const message = activities[field]
 
     const activityLog = {
-      target: updatedOriginalDataPoint,
+      target: updated,
       section: 'odp',
       message,
       countryIso,
@@ -51,6 +53,16 @@ export const updateComments = async (props: Props, client: BaseProtocol = DB): P
 
     await CountryService.updateLastEdit({ assessment, cycle, country, user, lastEditOdp: true, lastUpdateTimestamp }, t)
 
-    return updatedOriginalDataPoint
+    return updated
   })
+
+  const commentLinkField = NDPCommentLinkFields.find(({ commentKey }) => commentKey === field)
+  await visitNationalDataPointLinks({
+    assessment,
+    countryIso,
+    cycle,
+    targets: [{ ndpUuid: updatedOriginalDataPoint.uuid, fields: [commentLinkField.linkField] }],
+  })
+
+  return updatedOriginalDataPoint
 }

--- a/src/server/controller/cycleData/nationalDataPoint/updateDataSources.ts
+++ b/src/server/controller/cycleData/nationalDataPoint/updateDataSources.ts
@@ -5,12 +5,14 @@ import { Cycle } from 'meta/assessment/cycle'
 import { CommentableDescriptionName } from 'meta/assessment/descriptionValue'
 import { OriginalDataPoint } from 'meta/assessment/originalDataPoint'
 import { SectionNames } from 'meta/assessment/section'
+import { NDPLinkField } from 'meta/cycleData/links/nationalDataPointLink'
 import { User } from 'meta/user/user'
 
 import { BaseProtocol, DB } from 'server/db/db'
 import { DescriptionRepository } from 'server/db/repository/assessmentCycle/descriptions'
 import { ActivityLogRepository } from 'server/db/repository/public/activityLog'
 import { CountryService } from 'server/service/country'
+import { visitNationalDataPointLinks } from 'server/worker/tasks/verifyLinks/visitNationalDataPointLinks/visitNationalDataPointLinks'
 
 type Props = {
   assessment: Assessment
@@ -27,7 +29,7 @@ export const updateDataSources = async (props: Props, client: BaseProtocol = DB)
   const { assessment, country, cycle, originalDataPoint, user } = props
   const { countryIso, dataSources, uuid } = originalDataPoint
 
-  return client.tx(async (t) => {
+  await client.tx(async (t) => {
     await DescriptionRepository.upsert(
       { assessment, countryIso, cycle, name, sectionName, sectionUuid: uuid, value: dataSources },
       t
@@ -46,7 +48,14 @@ export const updateDataSources = async (props: Props, client: BaseProtocol = DB)
     )
 
     await CountryService.updateLastEdit({ assessment, cycle, country, user, lastEditOdp: true, lastUpdateTimestamp }, t)
-
-    return originalDataPoint
   })
+
+  await visitNationalDataPointLinks({
+    assessment,
+    countryIso,
+    cycle,
+    targets: [{ ndpUuid: uuid, fields: [NDPLinkField.dataSourceReferences] }],
+  })
+
+  return originalDataPoint
 }

--- a/src/server/controller/cycleData/nationalDataPoint/updateDataSources.ts
+++ b/src/server/controller/cycleData/nationalDataPoint/updateDataSources.ts
@@ -26,8 +26,8 @@ const name = CommentableDescriptionName.dataSources
 const sectionName = SectionNames.nationalDataPoint
 
 export const updateDataSources = async (props: Props, client: BaseProtocol = DB): Promise<OriginalDataPoint> => {
-  const { assessment, country, cycle, originalDataPoint, user } = props
-  const { countryIso, dataSources, uuid } = originalDataPoint
+  const { assessment, country, cycle, originalDataPoint: nationalDataPoint, user } = props
+  const { countryIso, dataSources, uuid } = nationalDataPoint
 
   await client.tx(async (t) => {
     await DescriptionRepository.upsert(
@@ -36,7 +36,7 @@ export const updateDataSources = async (props: Props, client: BaseProtocol = DB)
     )
 
     const activityLog = {
-      target: originalDataPoint,
+      target: nationalDataPoint,
       section: 'odp',
       message: ActivityLogMessage.originalDataPointUpdateDataSources,
       countryIso,
@@ -57,5 +57,5 @@ export const updateDataSources = async (props: Props, client: BaseProtocol = DB)
     targets: [{ ndpUuid: uuid, fields: [NDPLinkField.dataSourceReferences] }],
   })
 
-  return originalDataPoint
+  return nationalDataPoint
 }

--- a/src/server/controller/cycleData/nationalDataPoint/updateYear.ts
+++ b/src/server/controller/cycleData/nationalDataPoint/updateYear.ts
@@ -3,6 +3,7 @@ import { ActivityLogMessage } from 'meta/assessment/activityLog'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import { OriginalDataPoint } from 'meta/assessment/originalDataPoint'
+import { NDPLinkFields } from 'meta/cycleData/links/nationalDataPointLink'
 import { Sockets } from 'meta/socket/sockets'
 import { User } from 'meta/user/user'
 
@@ -13,6 +14,7 @@ import { OriginalDataPointRepository } from 'server/db/repository/assessmentCycl
 import { ActivityLogRepository } from 'server/db/repository/public/activityLog'
 import { CountryService } from 'server/service/country'
 import { SocketServer } from 'server/service/socket'
+import { visitNationalDataPointLinks } from 'server/worker/tasks/verifyLinks/visitNationalDataPointLinks/visitNationalDataPointLinks'
 
 import { updateOriginalDataPointsDependentNodes } from './updateDependants/updateOriginalDataPointsDependentNodes'
 
@@ -74,6 +76,14 @@ export const updateYear = async (props: Props, client: BaseProtocol = DB): Promi
     countryIso,
     cycle,
     nationalDataPoint: updatedNationalDataPoint,
+  })
+
+  // The stored link locations carry the year and a year-based url, so they are refreshed on year change.
+  await visitNationalDataPointLinks({
+    assessment,
+    countryIso,
+    cycle,
+    targets: [{ ndpUuid: updatedNationalDataPoint.uuid, fields: NDPLinkFields }],
   })
 
   return updatedNationalDataPoint

--- a/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/getNationalDataPointLinks.ts
+++ b/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/getNationalDataPointLinks.ts
@@ -1,6 +1,7 @@
 import { CountryIso } from 'meta/area/countryIso'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
+import { OriginalDataPoint } from 'meta/assessment/originalDataPoint'
 import { SectionNames } from 'meta/assessment/section'
 import { LinkToVisit } from 'meta/cycleData/links/link'
 import {
@@ -22,16 +23,21 @@ type Props = {
   targets: Array<NDPLinkTarget>
 }
 
-export const getNationalDataPointLinks = async (props: Props): Promise<Array<LinkToVisit>> => {
+type Returned = {
+  linksToVisit: Array<LinkToVisit>
+  nationalDataPoints: Array<OriginalDataPoint>
+}
+
+export const getNationalDataPointLinks = async (props: Props): Promise<Returned> => {
   const { assessment, countryIso, cycle, targets } = props
 
-  const originalDataPoints = await OriginalDataPointRepository.getMany({ assessment, countryIso, cycle })
+  const nationalDataPoints = await OriginalDataPointRepository.getMany({ assessment, countryIso, cycle })
 
-  return targets.flatMap<LinkToVisit>((target) => {
-    const originalDataPoint = originalDataPoints.find(({ uuid }) => uuid === target.ndpUuid)
-    if (!originalDataPoint) return []
+  const linksToVisit = targets.flatMap<LinkToVisit>((target) => {
+    const nationalDataPoint = nationalDataPoints.find(({ uuid }) => uuid === target.ndpUuid)
+    if (Objects.isEmpty(nationalDataPoint)) return []
 
-    const { comments, dataSources = [], uuid, year } = originalDataPoint
+    const { comments, dataSources = [], uuid, year } = nationalDataPoint
     const urlParams = { assessmentName: assessment.props.name, countryIso, cycleName: cycle.name, year: String(year) }
 
     // Build comment links to visit (1a / 1b)
@@ -73,4 +79,6 @@ export const getNationalDataPointLinks = async (props: Props): Promise<Array<Lin
 
     return commentLinks.concat(referenceLinks)
   })
+
+  return { linksToVisit, nationalDataPoints }
 }

--- a/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/mergeTargets.ts
+++ b/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/mergeTargets.ts
@@ -1,0 +1,23 @@
+import { NDPLinkTarget } from 'meta/cycleData/links/nationalDataPointLink'
+import { UUID } from 'meta/uuid/uuid'
+
+type Props = {
+  targets: Array<NDPLinkTarget>
+}
+
+// Merges targets of the same national data point into one, so a job never refreshes a national data point twice.
+export const mergeTargets = (props: Props): Array<NDPLinkTarget> => {
+  const { targets } = props
+
+  const targetsByNdpUuid: Record<UUID, NDPLinkTarget> = {}
+
+  targets.forEach(({ fields, ndpUuid }) => {
+    const target = (targetsByNdpUuid[ndpUuid] ??= { ndpUuid, fields: [] })
+
+    fields.forEach((field) => {
+      if (!target.fields.includes(field)) target.fields.push(field)
+    })
+  })
+
+  return Object.values(targetsByNdpUuid)
+}

--- a/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/mergeTargets.ts
+++ b/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/mergeTargets.ts
@@ -5,7 +5,11 @@ type Props = {
   targets: Array<NDPLinkTarget>
 }
 
-// Merges targets of the same national data point into one, so a job never refreshes a national data point twice.
+// Merges targets of the same national data point into one, so a job never refreshes it twice.
+// This can happen when a link is approved and it was used in more than one field.
+// Example:
+//   targets: [{ ndpUuid: 'abc', fields: [commentsExtentOfForest] }, { ndpUuid: 'abc', fields: [dataSourceReferences] }]
+//   result:  [{ ndpUuid: 'abc', fields: [commentsExtentOfForest, dataSourceReferences] }]
 export const mergeTargets = (props: Props): Array<NDPLinkTarget> => {
   const { targets } = props
 

--- a/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/refreshNationalDataPointValidations.ts
+++ b/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/refreshNationalDataPointValidations.ts
@@ -1,6 +1,7 @@
 import { CountryIso } from 'meta/area/countryIso'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
+import { OriginalDataPoint } from 'meta/assessment/originalDataPoint'
 import { RecordNDPValidations } from 'meta/assessment/validation/nationalDataPoint'
 import { NationalDataPointValidations } from 'meta/assessment/validation/nationalDataPointValidations'
 import { Link, LinkToVisit, VisitedLink } from 'meta/cycleData/links/link'
@@ -20,13 +21,14 @@ type Props = {
   cycle: Cycle
   linkVisits: Array<VisitedLink>
   linksToVisit: Array<LinkToVisit>
+  nationalDataPoints: Array<OriginalDataPoint>
   notifyClients?: boolean
   targets: Array<NDPLinkTarget>
 }
 
 // Rebuilds the target national data points' link validations, saves them in the cache and notifies clients.
 export const refreshNationalDataPointValidations = async (props: Props): Promise<void> => {
-  const { approvedLinks, assessment, countryIso, cycle, linkVisits, linksToVisit, targets } = props
+  const { approvedLinks, assessment, countryIso, cycle, linkVisits, linksToVisit, nationalDataPoints, targets } = props
   const { notifyClients = true } = props
 
   if (Objects.isEmpty(targets)) return
@@ -44,17 +46,22 @@ export const refreshNationalDataPointValidations = async (props: Props): Promise
   const uuidsToDelete: Array<UUID> = []
 
   targets.forEach(({ fields, ndpUuid }) => {
-    const current = currentValidations[ndpUuid] ?? {}
+    // The odp id is not a validation, so we keep it out of the merge.
+    const { odpId: currentOdpId, ...current } = currentValidations[ndpUuid] ?? {}
     const update = linkValidations[ndpUuid] ?? {}
     const value = NationalDataPointValidations.mergeLinkValidations({ current, fields, update })
-
-    validations[ndpUuid] = value
 
     if (Objects.isEmpty(value)) {
       uuidsToDelete.push(ndpUuid)
     } else {
+      // The odp header cell looks the validation up by odp id.
+      const odpId = nationalDataPoints.find(({ uuid }) => uuid === ndpUuid)?.id ?? currentOdpId
+      if (!Objects.isNil(odpId)) value.odpId = odpId
+
       validationsToSet[ndpUuid] = value
     }
+
+    validations[ndpUuid] = value
   })
 
   await Promise.all([

--- a/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/worker.ts
+++ b/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/worker.ts
@@ -17,24 +17,20 @@ export default async (job: VerifyNationalDataPointLinksJob): Promise<void> => {
 
   try {
     const { assessment, countryIso, cycle, notifyClients, targets: rawTargets } = job.data
+    const commonProps = { assessment, countryIso, cycle }
     const time = new Date().getTime()
 
     Logger.info(`${logKey} started.`)
 
     const targets = mergeTargets({ targets: rawTargets }) // Merge duplicated targets
 
-    const linksToVisit = await getNationalDataPointLinks({ assessment, countryIso, cycle, targets })
+    const nationalDataPointLinks = await getNationalDataPointLinks({ ...commonProps, targets })
+    const { linksToVisit } = nationalDataPointLinks
 
-    const { approvedLinks, linkVisits } = await syncNationalDataPointLinks({
-      assessment,
-      countryIso,
-      cycle,
-      linksToVisit,
-      targets,
-    })
+    const { approvedLinks, linkVisits } = await syncNationalDataPointLinks({ ...commonProps, linksToVisit, targets })
 
-    const params = { approvedLinks, assessment, countryIso, cycle, linkVisits, linksToVisit, notifyClients, targets }
-    await refreshNationalDataPointValidations(params)
+    const props = { ...commonProps, ...nationalDataPointLinks, approvedLinks, linkVisits, notifyClients, targets }
+    await refreshNationalDataPointValidations(props)
 
     const duration = (new Date().getTime() - time) / 1000
     Logger.info(`${logKey} ended in ${duration} seconds with ${linkVisits.length} links visited.`)

--- a/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/worker.ts
+++ b/src/server/worker/tasks/verifyLinks/visitNationalDataPointLinks/worker.ts
@@ -1,6 +1,7 @@
 import { Logger } from 'server/utils/logger'
 
 import { getNationalDataPointLinks } from './utils/getNationalDataPointLinks'
+import { mergeTargets } from './utils/mergeTargets'
 import { refreshNationalDataPointValidations } from './utils/refreshNationalDataPointValidations'
 import { syncNationalDataPointLinks } from './utils/syncNationalDataPointLinks'
 import { VerifyNationalDataPointLinksJob } from './props'
@@ -15,10 +16,12 @@ export default async (job: VerifyNationalDataPointLinksJob): Promise<void> => {
   const logKey = _getLogKey(job)
 
   try {
-    const { assessment, countryIso, cycle, notifyClients, targets } = job.data
+    const { assessment, countryIso, cycle, notifyClients, targets: rawTargets } = job.data
     const time = new Date().getTime()
 
     Logger.info(`${logKey} started.`)
+
+    const targets = mergeTargets({ targets: rawTargets }) // Merge duplicated targets
 
     const linksToVisit = await getNationalDataPointLinks({ assessment, countryIso, cycle, targets })
 


### PR DESCRIPTION


The NDP links job now runs whenever NDP links can change, and the errors are shown in the NDP page.

In this PR:

- Editing a 1a/1b comment or the data sources refreshes the link validations of the edited field
- Changing an NDP's year refreshes its link locations, because we need to update the year and a year-based url location
- Deleting an NDP removes its link locations
- Approving or unapproving a link refreshes the NDPs where the link is located
- Added `mergeTargets` to the worker: a link can be located in several fields of the same NDP, and the job should refresh each NDP only once
- The NDP comments and data sources now display the errors from the BE
- Link validations now carry the ndp id, which the component `OdpHeaderCell` needs 

https://github.com/user-attachments/assets/8c5cb31b-d1fe-4362-a6f4-eb66cccb483e

Coming next: Making the full links job reuse the logic from the ndp and description jobs so it handles validations as well. 

