### PR TITLE
5758 - Navigation: Data errors - Visit links tool - Add LinksService.verifyLinks

### DIFF
--- a/src/server/service/links/index.ts
+++ b/src/server/service/links/index.ts
@@ -1,0 +1,5 @@
+import { verifyLinks } from 'server/service/links/verifyLinks'
+
+export const LinksService = {
+  verifyLinks,
+}

--- a/src/server/service/links/verifyLinks.ts
+++ b/src/server/service/links/verifyLinks.ts
@@ -1,0 +1,50 @@
+import { CountryIso } from 'meta/area/countryIso'
+import { Assessment } from 'meta/assessment/assessment'
+import { Cycle } from 'meta/assessment/cycle'
+import { LinksVerificationEvent } from 'meta/socket/event/links'
+import { User } from 'meta/user/user'
+import { Objects } from 'utils/objects'
+
+import { BaseProtocol, DB } from 'server/db/db'
+import { emitLinksVerificationEvent } from 'server/worker/tasks/verifyLinks/utils/emitLinksVerificationEvent'
+import { insertLinksCheckActivityLog } from 'server/worker/tasks/verifyLinks/utils/insertLinksCheckActivityLog'
+import { VerifyLinksJob } from 'server/worker/tasks/verifyLinks/verifyLinksJob'
+import { verifyAllLinks } from 'server/worker/tasks/verifyLinks/visitCycleLinks/verifyAllLinks'
+
+type Props = {
+  assessment: Assessment
+  countryIso?: CountryIso
+  cycle: Cycle
+  user: User
+}
+
+const _getLogKey = (props: Props): string => {
+  const { assessment, countryIso, cycle } = props
+  const base = `${assessment.props.name}-${cycle.name}`
+  const scope = Objects.isEmpty(countryIso) ? base : `${base}-${countryIso}`
+  return `[verifyAllLinks-inProcess] [${scope}]`
+}
+
+export const verifyLinks = async (props: Props, client: BaseProtocol = DB): Promise<void> => {
+  const { assessment, countryIso, cycle, user } = props
+  const verifyLinksJob = new VerifyLinksJob({ assessment, countryIso, cycle })
+
+  await verifyLinksJob.setRunning()
+
+  try {
+    emitLinksVerificationEvent({ assessment, countryIso, cycle, event: LinksVerificationEvent.active })
+    await insertLinksCheckActivityLog({ assessment, countryIso, cycle, status: 'started', user }, client)
+
+    const logKey = _getLogKey(props)
+    await verifyAllLinks({ assessment, countryIso, cycle, logKey }, client)
+  } catch (error) {
+    await verifyLinksJob.setFailed(error)
+    emitLinksVerificationEvent({ assessment, countryIso, cycle, event: LinksVerificationEvent.failed })
+    await insertLinksCheckActivityLog({ assessment, countryIso, cycle, error, status: 'failed', user }, client)
+    throw error
+  }
+
+  await verifyLinksJob.setSuccess()
+  emitLinksVerificationEvent({ assessment, countryIso, cycle, event: LinksVerificationEvent.completed })
+  await insertLinksCheckActivityLog({ assessment, countryIso, cycle, status: 'completed', user }, client)
+}

--- a/src/server/worker/tasks/verifyLinks/verifyLinksJob.ts
+++ b/src/server/worker/tasks/verifyLinks/verifyLinksJob.ts
@@ -1,9 +1,11 @@
 import { CountryIso } from 'meta/area/countryIso'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
+import { Objects } from 'utils/objects'
 
 import { Job } from 'server/worker/job/job'
-import { JobStatus } from 'server/worker/job/jobStatus'
+import { JobStatus, JobStatusPayload } from 'server/worker/job/jobStatus'
+import { insertLinksCheckActivityLog } from 'server/worker/tasks/verifyLinks/utils/insertLinksCheckActivityLog'
 import { VerifyAllLinksJob } from 'server/worker/tasks/verifyLinks/visitCycleLinks/props'
 import workerProcessor from 'server/worker/tasks/verifyLinks/visitCycleLinks/worker'
 
