### PR TITLE
5758 - Navigation: Data errors - visitCycleLinks - Update descriptions code

### DIFF
--- a/src/server/cache/repository/validation/description/setValidations.ts
+++ b/src/server/cache/repository/validation/description/setValidations.ts
@@ -2,12 +2,10 @@ import { CountryIso } from 'meta/area/countryIso'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import { RecordDescriptionValidations } from 'meta/assessment/validation/description'
-import { DescriptionValidations } from 'meta/assessment/validation/descriptionValidations'
 import { Objects } from 'utils/objects'
 
 import { getKeyCountry, Keys } from 'server/cache/repository/keys'
 import { RedisData } from 'server/cache/repository/redisData'
-import { getValidations } from 'server/cache/repository/validation/description/getValidations'
 
 type Props = {
   assessment: Assessment
@@ -26,14 +24,9 @@ export const setValidations = async (props: Props): Promise<void> => {
 
   const redis = RedisData.getInstance()
   const key = getKeyCountry({ assessment, countryIso, cycle, key: Keys.Data.validationDescriptions })
-  const currentValidations = await getValidations({ assessment, countryIso, cycle, sectionNames })
 
   const validationsToSet = sectionNames.reduce<Record<string, string>>((acc, sectionName) => {
-    const current = currentValidations[sectionName] ?? {}
-    const update = descriptionValidations[sectionName]
-    const value = DescriptionValidations.mergeValidations({ current, update })
-
-    acc[sectionName] = JSON.stringify(value)
+    acc[sectionName] = JSON.stringify(descriptionValidations[sectionName] ?? {})
     return acc
   }, {})
 

--- a/src/server/controller/cycleData/validations/descriptions/notifyDescriptionValidationUpdate.ts
+++ b/src/server/controller/cycleData/validations/descriptions/notifyDescriptionValidationUpdate.ts
@@ -1,0 +1,29 @@
+import { CountryIso } from 'meta/area/countryIso'
+import { Assessment } from 'meta/assessment/assessment'
+import { Cycle } from 'meta/assessment/cycle'
+import { SectionName } from 'meta/assessment/section'
+import { RecordDescriptionValidations } from 'meta/assessment/validation/description'
+import { Sockets } from 'meta/socket/sockets'
+
+import { SocketServer } from 'server/service/socket'
+
+type Props = {
+  assessment: Assessment
+  countryIso: CountryIso
+  cycle: Cycle
+  descriptionValidations: RecordDescriptionValidations
+  // Without section names, clients replace their whole state instead of updating the given sections.
+  sectionNames?: Array<SectionName>
+}
+
+export const notifyDescriptionValidationUpdate = (props: Props): void => {
+  const { assessment, countryIso, cycle, descriptionValidations, sectionNames } = props
+
+  const eventName = Sockets.getDescriptionValidationsUpdateEvent({
+    assessmentName: assessment.props.name,
+    countryIso,
+    cycleName: cycle.name,
+  })
+
+  SocketServer.emit(eventName, { descriptionValidations, sectionNames })
+}

--- a/src/server/controller/cycleData/validations/descriptions/updateDataSourceFieldValidations.ts
+++ b/src/server/controller/cycleData/validations/descriptions/updateDataSourceFieldValidations.ts
@@ -5,11 +5,10 @@ import { CommentableDescription } from 'meta/assessment/descriptionValue'
 import { DataSource, DataSourceEditableField } from 'meta/assessment/descriptionValue/dataSource'
 import { RecordDescriptionValidations } from 'meta/assessment/validation/description'
 import { Validation } from 'meta/assessment/validation/validation'
-import { Sockets } from 'meta/socket/sockets'
 import { Objects } from 'utils/objects'
 
 import { DescriptionValidationRedisRepository } from 'server/cache/repository/validation/description'
-import { SocketServer } from 'server/service/socket'
+import { notifyDescriptionValidationUpdate } from 'server/controller/cycleData/validations/descriptions/notifyDescriptionValidationUpdate'
 
 type Props = {
   assessment: Assessment
@@ -63,11 +62,6 @@ export const updateDataSourceFieldValidations = async (props: Props): Promise<vo
 
   if (notifyClients) {
     const sectionNames = Array.from(new Set(dataSourceDescriptions.map(({ sectionName }) => sectionName)))
-    const eventName = Sockets.getDescriptionValidationsUpdateEvent({
-      assessmentName: assessment.props.name,
-      countryIso,
-      cycleName: cycle.name,
-    })
-    SocketServer.emit(eventName, { descriptionValidations, sectionNames })
+    notifyDescriptionValidationUpdate({ assessment, countryIso, cycle, descriptionValidations, sectionNames })
   }
 }

--- a/src/server/controller/cycleData/validations/descriptions/updateDataSourceFieldValidations.ts
+++ b/src/server/controller/cycleData/validations/descriptions/updateDataSourceFieldValidations.ts
@@ -4,6 +4,7 @@ import { Cycle } from 'meta/assessment/cycle'
 import { CommentableDescription } from 'meta/assessment/descriptionValue'
 import { DataSource, DataSourceEditableField } from 'meta/assessment/descriptionValue/dataSource'
 import { RecordDescriptionValidations } from 'meta/assessment/validation/description'
+import { DescriptionValidations } from 'meta/assessment/validation/descriptionValidations'
 import { Validation } from 'meta/assessment/validation/validation'
 import { Objects } from 'utils/objects'
 
@@ -53,15 +54,30 @@ export const updateDataSourceFieldValidations = async (props: Props): Promise<vo
     return acc
   }, {})
 
