### PR TITLE
5758 - Navigation: Data errors - Performance - validateTableData tool

### DIFF
--- a/src/server/controller/cycleData/tableData/updateDependencies/context/contextFactory.ts
+++ b/src/server/controller/cycleData/tableData/updateDependencies/context/contextFactory.ts
@@ -15,6 +15,7 @@ import { DataContextBuilder } from 'server/controller/cycleData/tableData/update
 
 export class ContextFactory extends BaseContextBuilder {
   readonly #queue: Array<VariableCache>
+  readonly #queueKeys: Set<string>
   readonly #rowKeys: Set<RowCacheKey>
   readonly #dataContextBuilder: DataContextBuilder
   readonly #visitedVariables: Array<VariableCache>
@@ -23,6 +24,7 @@ export class ContextFactory extends BaseContextBuilder {
   private constructor(props: ContextBuilderProps) {
     super(props)
     this.#queue = []
+    this.#queueKeys = new Set<string>()
     this.#rowKeys = new Set<RowCacheKey>()
     this.#dataContextBuilder = new DataContextBuilder(props)
     this.#visitedVariables = []
@@ -43,19 +45,18 @@ export class ContextFactory extends BaseContextBuilder {
     return true
   }
 
+  #getVariableKey(variable: VariableCache): string {
+    return [variable.tableName, variable.variableName, variable.colName].join(':')
+  }
+
   // check whether a variable has been added to the queue
   #isInQueue(variable: VariableCache): boolean {
-    const { colName, tableName, variableName } = variable
-    return Boolean(
-      this.#queue.find(
-        (processed) =>
-          processed.tableName === tableName && processed.variableName === variableName && processed.colName === colName
-      )
-    )
+    return this.#queueKeys.has(this.#getVariableKey(variable))
   }
 
   // add a variable to the queue
   async #addToQueue(variable: VariableCache): Promise<void> {
+    this.#queueKeys.add(this.#getVariableKey(variable))
     this.#queue.push(variable)
     await this.#dataContextBuilder.addVariable(variable)
     this.#rowKeys.add(RowCaches.getKey(variable)) // keep track of which rows must be fetched

--- a/src/server/service/dataValidation/tables/context/contextFactory.ts
+++ b/src/server/service/dataValidation/tables/context/contextFactory.ts
@@ -3,7 +3,6 @@ import { AssessmentMetaCaches } from 'meta/assessment/metaCaches'
 import { RowCacheKey } from 'meta/assessment/rowCache'
 import { RowCaches } from 'meta/assessment/rowCaches'
 import { TableName } from 'meta/assessment/table'
-import { Arrays } from 'utils/arrays'
 import { Promises } from 'utils/promises'
 
 import { RowRedisRepository } from 'server/cache/repository/row'
@@ -17,6 +16,7 @@ import { DataContextBuilder } from './dataContextBuilder'
 export class ContextFactory extends BaseContextBuilder {
   readonly #dataContextBuilder: DataContextBuilder
   readonly #queue: Array<VariableCache>
+  readonly #queueKeys: Set<string>
   readonly #rowKeys: Set<RowCacheKey>
   readonly #tableNames: Set<TableName>
 
@@ -25,6 +25,7 @@ export class ContextFactory extends BaseContextBuilder {
 
     this.#dataContextBuilder = new DataContextBuilder(this.props)
     this.#queue = []
+    this.#queueKeys = new Set<string>()
     this.#rowKeys = new Set<RowCacheKey>()
     this.#tableNames = new Set<TableName>()
   }
@@ -34,8 +35,7 @@ export class ContextFactory extends BaseContextBuilder {
   }
 
   #isInQueue(variable: VariableCache): boolean {
-    const variableKey = this.#getVariableKey(variable)
-    return this.#queue.some((queued) => this.#getVariableKey(queued) === variableKey)
+    return this.#queueKeys.has(this.#getVariableKey(variable))
   }
 
   #addToQueue(variable: VariableCache): void {
@@ -43,6 +43,7 @@ export class ContextFactory extends BaseContextBuilder {
       return
     }
 
+    this.#queueKeys.add(this.#getVariableKey(variable))
     this.#queue.push(variable)
   }
 
@@ -75,7 +76,7 @@ export class ContextFactory extends BaseContextBuilder {
       tableName: node.tableName,
       variableName: node.variableName,
     }))
-    this.#queue.push(...Arrays.uniqueBy(sourceVariables, (variable) => this.#getVariableKey(variable)))
+    sourceVariables.forEach((variable) => this.#addToQueue(variable))
 
     // Add the dependants of each queued variable. The queue grows while we iterate it,
     // so dependants of dependants are included as well.


### PR DESCRIPTION
Performance improvement (`validateTableData` only):

| Before | After | Improvement |
|---:|---:|---:|
| 71.6 s | 33.8 s | **2.1× faster** |

