### PR TITLE
5758 - Navigation: Data errors - Visit links tool - Add tool body

### DIFF
--- a/src/server/controller/cycleData/validations/nationalDataPoint/validateNationalDataPoint.ts
+++ b/src/server/controller/cycleData/validations/nationalDataPoint/validateNationalDataPoint.ts
@@ -10,5 +10,5 @@ type Props = {
 export const validateNationalDataPoint = (props: Props): NDPValidation => {
   const { nationalDataPoint, validation } = props
   return NationalDataPointValidator.validate({ nationalDataPoint, validation })
-  // TODO: Validate national data point data sources
+  // NDP data source references are validated by the links flow.
 }

--- a/src/tools/validations/failures.ts
+++ b/src/tools/validations/failures.ts
@@ -8,12 +8,16 @@ const throwIfFailed = (toolName: string, failures: Array<Failure>): void => {
   if (Objects.isEmpty(failures)) return
 
   const summary = failures
-    .map(({ assessmentName, countryIso, cycleName, error }) => {
-      return `- ${assessmentName}/${cycleName}/${countryIso}: ${_getErrorMessage(error)}`
+    .map<string>(({ assessmentName, countryIso, cycleName, error }) => {
+      const scope = Objects.isEmpty(countryIso)
+        ? `${assessmentName}/${cycleName}`
+        : `${assessmentName}/${cycleName}/${countryIso}`
+
+      return `- ${scope}: ${_getErrorMessage(error)}`
     })
     .join('\n')
 
-  throw new Error(`${toolName} failed for ${failures.length} countries:\n${summary}`)
+  throw new Error(`${toolName} failed with ${failures.length} failures:\n${summary}`)
 }
 
 export const Failures = {

--- a/src/tools/validations/types.ts
+++ b/src/tools/validations/types.ts
@@ -4,7 +4,7 @@ import { CycleName } from 'meta/assessment/cycle'
 
 export type Failure = {
   assessmentName: AssessmentName
-  countryIso: CountryIso
+  countryIso?: CountryIso
   cycleName: CycleName
   error: unknown
 }

--- a/src/tools/validations/validateLinks.ts
+++ b/src/tools/validations/validateLinks.ts
@@ -1,8 +1,15 @@
 import '../scriptInit'
 
+import http from 'http'
+
+import { Promises } from 'utils/promises'
 import { ToolsUtils } from 'tools/utils/toolsUtils'
 
+import { AssessmentController } from 'server/controller/assessment'
+import { UserController } from 'server/controller/user'
 import { BaseProtocol, DB } from 'server/db/db'
+import { LinksService } from 'server/service/links'
+import { SocketServer } from 'server/service/socket'
 import { Logger } from 'server/utils/logger'
 
 import { Failures } from './failures'
@@ -10,10 +17,31 @@ import { Failure } from './types'
 
 const toolName = 'validateLinks'
 
-// Placeholder: links validation will be implemented separately.
-export const validateLinks = async (_client: BaseProtocol = DB): Promise<Array<Failure>> => {
-  Logger.info(`${toolName} is not implemented yet`)
-  return []
+// Run this only when no link verification is queued or running: it verifies directly, without the queue dedup or lock,
+// so two runs would have conflicting status and activity logs, and race to rebuild the links validation cache.
+export const validateLinks = async (client: BaseProtocol = DB): Promise<Array<Failure>> => {
+  await SocketServer.init(http.createServer())
+
+  const user = await UserController.getUserRobot(client)
+  const assessments = await AssessmentController.getAll({ metaCache: true }, client)
+  const failures: Array<Failure> = []
+
+  await Promises.each(assessments, async (assessment) => {
+    await Promises.each(assessment.cycles, async (cycle) => {
+      const assessmentName = assessment.props.name
+      const { name: cycleName } = cycle
+      Logger.info(`${toolName}: ${assessmentName}/${cycleName}`)
+
+      try {
+        await LinksService.verifyLinks({ assessment, cycle, user }, client)
+      } catch (error) {
+        Logger.error(`${toolName} failed for ${assessmentName}/${cycleName}`)
+        failures.push({ assessmentName, cycleName, error })
+      }
+    })
+  })
+
+  return failures
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Adding the last part for the tool. Now we can run the links verification in-process. Takes around 10 minutes locally for all assessment/cycles. 

<img width="959" height="532" alt="image" src="https://github.com/user-attachments/assets/82c1a134-242d-48b8-bb56-ddb89ee4329c" />

Note: The rest of the validations (tables, descriptions, ndps) take only around 30s. 