### PR TITLE
6158 - Fix EditorWYSIWYGLinks text alignment

### DIFF
--- a/src/client/components/EditorWYSIWYG/EditorWYSIWYGLinks/EditorWYSIWYGLinks.scss
+++ b/src/client/components/EditorWYSIWYG/EditorWYSIWYGLinks/EditorWYSIWYGLinks.scss
@@ -1,6 +1,5 @@
 // Editor with links: Display toolbar to the right when displaying inline editor
 .editor-wysiwyg-links .jodit-container.jodit {
-  align-items: center;
   display: grid !important;
   grid-template-columns: 1fr auto !important;
   justify-content: center;


### PR DESCRIPTION
As seen around the platform:

<img width="1102" height="124" alt="image" src="https://github.com/user-attachments/assets/56a3349b-069b-41ed-a588-aaa6bf0a9e32" />

<img width="2141" height="118" alt="image" src="https://github.com/user-attachments/assets/4a1fd897-e93f-460e-a369-983454478c5e" />

<img width="765" height="718" alt="image" src="https://github.com/user-attachments/assets/429e413a-f634-4b11-b4c5-eb2290b4a1c2" />

<img width="915" height="707" alt="image" src="https://github.com/user-attachments/assets/186c1548-75e6-47c5-bf2b-dd106026511b" />

<img width="1661" height="273" alt="image" src="https://github.com/user-attachments/assets/01df98b6-2cb7-4516-aab4-88f36acd576e" />
