### PR TITLE
5758 - Navigation: Data errors - Add LinksService.enqueueAllLinksValidation

### DIFF
--- a/src/server/api/cycleData/links/verifyLinks.ts
+++ b/src/server/api/cycleData/links/verifyLinks.ts
@@ -3,9 +3,8 @@ import { Response } from 'express'
 import { CycleRequest } from 'meta/api/request/cycle'
 import { AreaCode } from 'meta/area/areaCode'
 
-import { LinksController } from 'server/controller/cycleData/links'
+import { LinksService } from 'server/service/links'
 import Requests from 'server/utils/requests'
-import { triggerVerifyLinksWorker } from 'server/worker/tasks/verifyLinks/triggerVerifyLinksWorker'
 
 type Request = CycleRequest<{ countryIso?: AreaCode }>
 
@@ -16,10 +15,7 @@ export const verifyLinks = async (req: Request, res: Response): Promise<void> =>
 
     const user = Requests.getUser(req)
 
-    // Enqueue the verify-links job.
-    await LinksController.verify({ assessment, countryIso, cycle, user })
-    // Ensure the worker dyno (or local worker) is running to consume the queue.
-    await triggerVerifyLinksWorker()
+    await LinksService.enqueueAllLinksValidation({ assessment, countryIso, cycle, user })
 
     Requests.send(res)
   } catch (e) {

--- a/src/server/controller/cycleData/links/linksController.ts
+++ b/src/server/controller/cycleData/links/linksController.ts
@@ -1,5 +1,4 @@
 import { LinkRepository } from 'server/db/repository/assessmentCycle/links'
-import { scheduleVerifyAllLinks } from 'server/worker/tasks/verifyLinks/visitCycleLinks/scheduleVerifyAllLinks'
 
 import { getActiveVerifyJob } from './getActiveVerifyJob'
 import { getManyExport } from './getManyExport'
@@ -13,5 +12,4 @@ export const LinksController = {
   getManyExport,
   getVerificationSummary,
   update,
-  verify: scheduleVerifyAllLinks,
 }

--- a/src/server/service/links/index.ts
+++ b/src/server/service/links/index.ts
@@ -1,8 +1,10 @@
 import { enqueueDescriptionLinksValidation } from 'server/service/links/enqueueDescriptionLinksValidation'
 import { enqueueNationalDataPointLinksValidation } from 'server/service/links/enqueueNationalDataPointLinksValidation'
 import { verifyLinks } from 'server/service/links/verifyLinks'
+import { scheduleVerifyAllLinks } from 'server/worker/tasks/verifyLinks/visitCycleLinks/scheduleVerifyAllLinks'
 
 export const LinksService = {
+  enqueueAllLinksValidation: scheduleVerifyAllLinks,
   enqueueDescriptionLinksValidation,
   enqueueNationalDataPointLinksValidation,
   verifyLinks,

--- a/src/server/service/links/index.ts
+++ b/src/server/service/links/index.ts
@@ -1,10 +1,10 @@
 import { enqueueDescriptionLinksValidation } from 'server/service/links/enqueueDescriptionLinksValidation'
 import { enqueueNationalDataPointLinksValidation } from 'server/service/links/enqueueNationalDataPointLinksValidation'
 import { verifyLinks } from 'server/service/links/verifyLinks'
-import { scheduleVerifyAllLinks } from 'server/worker/tasks/verifyLinks/visitCycleLinks/scheduleVerifyAllLinks'
+import { enqueueAllLinksValidation } from 'server/worker/tasks/verifyLinks/visitCycleLinks/enqueueAllLinksValidation'
 
 export const LinksService = {
-  enqueueAllLinksValidation: scheduleVerifyAllLinks,
+  enqueueAllLinksValidation,
   enqueueDescriptionLinksValidation,
   enqueueNationalDataPointLinksValidation,
   verifyLinks,

--- a/src/server/worker/cronJobs/notifyLinksInvalid.ts
+++ b/src/server/worker/cronJobs/notifyLinksInvalid.ts
@@ -4,12 +4,11 @@ import { AssessmentNames } from 'meta/assessment/assessment'
 import { CycleNames } from 'meta/assessment/cycle/names'
 
 import { AssessmentController } from 'server/controller/assessment'
-import { LinksController } from 'server/controller/cycleData/links'
 import { UserController } from 'server/controller/user'
 import { MailService } from 'server/service'
+import { LinksService } from 'server/service/links'
 import { ProcessEnv } from 'server/utils'
 import { Job } from 'server/worker/job/job'
-import { triggerVerifyLinksWorker } from 'server/worker/tasks/verifyLinks/triggerVerifyLinksWorker'
 import { VerifyLinksQueueFactory } from 'server/worker/tasks/verifyLinks/visitCycleLinks/queueFactory'
 
 const name = 'Scheduler-NotifyLinksInvalid'
@@ -29,10 +28,7 @@ export class NotifyLinksInvalid extends Job {
 
     const user = await UserController.getUserRobot()
 
-    // get existing job or create new job and process it
-    const existingJob = await VerifyLinksQueueFactory.getQueuedOrActiveVerifyAllLinksJob({ assessment, cycle })
-    const job = existingJob ?? (await LinksController.verify({ assessment, cycle, user }))
-    await triggerVerifyLinksWorker()
+    const job = await LinksService.enqueueAllLinksValidation({ assessment, cycle, user })
 
     const connection = { url: ProcessEnv.redisQueueUrl }
     const queueEvents = new QueueEvents(VerifyLinksQueueFactory.queueName, { connection })

--- a/src/server/worker/tasks/verifyLinks/visitCycleLinks/enqueueAllLinksValidation.ts
+++ b/src/server/worker/tasks/verifyLinks/visitCycleLinks/enqueueAllLinksValidation.ts
@@ -18,7 +18,7 @@ const jobOptions: JobsOptions = {
 }
 
 // Returns the job performing the verification, either already queued/running or newly scheduled.
-export const scheduleVerifyAllLinks = async (props: VerifyAllLinksJobProps): Promise<Job> => {
+export const enqueueAllLinksValidation = async (props: VerifyAllLinksJobProps): Promise<Job> => {
   const { assessment, countryIso, cycle } = props
   const scope = countryIso
     ? `${assessment.props.name} / ${cycle.name} / ${countryIso}`

--- a/src/server/worker/tasks/verifyLinks/visitCycleLinks/scheduleVerifyAllLinks.ts
+++ b/src/server/worker/tasks/verifyLinks/visitCycleLinks/scheduleVerifyAllLinks.ts
@@ -4,6 +4,7 @@ import { LinksVerificationEvent } from 'meta/socket/event/links'
 
 import { Logger } from 'server/utils/logger'
 import { VerifyLinksJobName } from 'server/worker/tasks/verifyLinks/jobNames'
+import { triggerVerifyLinksWorker } from 'server/worker/tasks/verifyLinks/triggerVerifyLinksWorker'
 import { emitLinksVerificationEvent } from 'server/worker/tasks/verifyLinks/utils/emitLinksVerificationEvent'
 import { VerifyLinksJob } from 'server/worker/tasks/verifyLinks/verifyLinksJob'
 
@@ -16,7 +17,8 @@ const jobOptions: JobsOptions = {
   removeOnFail: true,
 }
 
-export const scheduleVerifyAllLinks = async (props: VerifyAllLinksJobProps): Promise<Job | undefined> => {
+// Returns the job performing the verification, either already queued/running or newly scheduled.
+export const scheduleVerifyAllLinks = async (props: VerifyAllLinksJobProps): Promise<Job> => {
   const { assessment, countryIso, cycle } = props
   const scope = countryIso
     ? `${assessment.props.name} / ${cycle.name} / ${countryIso}`
@@ -24,11 +26,12 @@ export const scheduleVerifyAllLinks = async (props: VerifyAllLinksJobProps): Pro
 
   // Skip if a verification job is already active.
   const activeJob = await VerifyLinksQueueFactory.getQueuedOrActiveVerifyAllLinksJob(props)
-  const isVerificationInProgress = Boolean(activeJob)
 
-  if (isVerificationInProgress) {
+  if (activeJob) {
     Logger.debug(`[visitCycleLinks] skipping enqueue: verification already queued or running for ${scope}`)
-    return undefined
+    // Ensure a worker is running, in case the worker was lost.
+    await triggerVerifyLinksWorker()
+    return activeJob
   }
 
   const queue = VerifyLinksQueueFactory.getInstance()
@@ -42,6 +45,8 @@ export const scheduleVerifyAllLinks = async (props: VerifyAllLinksJobProps): Pro
   Logger.debug(`[visitCycleLinks] added visit all links job for ${scope} to the queue`)
 
   emitLinksVerificationEvent({ assessment, countryIso, cycle, event: LinksVerificationEvent.queued })
+
+  await triggerVerifyLinksWorker()
 
   return job
 }


### PR DESCRIPTION
We have `LinksService`:
- `enqueueDescriptionLinksValidation`
- `enqueueNationalDataPointLinksValidation`

Those enqueue jobs and make sure there is a worker to process it.

So, for consistency, I am adding `enqueueAllLinksValidation` which does the same.
