### PR TITLE
5758 - E2E: ODP Full test: Refactor 1

### DIFF
--- a/src/test/e2e/api/ndp.ts
+++ b/src/test/e2e/api/ndp.ts
@@ -48,7 +48,7 @@ const _buildNationalDataPoint = (seed: NdpSeed): Partial<OriginalDataPoint> => {
   return ODPs.calculateValues(originalDataPoint as OriginalDataPoint)
 }
 
-// The error in case it is already deleted is ignored - used for cleanup/setup
+// Ignore error - we use this for teardown/recreating
 const removeIfExists = async (page: Page, seed: NdpSeed): Promise<void> => {
   const { countryIso, year } = seed
 

--- a/src/test/e2e/api/ndp.ts
+++ b/src/test/e2e/api/ndp.ts
@@ -1,0 +1,78 @@
+import { expect, type Page } from '@playwright/test'
+
+import { ApiEndPoint } from 'meta/api/endpoint'
+import { type CountryIso } from 'meta/area/countryIso'
+import { AssessmentNames } from 'meta/assessment/assessment'
+import { CycleNames } from 'meta/assessment/cycle/names'
+import { ODPs } from 'meta/assessment/odps'
+import { type ODPNationalClass, type OriginalDataPoint } from 'meta/assessment/originalDataPoint'
+import { type SectionName, SectionNames } from 'meta/assessment/section'
+import { TableNames } from 'meta/assessment/table'
+
+const assessmentName = AssessmentNames.fra
+const cycleName = CycleNames._2025
+
+export type NdpSeed = {
+  countryIso: CountryIso
+  nationalClasses: Array<ODPNationalClass>
+  year: number
+}
+
+type QueryProps = {
+  countryIso: CountryIso
+  sectionName?: SectionName
+  year?: number
+}
+
+const _getQueryParams = (props: QueryProps): string => {
+  const { countryIso, sectionName, year } = props
+
+  const params = new URLSearchParams({ assessmentName, countryIso, cycleName })
+  if (sectionName) params.set('sectionName', sectionName)
+  if (year) params.set('year', String(year))
+
+  return params.toString()
+}
+
+const _buildNationalDataPoint = (seed: NdpSeed): Partial<OriginalDataPoint> => {
+  const { countryIso, nationalClasses, year } = seed
+
+  const originalDataPoint: Partial<OriginalDataPoint> = {
+    comments: { [TableNames.extentOfForest]: '', [TableNames.forestCharacteristics]: '' },
+    countryIso,
+    nationalClasses,
+    values: {},
+    year,
+  }
+
+  return ODPs.calculateValues(originalDataPoint as OriginalDataPoint)
+}
+
+// The error in case it is already deleted is ignored - used for cleanup/setup
+const removeIfExists = async (page: Page, seed: NdpSeed): Promise<void> => {
+  const { countryIso, year } = seed
+
+  const query = _getQueryParams({ countryIso, year })
+  await page.request.delete(`${ApiEndPoint.CycleData.NationalDataPoint.one()}?${query}`)
+}
+
+const create = async (page: Page, seed: NdpSeed): Promise<OriginalDataPoint> => {
+  const { countryIso } = seed
+
+  await removeIfExists(page, seed)
+
+  const query = _getQueryParams({ countryIso, sectionName: SectionNames.extentOfForest })
+  const url = `${ApiEndPoint.CycleData.NationalDataPoint.one()}?${query}`
+  const response = await page.request.post(url, {
+    data: { originalDataPoint: _buildNationalDataPoint(seed) },
+  })
+
+  expect(response.ok(), `POST ${url} failed: ${response.status()} ${await response.text()}`).toBeTruthy()
+
+  return response.json()
+}
+
+export const NdpApiUtils = {
+  create,
+  removeIfExists,
+}

--- a/src/test/e2e/fixtures/ndp.ts
+++ b/src/test/e2e/fixtures/ndp.ts
@@ -1,0 +1,37 @@
+import { type OriginalDataPoint } from 'meta/assessment/originalDataPoint'
+import { Promises } from 'utils/promises'
+
+import { NdpApiUtils, type NdpSeed } from '../api/ndp'
+import { test as base } from './auth'
+
+type NdpOptions = {
+  ndpSeeds: Array<NdpSeed>
+}
+
+type NdpFixtures = {
+  ndp: OriginalDataPoint
+  ndps: Array<OriginalDataPoint>
+}
+
+export const test = base.extend<NdpOptions & NdpFixtures>({
+  ndpSeeds: [[], { option: true }],
+
+  ndps: async ({ authenticatedPage, ndpSeeds }, use) => {
+    // Create NDPs for test
+    const created: Array<OriginalDataPoint> = await Promises.each(ndpSeeds, (seed) =>
+      NdpApiUtils.create(authenticatedPage, seed)
+    )
+
+    // pass NDPs to test
+    await use(created)
+
+    // Remove NDPs after test
+    await Promises.each(ndpSeeds, (seed) => NdpApiUtils.removeIfExists(authenticatedPage, seed))
+  },
+
+  ndp: async ({ ndps }, use) => {
+    await use(ndps[0])
+  },
+})
+
+export { expect } from '@playwright/test'

--- a/src/test/e2e/fixtures/ndp.ts
+++ b/src/test/e2e/fixtures/ndp.ts
@@ -1,8 +1,8 @@
 import { type OriginalDataPoint } from 'meta/assessment/originalDataPoint'
 import { Promises } from 'utils/promises'
 
-import { NdpApiUtils, type NdpSeed } from '../api/ndp'
-import { test as base } from './auth'
+import { NdpApiUtils, type NdpSeed } from 'test/e2e/api/ndp'
+import { test as base } from 'test/e2e/fixtures/auth'
 
 type NdpOptions = {
   ndpSeeds: Array<NdpSeed>

--- a/src/test/e2e/playwright.config.ts
+++ b/src/test/e2e/playwright.config.ts
@@ -1,9 +1,12 @@
-import path from 'path'
 import type { PlaywrightTestConfig } from '@playwright/test'
 
 const config: PlaywrightTestConfig = {
-  testDir: path.join(__dirname, 'tests'),
-  testMatch: ['**/*.spec.ts'],
+  testDir: __dirname,
+  testMatch: [
+    'specs/**/*.spec.ts',
+    /** @deprecated */
+    'tests/**/*.spec.ts',
+  ],
   timeout: 10_0000,
   retries: 2,
   expect: {

--- a/src/test/e2e/specs/ndp/create.spec.ts
+++ b/src/test/e2e/specs/ndp/create.spec.ts
@@ -1,18 +1,15 @@
 import { SectionNames } from 'meta/assessment/section'
 
-import { NdpApiUtils, type NdpSeed } from '../../api/ndp'
-import { expect, test } from '../../fixtures/ndp'
-import { DOMUtils } from '../../utils/dom'
-import { NDPDomUtils } from '../../utils/ndpDom'
-import { SectionUtils } from '../../utils/section'
-import { TableDomUtils } from '../../utils/table'
+import { NdpApiUtils, type NdpSeed } from 'test/e2e/api/ndp'
+import { expect, test } from 'test/e2e/fixtures/ndp'
+import { DOMUtils } from 'test/e2e/utils/dom'
+import { NDPDomUtils } from 'test/e2e/utils/ndpDom'
+import { SectionUtils } from 'test/e2e/utils/section'
 
 const countryIso = 'X08'
 const extentOfForestPath = SectionUtils.path({ countryIso, sectionName: SectionNames.extentOfForest })
 
 const createdYear = 2015
-const seededYear = 2016
-const seededUrlRegex = new RegExp(`/originalDataPoints/${seededYear}/extentOfForest$`)
 
 test.describe('National data point: create', () => {
   const createdSeed: NdpSeed = { countryIso, nationalClasses: [], year: createdYear }
@@ -40,27 +37,6 @@ test.describe('National data point: create', () => {
     await expect(page).toHaveURL(/\/sections\/extentOfForest$/)
 
     await expect(page.locator('.table-grid__odp-link', { hasText: String(createdYear) })).toBeVisible({
-      timeout: 10000,
-    })
-  })
-})
-
-test.describe('National data point: delete', () => {
-  test.use({ ndpSeeds: [{ countryIso, nationalClasses: [], year: seededYear }] })
-
-  test('NC deletes the national data point', async ({ authenticatedPage, ndp }) => {
-    const page = authenticatedPage
-    expect(ndp.id).toBeTruthy()
-
-    await page.goto(extentOfForestPath)
-    await DOMUtils.ensureEditingUnlocked(page)
-    await TableDomUtils.clickOdpLink(page, String(seededYear), seededUrlRegex)
-
-    page.once('dialog', (dialog) => dialog.accept())
-    await page.getByRole('button', { name: 'Delete' }).first().click()
-
-    await expect(page).toHaveURL(/\/sections\/extentOfForest$/)
-    await expect(page.locator('.table-grid__odp-link', { hasText: String(seededYear) })).toHaveCount(0, {
       timeout: 10000,
     })
   })

--- a/src/test/e2e/specs/ndp/lifecycle.spec.ts
+++ b/src/test/e2e/specs/ndp/lifecycle.spec.ts
@@ -1,0 +1,65 @@
+import { SectionNames } from 'meta/assessment/section'
+
+import { NdpApiUtils, type NdpSeed } from '../../api/ndp'
+import { expect, test } from '../../fixtures/ndp'
+import { DOMUtils } from '../../utils/dom'
+import { NDPDomUtils } from '../../utils/ndpDom'
+import { SectionUtils } from '../../utils/section'
+import { TableDomUtils } from '../../utils/table'
+
+const countryIso = 'X08'
+const extentOfForestPath = SectionUtils.path({ countryIso, sectionName: SectionNames.extentOfForest })
+
+const year = 2015
+const seed: NdpSeed = { countryIso, nationalClasses: [], year }
+
+const seededYear = 2016
+const seededUrlRegex = new RegExp(`/originalDataPoints/${seededYear}/extentOfForest$`)
+
+test.describe('National data point: create', () => {
+  test.beforeEach(async ({ authenticatedPage }) => {
+    await NdpApiUtils.removeIfExists(authenticatedPage, seed)
+  })
+
+  test.afterEach(async ({ authenticatedPage }) => {
+    await NdpApiUtils.removeIfExists(authenticatedPage, seed)
+  })
+
+  test('NC creates a national data point and sees it back on the table', async ({ authenticatedPage }) => {
+    const page = authenticatedPage
+
+    await page.goto(extentOfForestPath)
+    await DOMUtils.ensureEditingUnlocked(page)
+
+    await page.getByRole('link', { name: 'Add national data point' }).click()
+
+    await NDPDomUtils.fillYear(page, String(year))
+    await NDPDomUtils.fillDataSourcesV1Reference(page, 'https://example.com/e2e-reference')
+
+    await NDPDomUtils.doneEditing(page)
+    await expect(page).toHaveURL(/\/sections\/extentOfForest$/)
+
+    await expect(page.locator('.table-grid__odp-link', { hasText: String(year) })).toBeVisible({ timeout: 10000 })
+  })
+})
+
+test.describe('National data point: delete', () => {
+  test.use({ ndpSeeds: [{ countryIso, nationalClasses: [], year: seededYear }] })
+
+  test('NC deletes the national data point', async ({ authenticatedPage, ndp }) => {
+    const page = authenticatedPage
+    expect(ndp.id).toBeTruthy()
+
+    await page.goto(extentOfForestPath)
+    await DOMUtils.ensureEditingUnlocked(page)
+    await TableDomUtils.clickOdpLink(page, String(seededYear), seededUrlRegex)
+
+    page.once('dialog', (dialog) => dialog.accept())
+    await page.getByRole('button', { name: 'Delete' }).first().click()
+
+    await expect(page).toHaveURL(/\/sections\/extentOfForest$/)
+    await expect(page.locator('.table-grid__odp-link', { hasText: String(seededYear) })).toHaveCount(0, {
+      timeout: 10000,
+    })
+  })
+})

--- a/src/test/e2e/specs/ndp/lifecycle.spec.ts
+++ b/src/test/e2e/specs/ndp/lifecycle.spec.ts
@@ -10,19 +10,19 @@ import { TableDomUtils } from '../../utils/table'
 const countryIso = 'X08'
 const extentOfForestPath = SectionUtils.path({ countryIso, sectionName: SectionNames.extentOfForest })
 
-const year = 2015
-const seed: NdpSeed = { countryIso, nationalClasses: [], year }
-
+const createdYear = 2015
 const seededYear = 2016
 const seededUrlRegex = new RegExp(`/originalDataPoints/${seededYear}/extentOfForest$`)
 
 test.describe('National data point: create', () => {
+  const createdSeed: NdpSeed = { countryIso, nationalClasses: [], year: createdYear }
+
   test.beforeEach(async ({ authenticatedPage }) => {
-    await NdpApiUtils.removeIfExists(authenticatedPage, seed)
+    await NdpApiUtils.removeIfExists(authenticatedPage, createdSeed)
   })
 
   test.afterEach(async ({ authenticatedPage }) => {
-    await NdpApiUtils.removeIfExists(authenticatedPage, seed)
+    await NdpApiUtils.removeIfExists(authenticatedPage, createdSeed)
   })
 
   test('NC creates a national data point and sees it back on the table', async ({ authenticatedPage }) => {
@@ -33,13 +33,15 @@ test.describe('National data point: create', () => {
 
     await page.getByRole('link', { name: 'Add national data point' }).click()
 
-    await NDPDomUtils.fillYear(page, String(year))
+    await NDPDomUtils.fillYear(page, String(createdYear))
     await NDPDomUtils.fillDataSourcesV1Reference(page, 'https://example.com/e2e-reference')
 
     await NDPDomUtils.doneEditing(page)
     await expect(page).toHaveURL(/\/sections\/extentOfForest$/)
 
-    await expect(page.locator('.table-grid__odp-link', { hasText: String(year) })).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('.table-grid__odp-link', { hasText: String(createdYear) })).toBeVisible({
+      timeout: 10000,
+    })
   })
 })
 

--- a/src/test/e2e/specs/ndp/remove.spec.ts
+++ b/src/test/e2e/specs/ndp/remove.spec.ts
@@ -1,0 +1,33 @@
+import { SectionNames } from 'meta/assessment/section'
+
+import { expect, test } from 'test/e2e/fixtures/ndp'
+import { DOMUtils } from 'test/e2e/utils/dom'
+import { SectionUtils } from 'test/e2e/utils/section'
+import { TableDomUtils } from 'test/e2e/utils/table'
+
+const countryIso = 'X09'
+const extentOfForestPath = SectionUtils.path({ countryIso, sectionName: SectionNames.extentOfForest })
+
+const seededYear = 2015
+const seededUrlRegex = new RegExp(`/originalDataPoints/${seededYear}/extentOfForest$`)
+
+test.describe('National data point: remove', () => {
+  test.use({ ndpSeeds: [{ countryIso, nationalClasses: [], year: seededYear }] })
+
+  test('NC deletes the national data point', async ({ authenticatedPage, ndp }) => {
+    const page = authenticatedPage
+    expect(ndp.id).toBeTruthy()
+
+    await page.goto(extentOfForestPath)
+    await DOMUtils.ensureEditingUnlocked(page)
+    await TableDomUtils.clickOdpLink(page, String(seededYear), seededUrlRegex)
+
+    page.once('dialog', (dialog) => dialog.accept())
+    await page.getByRole('button', { name: 'Delete' }).first().click()
+
+    await expect(page).toHaveURL(/\/sections\/extentOfForest$/)
+    await expect(page.locator('.table-grid__odp-link', { hasText: String(seededYear) })).toHaveCount(0, {
+      timeout: 10000,
+    })
+  })
+})


### PR DESCRIPTION
Idea of the PR is:
- to introduce `specs/{category}/{testName}.spec.ts to group tests instead of large files
- to introduce data seeding through fixtures
- to isolate tests - remove what was added etc

You can see one example of data seeding in the deletion of NDP:

```
test.describe('National data point: delete', () => {
  test.use({ ndpSeeds: [{ countryIso, nationalClasses: [], year: seededYear }] })
```

The series of PRs will modularize the following and mark them [x] per PR:

- National data point: 
  - [x] NC creates a national data point and sees it back on the table (`lifecycle.spec.ts`)
  - [ ] NC edits the national data point with incorrect data and sees validation errors (split in 2, `extent-of-forest.spec.ts` and `forest-characteristics.spec.ts`)
  - [ ] NC enters invalid links in comments and sees validation errors (`description.spec.ts`)
  - [ ] NC enters invalid links in the data source reference and sees validation errors (`description.spec.ts`)
  - [x] NC deletes the national data point (`lifecycle.spec.ts`)

Note base branch: [5758-refactor-odp-test](https://github.com/openforis/fra-platform/tree/5758-refactor-odp-test)
This will be serie of small PRs
