### PR TITLE
6127 - Evaluator optimisation

### DIFF
--- a/src/lib/expressionEvaluator/javascript/evaluator.ts
+++ b/src/lib/expressionEvaluator/javascript/evaluator.ts
@@ -42,8 +42,11 @@ export class JavascriptExpressionEvaluator<C extends ExpressionContext> implemen
 
   constructor(functions: Array<ExpressionFunction<C>> = [], evaluators: Evaluators<C> = {}) {
     this.evaluators = { ...defaultEvaluators, ...evaluators }
-    this.functions = [...functionsDefault, ...functions].reduce(
-      (functionsAcc, expressionFunction) => ({ ...functionsAcc, [expressionFunction.name]: expressionFunction }),
+    this.functions = [...functionsDefault, ...functions].reduce<{ [functionName: string]: ExpressionFunction<C> }>(
+      (acc, expressionFunction) => {
+        acc[expressionFunction.name] = expressionFunction
+        return acc
+      },
       {}
     )
   }

--- a/src/meta/expressionEvaluator/expressionEvaluator.ts
+++ b/src/meta/expressionEvaluator/expressionEvaluator.ts
@@ -8,8 +8,9 @@ import { functions } from './functions'
 
 type Props = Context & { formula: string }
 
+const evaluator = new JavascriptExpressionEvaluator<Context>(functions, evaluators)
+
 const evalFormula = <ReturnType>(props: Props): ReturnType => {
-  const evaluator = new JavascriptExpressionEvaluator<Context>(functions, evaluators)
   return evaluator.evaluate(props.formula, props)
 }
 


### PR DESCRIPTION
1. Move evaluator (static) to top level (major)
2. Avoid desctucting the accumulator (minor)

Saves almost 30 seconds when running all table validations

57.845s ( ------ with new optimisation )
86.746s ( ------ without optimisation )