### PR TITLE
5623 - GEO - Fix Sentinel mosaic builder timing out - Small layer request improvements

### DIFF
--- a/src/client/components/Navigation/NavGeo/SatelliteMosaic/MosaicControl/MosaicControl.tsx
+++ b/src/client/components/Navigation/NavGeo/SatelliteMosaic/MosaicControl/MosaicControl.tsx
@@ -37,7 +37,7 @@ const MosaicControl: React.FC = () => {
               checked={checked}
               label={label}
               onClick={() =>
-                dispatch(MosaicActions.setOption({ key: 'sources', value: { ...uiSources, [key]: !checked } }))
+                dispatch(MosaicActions.setOption({ key: 'sources', value: checked ? {} : { [key]: true } }))
               }
             />
           )

--- a/src/client/store/geo/mosaic/actions/_getUrlTemplateReqBody.ts
+++ b/src/client/store/geo/mosaic/actions/_getUrlTemplateReqBody.ts
@@ -3,6 +3,14 @@ import { MosaicOptions } from 'meta/geo/mosaic/options'
 
 export const _getUrlTemplateReqBody = (mosaicOptions: MosaicOptions, countryIso: CountryIso): any => {
   const { maxCloudCoverage, snowMasking, sources, year } = mosaicOptions
+  let dataSets = {}
+
+  if (sources.sentinel) {
+    dataSets = { SENTINEL: ['SENTINEL_2'] }
+  } else if (sources.landsat) {
+    dataSets = { LANDSAT: ['LANDSAT_7', 'LANDSAT_8'] }
+  }
+
   const body = {
     recipe: {
       id: '390c7c3f-1540-0e1f-52a0-5609b46122a8',
@@ -17,10 +25,7 @@ export const _getUrlTemplateReqBody = (mosaicOptions: MosaicOptions, countryIso:
           yearsAfter: 0,
         },
         sources: {
-          dataSets: {
-            ...(sources.sentinel ? { SENTINEL: ['SENTINEL_2'] } : {}),
-            ...(sources.landsat ? { LANDSAT: ['LANDSAT_7', 'LANDSAT_8'] } : {}),
-          },
+          dataSets,
           cloudPercentageThreshold: maxCloudCoverage,
         },
         sceneSelectionOptions: { type: 'ALL', targetDateWeight: 0 },
@@ -28,7 +33,7 @@ export const _getUrlTemplateReqBody = (mosaicOptions: MosaicOptions, countryIso:
           corrections: ['SR'],
           // @ts-ignore
           filters: [],
-          cloudDetection: ['QA', 'CLOUD_SCORE'],
+          cloudDetection: ['QA'],
           cloudMasking: 'MODERATE',
           cloudBuffering: 0,
           snowMasking: snowMasking ? 'ON' : 'OFF',

--- a/src/client/store/geo/mosaic/slice/extraReducers/setOptionReducer.ts
+++ b/src/client/store/geo/mosaic/slice/extraReducers/setOptionReducer.ts
@@ -1,4 +1,5 @@
 import { ActionReducerMapBuilder } from '@reduxjs/toolkit'
+
 import { Objects } from 'utils/objects'
 
 import { setOption } from 'client/store/geo/mosaic/actions/setOption'
@@ -7,6 +8,11 @@ import { GeoMosaicState } from 'client/store/geo/mosaic/state'
 export const setOptionReducer = (builder: ActionReducerMapBuilder<GeoMosaicState>): void => {
   builder.addCase(setOption, (state, action) => {
     const { key, value } = action.payload
+
+    if (key === 'sources') {
+      state.options.sources = value
+      return
+    }
 
     Objects.setInPath({ obj: state, path: ['options', key], value })
   })


### PR DESCRIPTION
Adding two small improvements suggested by the colleagues: using only QA for cloudDetection and using sentinel or landsat, not both at the same time.


Before/after

<img width="300" height="168" alt="image" src="https://github.com/user-attachments/assets/deaccea3-cda4-480c-a356-729337dca6fc" />

https://github.com/user-attachments/assets/c5bd0725-a653-442a-93ad-3708c2806f88


Closes #5623


Note: as discussed, we will still get this error for Canada:
<img width="553" height="200" alt="image" src="https://github.com/user-attachments/assets/da6bd8b9-9608-4e75-92a5-cdc9d9480636" />