@@ -25,7 +27,7 @@ export class VerifyLinksJob extends Job {
   public static getJobName(context: VerifyLinksJobContext): string {
     const { assessment, countryIso, cycle } = context
     const baseJobName = `${jobNamePrefix}/${assessment.props.name}/${cycle.name}`
-    return countryIso ? `${baseJobName}/${countryIso}` : baseJobName
+    return Objects.isEmpty(countryIso) ? baseJobName : `${baseJobName}/${countryIso}`
   }
 
   public async runFromQueue(job: VerifyAllLinksJob): Promise<void> {
@@ -33,8 +35,12 @@ export class VerifyLinksJob extends Job {
     this.#queueJob = job
 
     try {
+      const { assessment, countryIso, cycle, user } = job.data
+
       // Update redis to sync with BullMQ job status.
       await this.setRunning(jobId)
+      await insertLinksCheckActivityLog({ assessment, countryIso, cycle, status: 'started', user })
+
       await this.execute()
       await this.setSuccess(jobId)
     } catch (error) {
@@ -50,7 +56,11 @@ export class VerifyLinksJob extends Job {
   }
 
   public async setRunning(jobId?: string): Promise<void> {
-    await this.setStatus(JobStatus.running, { jobId, startedAt: new Date().toISOString() })
+    const startedAt = new Date().toISOString()
+    const details: Partial<JobStatusPayload> = Objects.isEmpty(jobId)
+      ? { jobId, queuedAt: undefined, startedAt }
+      : { jobId, startedAt }
+    await this.setStatus(JobStatus.running, details)
   }
 
   public async setSuccess(jobId?: string): Promise<void> {

--- a/src/server/worker/tasks/verifyLinks/visitCycleLinks/verifyAllLinks.ts
+++ b/src/server/worker/tasks/verifyLinks/visitCycleLinks/verifyAllLinks.ts
@@ -3,17 +3,15 @@ import { Assessment, AssessmentNames } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import { OriginalDataPoint } from 'meta/assessment/originalDataPoint'
 import { LinkToVisit } from 'meta/cycleData/links/link'
-import { User } from 'meta/user/user'
 import { Objects } from 'utils/objects'
 
 import { AreaRedisRepository } from 'server/cache/repository/area'
 import { SectionRedisRepository } from 'server/cache/repository/section'
-import { DB } from 'server/db/db'
+import { BaseProtocol, DB } from 'server/db/db'
 import { DescriptionRepository } from 'server/db/repository/assessmentCycle/descriptions'
 import { LinkRepository } from 'server/db/repository/assessmentCycle/links'
 import { OriginalDataPointRepository } from 'server/db/repository/assessmentCycle/originalDataPoint'
 import { Logger } from 'server/utils/logger'
-import { insertLinksCheckActivityLog } from 'server/worker/tasks/verifyLinks/utils/insertLinksCheckActivityLog'
 import { refreshDescriptionValidations } from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/refreshDescriptionValidations'
 import { refreshNationalDataPointValidations } from 'server/worker/tasks/verifyLinks/visitNationalDataPointLinks/utils/refreshNationalDataPointValidations'
 
@@ -27,27 +25,27 @@ type Props = {
   countryIso?: CountryIso
   cycle: Cycle
   logKey: string
-  user: User
 }
 
-const _getCycleNationalDataPoints = (props: {
-  assessment: Assessment
-  countryISOs: Array<CountryIso>
-  cycle: Cycle
-}): Promise<Array<OriginalDataPoint>> => {
+const _getCycleNationalDataPoints = (
+  props: {
+    assessment: Assessment
+    countryISOs: Array<CountryIso>
+    cycle: Cycle
+  },
+  client: BaseProtocol
+): Promise<Array<OriginalDataPoint>> => {
   const { assessment, countryISOs, cycle } = props
   // panEuropean doesn't have NDPs
   if (assessment.props.name === AssessmentNames.panEuropean) return Promise.resolve([])
-  return OriginalDataPointRepository.getMany({ assessment, countryISOs, cycle })
+  return OriginalDataPointRepository.getMany({ assessment, countryISOs, cycle }, client)
 }
 
 // Verifies all links (descriptions + national data points) of an assessment/cycle,
 // or of a single country when countryIso is set.
-export const verifyAllLinks = async (props: Props): Promise<void> => {
-  const { assessment, countryIso, cycle, logKey, user } = props
+export const verifyAllLinks = async (props: Props, client: BaseProtocol = DB): Promise<void> => {
+  const { assessment, countryIso, cycle, logKey } = props
   try {
-    await insertLinksCheckActivityLog({ assessment, countryIso, cycle, status: 'started', user })
-
     const time = new Date().getTime()
     Logger.info(`${logKey} started.`)
 
@@ -56,7 +54,7 @@ export const verifyAllLinks = async (props: Props): Promise<void> => {
     // 1. Get all the countryIsos if we are running the full cycle job
     let countryISOs: Array<CountryIso>
     if (isFullCycleJob) {
-      const countries = await AreaRedisRepository.getManyCountries({ assessment, cycle })
+      const countries = await AreaRedisRepository.getManyCountries({ assessment, cycle }, client)
       countryISOs = countries.map(({ countryIso }) => countryIso)
     } else {
       countryISOs = [countryIso]
@@ -69,10 +67,10 @@ export const verifyAllLinks = async (props: Props): Promise<void> => {
 
     // 2. Get the countries' descriptions, NDPs, approved links, and cycle sections
     const [descriptionValues, cycleNationalDataPoints, approvedLinks, sections] = await Promise.all([
-      DescriptionRepository.getValues({ assessment, countryISOs, cycle }),
-      _getCycleNationalDataPoints({ assessment, countryISOs, cycle }),
-      LinkRepository.getMany({ assessment, cycle, filters: approvedLinkFilters }),
-      SectionRedisRepository.getMany({ assessment, cycle }),
+      DescriptionRepository.getValues({ assessment, countryISOs, cycle }, client),
+      _getCycleNationalDataPoints({ assessment, countryISOs, cycle }, client),
+      LinkRepository.getMany({ assessment, cycle, filters: approvedLinkFilters }, client),
+      SectionRedisRepository.getMany({ assessment, cycle }, client),
     ])
 
     const nationalDataPoints: Partial<Record<CountryIso, Array<OriginalDataPoint>>> = {}
@@ -101,8 +99,8 @@ export const verifyAllLinks = async (props: Props): Promise<void> => {
     const linkVisits = await visitLinks(filterLinks({ approvedLinks, linksToVisit: mergedLinks }))
 
     // 4. Refresh link table locations
-    await DB.tx(async (client) => {
-      await LinkRepository.clearLocations({ assessment, countryIso, cycle }, client)
+    await client.tx(async (tx) => {
+      await LinkRepository.clearLocations({ assessment, countryIso, cycle }, tx)
       await LinkRepository.markDeletedMany(
         {
           assessment,
@@ -113,9 +111,9 @@ export const verifyAllLinks = async (props: Props): Promise<void> => {
             link: link.link,
           })),
         },
-        client
+        tx
       )
-      await LinkRepository.upsertLinks({ assessment, cycle, linkVisits, linksToVisit: mergedLinks }, client)
+      await LinkRepository.upsertLinks({ assessment, cycle, linkVisits, linksToVisit: mergedLinks }, tx)
     })
 
     const sectionNames = sections.flatMap(({ subSections }) => subSections?.map(({ props }) => props.name) ?? [])

--- a/src/server/worker/tasks/verifyLinks/visitCycleLinks/worker.ts
+++ b/src/server/worker/tasks/verifyLinks/visitCycleLinks/worker.ts
@@ -15,8 +15,8 @@ const _getLogKey = (job: VerifyAllLinksJob): string => {
 }
 
 export default async (job: VerifyAllLinksJob): Promise<void> => {
-  const { assessment, countryIso, cycle, user } = job.data
+  const { assessment, countryIso, cycle } = job.data
   const logKey = _getLogKey(job)
 
-  return verifyAllLinks({ assessment, countryIso, cycle, logKey, user })
+  return verifyAllLinks({ assessment, countryIso, cycle, logKey })
 }


### PR DESCRIPTION
Adding `LinksService.verifyLinks`. 
In this PR:
- Removed `insertLinksCheckActivityLog` from `verifyAllLinks` because any logging should be done from outside of it.
- Added arg `client: BaseProtocol = DB` to `verifyAllLinks` so we can pass a db client from outside.

Now in the tool for the next PR we can do:
```ts
  await Promises.each(assessments, async (assessment) => {
    await Promises.each(assessment.cycles, async (cycle) => {
      const assessmentName = assessment.props.name
      const { name: cycleName } = cycle
      try {
        await LinksService.verifyLinks({ assessment, cycle, user }, client) //    <----
      } catch (error) {
        Logger.error(`${toolName} failed for ${assessmentName}/${cycleName}`)
      }
    })
  })
```