+  const sectionNames = Array.from(new Set(dataSourceDescriptions.map(({ sectionName }) => sectionName)))
+
+  // Merge the results onto the current state, so the other validations of the sections are kept.
+  const currentValidations = await DescriptionValidationRedisRepository.getValidations({
+    assessment,
+    countryIso,
+    cycle,
+    sectionNames,
+  })
+  const validations: RecordDescriptionValidations = {}
+  sectionNames.forEach((sectionName) => {
+    const current = currentValidations[sectionName] ?? {}
+    const update = descriptionValidations[sectionName] ?? {}
+    validations[sectionName] = DescriptionValidations.mergeValidations({ current, update })
+  })
+
   await DescriptionValidationRedisRepository.setValidations({
     assessment,
     countryIso,
     cycle,
-    descriptionValidations,
+    descriptionValidations: validations,
   })
 
   if (notifyClients) {
-    const sectionNames = Array.from(new Set(dataSourceDescriptions.map(({ sectionName }) => sectionName)))
     notifyDescriptionValidationUpdate({ assessment, countryIso, cycle, descriptionValidations, sectionNames })
   }
 }

--- a/src/server/worker/tasks/verifyLinks/visitCycleLinks/utils/refreshDescriptionLinkValidationCache.ts
+++ b/src/server/worker/tasks/verifyLinks/visitCycleLinks/utils/refreshDescriptionLinkValidationCache.ts
@@ -2,12 +2,11 @@ import { CountryIso } from 'meta/area/countryIso'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import { Link, LinkToVisit, VisitedLink } from 'meta/cycleData/links/link'
-import { Sockets } from 'meta/socket/sockets'
 
 import { AreaRedisRepository } from 'server/cache/repository/area'
 import { SectionRedisRepository } from 'server/cache/repository/section'
 import { DescriptionValidationRedisRepository } from 'server/cache/repository/validation/description'
-import { SocketServer } from 'server/service/socket'
+import { notifyDescriptionValidationUpdate } from 'server/controller/cycleData/validations/descriptions/notifyDescriptionValidationUpdate'
 import { buildDescriptionLinkValidationsByCountry } from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/buildDescriptionLinkValidations'
 
 type Props = {
@@ -53,12 +52,10 @@ export const refreshDescriptionLinkValidationCache = async (props: Props): Promi
         }
       )
 
-      const eventName = Sockets.getDescriptionValidationsUpdateEvent({
-        assessmentName: assessment.props.name,
+      notifyDescriptionValidationUpdate({
+        assessment,
         countryIso: targetCountryIso,
-        cycleName: cycle.name,
-      })
-      SocketServer.emit(eventName, {
+        cycle,
         descriptionValidations: updatedDescriptionValidations,
       })
     })

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/worker.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/worker.ts
@@ -1,8 +1,7 @@
-import { Sockets } from 'meta/socket/sockets'
 import { Objects } from 'utils/objects'
 
 import { DescriptionValidationRedisRepository } from 'server/cache/repository/validation/description'
-import { SocketServer } from 'server/service/socket'
+import { notifyDescriptionValidationUpdate } from 'server/controller/cycleData/validations/descriptions/notifyDescriptionValidationUpdate'
 import { Logger } from 'server/utils/logger'
 
 import { buildDescriptionLinkValidations } from './utils/buildDescriptionLinkValidations'
@@ -62,12 +61,7 @@ export default async (job: VerifyDescriptionLinksJob): Promise<void> => {
     })
 
     if (notifyClients) {
-      const eventName = Sockets.getDescriptionValidationsUpdateEvent({
-        assessmentName: assessment.props.name,
-        countryIso,
-        cycleName: cycle.name,
-      })
-      SocketServer.emit(eventName, { descriptionValidations, sectionNames })
+      notifyDescriptionValidationUpdate({ assessment, countryIso, cycle, descriptionValidations, sectionNames })
     }
 
     const duration = (new Date().getTime() - time) / 1000

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/worker.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/worker.ts
@@ -1,3 +1,5 @@
+import { RecordDescriptionValidations } from 'meta/assessment/validation/description'
+import { DescriptionValidations } from 'meta/assessment/validation/descriptionValidations'
 import { Objects } from 'utils/objects'
 
 import { DescriptionValidationRedisRepository } from 'server/cache/repository/validation/description'
@@ -53,11 +55,25 @@ export default async (job: VerifyDescriptionLinksJob): Promise<void> => {
 
     const sectionNames = Array.from(new Set(descriptions.map(({ sectionName }) => sectionName)))
 
+    // Merge the results onto the current state, so the other validations of the sections are kept.
+    const currentValidations = await DescriptionValidationRedisRepository.getValidations({
+      assessment,
+      countryIso,
+      cycle,
+      sectionNames,
+    })
+    const validations: RecordDescriptionValidations = {}
+    sectionNames.forEach((sectionName) => {
+      const current = currentValidations[sectionName] ?? {}
+      const update = descriptionValidations[sectionName] ?? {}
+      validations[sectionName] = DescriptionValidations.mergeValidations({ current, update })
+    })
+
     await DescriptionValidationRedisRepository.setValidations({
       assessment,
       countryIso,
       cycle,
-      descriptionValidations,
+      descriptionValidations: validations,
     })
 
     if (notifyClients) {


### PR DESCRIPTION
First step to update `visitCycleLinks`: making the descriptions code reusable for it. 

- Adding a common `notifyDescriptionValidationUpdate` like in NDP links.
- Removing `const currentValidations = await getValidations` from the redis set method, like we discussed while working on NDP
