### PR TITLE
5758 - Navigation: Data errors - Rename DescriptionIdentifier to CommentableDescriptionKey

### DIFF
--- a/src/meta/assessment/descriptionValue/index.ts
+++ b/src/meta/assessment/descriptionValue/index.ts
@@ -21,16 +21,13 @@ export interface CommentableDescriptionValue {
 export interface CommentableDescription {
   id: number
   countryIso: CountryIso
-  sectionName: string
+  sectionName: SectionName
   sectionUuid?: UUID
   name: CommentableDescriptionName
   value: CommentableDescriptionValue
 }
 
-export type DescriptionIdentifier = {
-  name: CommentableDescriptionName
-  sectionName: SectionName
-}
+export type CommentableDescriptionKey = Pick<CommentableDescription, 'name' | 'sectionName'>
 
 export type DescriptionValues = Record<CommentableDescriptionName, CommentableDescriptionValue>
 export type DescriptionSectionValues = Record<SectionName, DescriptionValues>

--- a/src/meta/cycleData/links/descriptionLink.ts
+++ b/src/meta/cycleData/links/descriptionLink.ts
@@ -1,4 +1,5 @@
 import { CommentableDescriptionName } from 'meta/assessment/descriptionValue'
+import { SectionName } from 'meta/assessment/section'
 import { LinkLocationBase } from 'meta/cycleData/links/linkLocationBase'
 
 export const DescriptionLinkLocationPath = {
@@ -10,7 +11,7 @@ export type DescriptionLinkLocation = LinkLocationBase & {
   colName: string
   descriptionName: CommentableDescriptionName
   path: Array<string>
-  sectionName: string
+  sectionName: SectionName
   uuid?: string
 }
 

--- a/src/server/controller/cycleData/links/update.ts
+++ b/src/server/controller/cycleData/links/update.ts
@@ -2,7 +2,7 @@ import { CountryIso } from 'meta/area/countryIso'
 import { ActivityLogMessage } from 'meta/assessment/activityLog'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
-import { DescriptionIdentifier } from 'meta/assessment/descriptionValue'
+import { CommentableDescriptionKey } from 'meta/assessment/descriptionValue'
 import { Link } from 'meta/cycleData/links/link'
 import { Links } from 'meta/cycleData/links/links'
 import { NDPLinkTarget } from 'meta/cycleData/links/nationalDataPointLink'
@@ -44,13 +44,11 @@ export const update = async (props: Props): Promise<Link> => {
   const descriptionLocations = updatedLink.locations.filter(Links.isDescriptionLocation)
   if (!Objects.isEmpty(descriptionLocations)) {
     const { countryIso } = updatedLink
-    const descriptionIdentifiers = descriptionLocations.map<DescriptionIdentifier>(
-      ({ descriptionName, sectionName }) => ({
-        name: descriptionName,
-        sectionName,
-      })
-    )
-    await LinksService.enqueueDescriptionLinksValidation({ assessment, countryIso, cycle, descriptionIdentifiers })
+    const descriptionKeys = descriptionLocations.map<CommentableDescriptionKey>(({ descriptionName, sectionName }) => ({
+      name: descriptionName,
+      sectionName,
+    }))
+    await LinksService.enqueueDescriptionLinksValidation({ assessment, countryIso, cycle, descriptionKeys })
   }
 
   // If the link has national data point locations, we trigger the flow that updates the ndp validation cache.

--- a/src/server/service/dataValidation/validateDescriptions.ts
+++ b/src/server/service/dataValidation/validateDescriptions.ts
@@ -1,7 +1,7 @@
 import { Country } from 'meta/area/country'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
-import { CommentableDescription, DescriptionIdentifier } from 'meta/assessment/descriptionValue'
+import { CommentableDescription, CommentableDescriptionKey } from 'meta/assessment/descriptionValue'
 
 import { LinksService } from 'server/service/links'
 
@@ -22,7 +22,7 @@ export const validateDescriptions = async (props: Props): Promise<void> => {
   // Validate data source fields first (not in parallel) to avoid cache race conditions.
   await validateDataSources({ assessment, country, cycle, descriptions, notifyClients })
 
-  const descriptionIdentifiers = descriptions.map<DescriptionIdentifier>(({ name, sectionName }) => ({
+  const descriptionKeys = descriptions.map<CommentableDescriptionKey>(({ name, sectionName }) => ({
     name,
     sectionName,
   }))
@@ -31,7 +31,7 @@ export const validateDescriptions = async (props: Props): Promise<void> => {
     assessment,
     countryIso,
     cycle,
-    descriptionIdentifiers,
+    descriptionKeys,
     notifyClients,
   })
 }

--- a/src/server/service/links/enqueueDescriptionLinksValidation.ts
+++ b/src/server/service/links/enqueueDescriptionLinksValidation.ts
@@ -5,9 +5,9 @@ import { enqueueVerifyLinksJob } from 'server/worker/tasks/verifyLinks/utils/enq
 import { VerifyDescriptionLinksJobProps } from 'server/worker/tasks/verifyLinks/visitDescriptionLinks/props'
 
 export const enqueueDescriptionLinksValidation = async (props: VerifyDescriptionLinksJobProps): Promise<void> => {
-  const { descriptionIdentifiers } = props
+  const { descriptionKeys } = props
 
-  if (Objects.isEmpty(descriptionIdentifiers)) return
+  if (Objects.isEmpty(descriptionKeys)) return
 
   await enqueueVerifyLinksJob(VerifyLinksJobName.verifyDescriptionLinks, props)
 }

--- a/src/server/worker/tasks/verifyLinks/visitCycleLinks/utils/buildCountryLinks.ts
+++ b/src/server/worker/tasks/verifyLinks/visitCycleLinks/utils/buildCountryLinks.ts
@@ -3,9 +3,9 @@ import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import {
   CommentableDescription,
+  CommentableDescriptionKey,
   CommentableDescriptionName,
   DescriptionCountryValues,
-  DescriptionIdentifier,
 } from 'meta/assessment/descriptionValue'
 import { OriginalDataPoint } from 'meta/assessment/originalDataPoint'
 import { SectionNames } from 'meta/assessment/section'
@@ -31,19 +31,19 @@ export type CountryLinks = {
   nationalDataPointTargets: Array<NDPLinkTarget>
 }
 
-type GetDescriptionIdentifiersProps = {
+type GetDescriptionKeysProps = {
   countryIso: CountryIso
   descriptionValues: DescriptionCountryValues
 }
 
-const _getDescriptionIdentifiers = (props: GetDescriptionIdentifiersProps): Array<DescriptionIdentifier> => {
+const _getDescriptionKeys = (props: GetDescriptionKeysProps): Array<CommentableDescriptionKey> => {
   const { countryIso, descriptionValues } = props
 
-  return Object.entries(descriptionValues[countryIso] ?? {}).flatMap<DescriptionIdentifier>(
+  return Object.entries(descriptionValues[countryIso] ?? {}).flatMap<CommentableDescriptionKey>(
     ([sectionName, sectionValues]) => {
       // NDP data sources are stored as descriptions, but their links belong to the NDP flow.
       if (sectionName === SectionNames.nationalDataPoint) return []
-      return Object.keys(sectionValues).map<DescriptionIdentifier>((name) => ({
+      return Object.keys(sectionValues).map<CommentableDescriptionKey>((name) => ({
         name: name as CommentableDescriptionName,
         sectionName,
       }))
@@ -54,12 +54,12 @@ const _getDescriptionIdentifiers = (props: GetDescriptionIdentifiersProps): Arra
 export const buildCountryLinks = (props: Props): CountryLinks => {
   const { assessment, countryIso, cycle, descriptionValues, nationalDataPoints } = props
 
-  const descriptionIdentifiers = _getDescriptionIdentifiers({ countryIso, descriptionValues })
+  const descriptionKeys = _getDescriptionKeys({ countryIso, descriptionValues })
   const { descriptions, linksToVisit: descriptionLinksToVisit } = buildDescriptionLinks({
     assessment,
     countryIso,
     cycle,
-    descriptionIdentifiers,
+    descriptionKeys,
     descriptionValues,
   })
 

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/props.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/props.ts
@@ -3,7 +3,7 @@ import { Job } from 'bullmq'
 import { CountryIso } from 'meta/area/countryIso'
 import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
-import { DescriptionIdentifier } from 'meta/assessment/descriptionValue'
+import { CommentableDescriptionKey } from 'meta/assessment/descriptionValue'
 
 import { VerifyLinksJobName } from 'server/worker/tasks/verifyLinks/jobNames'
 
@@ -11,7 +11,7 @@ export type VerifyDescriptionLinksJobProps = {
   assessment: Assessment
   countryIso: CountryIso
   cycle: Cycle
-  descriptionIdentifiers: Array<DescriptionIdentifier>
+  descriptionKeys: Array<CommentableDescriptionKey>
   notifyClients?: boolean
 }
 

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/buildDescriptionLinks.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/utils/buildDescriptionLinks.ts
@@ -3,8 +3,8 @@ import { Assessment } from 'meta/assessment/assessment'
 import { Cycle } from 'meta/assessment/cycle'
 import {
   CommentableDescription,
+  CommentableDescriptionKey,
   DescriptionCountryValues,
-  DescriptionIdentifier,
 } from 'meta/assessment/descriptionValue'
 import { DescriptionLinkLocationPath } from 'meta/cycleData/links/descriptionLink'
 import { LinkToVisit } from 'meta/cycleData/links/link'
@@ -16,7 +16,7 @@ type Props = {
   assessment: Assessment
   countryIso: CountryIso
   cycle: Cycle
-  descriptionIdentifiers: Array<DescriptionIdentifier>
+  descriptionKeys: Array<CommentableDescriptionKey>
   descriptionValues: DescriptionCountryValues
 }
 
@@ -26,18 +26,15 @@ type Returned = {
 }
 
 export const buildDescriptionLinks = (props: Props): Returned => {
-  const { assessment, countryIso, cycle, descriptionIdentifiers, descriptionValues } = props
+  const { assessment, countryIso, cycle, descriptionKeys, descriptionValues } = props
 
-  const descriptions = descriptionIdentifiers.reduce<Array<Omit<CommentableDescription, 'id'>>>(
-    (acc, descriptionIdentifier) => {
-      const { name, sectionName } = descriptionIdentifier
-      const value = descriptionValues[countryIso]?.[sectionName]?.[name]
-      if (Objects.isEmpty(value)) return acc
-      acc.push({ countryIso, name, sectionName, value })
-      return acc
-    },
-    []
-  )
+  const descriptions = descriptionKeys.reduce<Array<Omit<CommentableDescription, 'id'>>>((acc, descriptionKey) => {
+    const { name, sectionName } = descriptionKey
+    const value = descriptionValues[countryIso]?.[sectionName]?.[name]
+    if (Objects.isEmpty(value)) return acc
+    acc.push({ countryIso, name, sectionName, value })
+    return acc
+  }, [])
 
   const linksToVisit = descriptions.flatMap<LinkToVisit>((description) => {
     const { name: descriptionName, sectionName, value } = description

--- a/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/worker.ts
+++ b/src/server/worker/tasks/verifyLinks/visitDescriptionLinks/worker.ts
@@ -20,25 +20,25 @@ export default async (job: VerifyDescriptionLinksJob): Promise<void> => {
   const logKey = _getLogKey(job)
 
   try {
-    const { assessment, countryIso, cycle, descriptionIdentifiers, notifyClients = true } = job.data
+    const { assessment, countryIso, cycle, descriptionKeys, notifyClients = true } = job.data
     const commonProps = { assessment, countryIso, cycle }
     const time = new Date().getTime()
 
     Logger.info(`${logKey} started.`)
 
-    const sectionNames = Array.from(new Set(descriptionIdentifiers.map<SectionName>(({ sectionName }) => sectionName)))
+    const sectionNames = Array.from(new Set(descriptionKeys.map<SectionName>(({ sectionName }) => sectionName)))
 
     const descriptionValues = await DescriptionRepository.getValues({
       assessment,
       countryISOs: [countryIso],
       cycle,
-      names: descriptionIdentifiers.map<CommentableDescriptionName>(({ name }) => name),
+      names: descriptionKeys.map<CommentableDescriptionName>(({ name }) => name),
       sectionNames,
     })
 
     const { descriptions, linksToVisit } = buildDescriptionLinks({
       ...commonProps,
-      descriptionIdentifiers,
+      descriptionKeys,
       descriptionValues,
     })
 


### PR DESCRIPTION
Addressing from the main PR TODO:
"
 - [x] Revisit DescriptionIdentifier type — maybe use Pick and revisit name.
 
 "
 
 Proposal: 
 ```ts
 export type CommentableDescriptionKey = Pick<CommentableDescription, 'name' | 'sectionName'>
 ```